### PR TITLE
Bridge shouldn't get special placement if we already have it

### DIFF
--- a/FF1Lib/ItemPlacement.cs
+++ b/FF1Lib/ItemPlacement.cs
@@ -151,7 +151,7 @@ namespace FF1Lib
 						placedItems.Any(x => x.Item == Item.Ship && startingMapLocations.Contains(x.MapLocation) &&
 							startingMapLocations.Contains((x as MapObject)?.SecondLocation ?? MapLocation.StartingLocation));
 
-					if (!(startingCanoeAvailable && canoeObsoletesBridge) && !startingShipAvailable)
+					if (!(startingCanoeAvailable && canoeObsoletesBridge) && !startingShipAvailable && !flags.FreeBridge)
 					{
 						var startingKeyAvailable =
 							earlyKeyAvailable && placedItems.Any(x => x.Item == Item.Key && startingMapLocations.Contains(x.MapLocation) &&


### PR DESCRIPTION
Item placement now will check to see if Free Bridge is on before placing the bridge in its limited spots, and if it is... instead it won't. There should probably be another change to this to make sure it doesn't put it in incentive spots either, but this will solve some silliness.