### PR TITLE
Add enum with magic names and use them for ItemMagic

### DIFF
--- a/FF1Lib/ItemMagic.cs
+++ b/FF1Lib/ItemMagic.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using RomUtilities;
 using System.Diagnostics;
 
@@ -21,7 +19,13 @@ namespace FF1Lib
 		private int ArmorStart = (byte)ItemLists.AllArmor.ElementAt(0);
 
 		// Remove all out of battle only spells
-		private readonly List<byte> SpellsToRemove = new List<byte> { 38, 40, 41, 33, 56 }; // Warp, Soft, Exit, Life, Life 2
+		private readonly List<Magic> OutOfBattleMagic = new List<Magic> {
+			Magic.WARP,
+			Magic.SOFT,
+			Magic.EXIT,
+			Magic.LIFE,
+			Magic.LIF2
+		};
 
 		public void ShuffleItemMagic(MT19337 rng)
 		{
@@ -35,6 +39,7 @@ namespace FF1Lib
 				Name = FF1Text.TextToBytes(FF1Text.BytesToText(blob).PadRight(6), false, FF1Text.Delimiter.Empty),
 			}).ToList();
 
+			var SpellsToRemove = OutOfBattleMagic.Select(magic => (byte)magic);
 			Spells.RemoveAll(spell => SpellsToRemove.Contains(spell.Index)); // Remove the spells specified in SpellsToRemove
 			Spells.Shuffle(rng); // Shuffle all spells remaining, then assign to each item that can cast a spell
 			foreach (var item in Spells.Zip(ItemLists.AllMagicItem, (s, i) => new { Spell = s, Item = i }))

--- a/FF1Lib/Magic.cs
+++ b/FF1Lib/Magic.cs
@@ -1,12 +1,76 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using RomUtilities;
 
 namespace FF1Lib
 {
+	public enum Magic : byte
+	{
+		CURE = 0,
+		HARM,
+		FOG,
+		RUSE,
+		FIRE,
+		SLEP,
+		LOCK,
+		LIT,
+		LAMP,
+		MUTE,
+		ALIT,
+		INVS,
+		ICE,
+		DARK,
+		TMPR,
+		SLOW,
+		CUR2,
+		HRM2,
+		AFIR,
+		HEAL,
+		FIR2,
+		HOLD,
+		LIT2,
+		LOK2,
+		PURE,
+		FEAR,
+		AICE,
+		AMUT,
+		SLP2,
+		FAST,
+		CONF,
+		ICE2,
+		CUR3,
+		LIFE,
+		HRM3,
+		HEL2,
+		FIR3,
+		BANE,
+		WARP,
+		SLO2,
+		SOFT,
+		EXIT,
+		FOG2,
+		INV2,
+		LIT3,
+		RUB,
+		QAKE,
+		STUN,
+		CUR4,
+		HRM4,
+		ARUB,
+		HEL3,
+		ICE3,
+		BRAK,
+		SABR,
+		BLND,
+		LIF2,
+		FADE,
+		WALL,
+		XFER,
+		NUKE,
+		STOP,
+		ZAP,
+		XXXX
+	}
 	public partial class FF1Rom : NesRom
 	{
 		public const int MagicOffset = 0x301E0;


### PR DESCRIPTION
This adds an enum that contains all magic in the game, and then
uses that list in ItemMagic for excluding out of battle magic.

I'm planning to add a flag to refine (at least for me) which magics are used for ItemMagic, but this felt like a good first step that works regardless of the next set of changes.

If you'd rather have a PR with this + that, let me know and I'll just amend this one in the next day or so.