### PR TITLE
Caravan item price based on location

### DIFF
--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -363,7 +363,7 @@ namespace FF1Lib
 			// var dialogueText = ReadText(DialogueTextPointerOffset, DialogueTextPointerBase, DialogueTextPointerCount);
 			FixVanillaRibbon(itemText);
 			ExpGoldBoost(flags.ExpBonus, flags.ExpMultiplier);
-			ScalePrices(flags, itemText, rng);
+			ScalePrices(flags, itemText, rng, shopItemLocation);
 			ScaleEncounterRate(flags.EncounterRate / 30.0, flags.DungeonEncounterRate / 30.0);
 
 

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -187,7 +187,6 @@ namespace FF1Lib
 		[FlagString(Character = ITEM_REQUIREMENTS, FlagBit = 32)]
 		public bool OnlyRequireGameIsBeatable { get; set; }
 
-
 		[FlagString(Character = FILTHY_CASUALS, FlagBit = 1)]
 		public bool FreeBridge { get; set; }
 		[FlagString(Character = FILTHY_CASUALS, FlagBit = 2)]

--- a/FF1Lib/Scale.cs
+++ b/FF1Lib/Scale.cs
@@ -49,13 +49,11 @@ namespace FF1Lib
 				prices[i] = (ushort) (flags.WrapPriceOverflow ? ((newPrice - 1) % 0xFFFF) + 1 : Min(newPrice, 0xFFFF));
             }
 			var questItemPrice = prices[(int)Item.Bottle];
-
-			// do this before the item location check fucks everything to shit
+			// If we don't do this before checking for the item shop location factor, Ribbons and Shirts will end up being really cheap
+			// This realistically doesn't matter without Shop Wares shuffle on because nobody wants to sell Ribbons/Shirts, but if it is...
 			prices[(int)Item.WhiteShirt] = (ushort)(questItemPrice / 2);
 			prices[(int)Item.BlackShirt] = (ushort)(questItemPrice / 2);
 			prices[(int)Item.Ribbon] = questItemPrice;
-
-			// this way we cannot possibly mess up what it's doing here. probably.
 			var itemShopFactor = new Dictionary<MapLocation, int>() {
 				{ MapLocation.Coneria, 8 },
 				{ MapLocation.Pravoka, 2 }
@@ -65,7 +63,6 @@ namespace FF1Lib
 			{
 				questItemPrice = (ushort)(prices[(int)Item.Bottle] / divisor);
 			}
-			Console.WriteLine(questItemPrice);
 			for (var i = 0; i < (int)Item.Tent; i++)
             {
                 prices[i] = questItemPrice;

--- a/FF1Lib/Scale.cs
+++ b/FF1Lib/Scale.cs
@@ -58,15 +58,14 @@ namespace FF1Lib
 				{ MapLocation.Coneria, 8 },
 				{ MapLocation.Pravoka, 2 }
 			};
-			var divisor = new int();
-			if (itemShopFactor.TryGetValue(shopItemLocation.MapLocation, out divisor))
+			if (itemShopFactor.TryGetValue(shopItemLocation.MapLocation, out int divisor))
 			{
 				questItemPrice = (ushort)(prices[(int)Item.Bottle] / divisor);
 			}
 			for (var i = 0; i < (int)Item.Tent; i++)
-            {
+			{
                 prices[i] = questItemPrice;
-            }
+			}
 			Put(PriceOffset, Blob.FromUShorts(prices));
 
 			for (int i = GoldItemOffset; i < GoldItemOffset + GoldItemCount; i++)


### PR DESCRIPTION
Removes the price reduction for the CRYSTAL and replaces it with scaling the price of the incentive item, based on wherever the item is. It defaults to Coneria being 1/8th of normal price, and Pravoka being 1/2, but this is changable.

I haven't implemented it as a flag since the Crystal being 1/8th price wasn't implemented as a flag, and I don't see "making a seed take forever because you have to grind Ogres or some shit" as an enjoyable option.