### PR TITLE
Add basic support for overrides

### DIFF
--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -8,6 +8,8 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using FF1Lib.Assembly;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace FF1Lib
 {
@@ -29,6 +31,8 @@ namespace FF1Lib
 		public const int GoldItemOffset = 108; // 108 items before gold chests
 		public const int GoldItemCount = 68;
 		public static readonly List<int> UnusedGoldItems = new List<int> { 110, 111, 112, 113, 114, 116, 120, 121, 122, 124, 125, 127, 132, 158, 165, 166, 167, 168, 170, 171, 172 };
+
+		private JObject Overrides;
 
 		public void PutInBank(int bank, int address, Blob data)
 		{
@@ -83,6 +87,11 @@ namespace FF1Lib
 
 		public void Randomize(Blob seed, Flags flags)
 		{
+			Randomize(seed, flags, null);
+		}
+
+		public void Randomize(Blob seed, Flags flags, String overrideJson)
+		{
 			var rng = new MT19337(BitConverter.ToUInt32(seed, 0));
 
 			UpgradeToMMC3();
@@ -92,6 +101,10 @@ namespace FF1Lib
 			PermanentCaravan();
 			ShiftEarthOrbDown();
 			CastableItemTargeting();
+
+			Overrides = overrideJson != null
+				? JObject.Parse(overrideJson)
+				: JObject.Parse("{}");
 
 			TeleportShuffle teleporters = new TeleportShuffle();
 			var palettes = OverworldMap.GeneratePalettes(Get(OverworldMap.MapPaletteOffset, MapCount * OverworldMap.MapPaletteSize).Chunk(OverworldMap.MapPaletteSize));
@@ -485,6 +498,11 @@ namespace FF1Lib
 			}
 
 			PartyComposition(rng, flags);
+
+			if (true)
+			{
+				LowerMaxLevel(10);
+			}
 
 			if (flags.RecruitmentMode)
 			{

--- a/FF1Lib/ItemMagic.cs
+++ b/FF1Lib/ItemMagic.cs
@@ -32,6 +32,27 @@ namespace FF1Lib
 			{
 				WriteItemSpellData(item.Spell, item.Item);
 			}
+
+			if (Overrides.ContainsKey("ItemMagic"))
+			{
+				var itemMagicOverrides = Overrides["ItemMagic"];
+				foreach (var itemMagic in itemMagicOverrides)
+				{
+					var castItem = (Item)Enum.Parse(typeof(Item), itemMagic["item"].ToString());
+
+					var magicName = itemMagic["magic"].ToString();
+					var castMagic = FindMagicSpell(Spells, magicName);
+
+					if (castMagic.Data != null)
+					{
+						WriteItemSpellData(castMagic, castItem);
+					}
+					else
+					{
+						Debug.WriteLine("Failed to place override for " + magicName + " - not found");
+					}
+				}
+			}
 		}
 
 		private void WriteItemSpellData(MagicSpell Spell, Item item)
@@ -90,6 +111,12 @@ namespace FF1Lib
 			PutInBank(0x0F, 0x8AD0, Blob.FromHex("85808681C0FFD008A9D68580A9968581A91060"));
 		}
 
-
+		private MagicSpell FindMagicSpell(List<MagicSpell> spells, string name)
+		{
+			var upperName = name.ToUpper();
+			var found = spells.Find(spell =>
+				FF1Text.BytesToText(spell.Name).ToUpper().StartsWith(upperName));
+			return found;
+		}
 	}
 }


### PR DESCRIPTION
The idea of an "override" is to get the randomizer to create certain
items, or place certain things in specific places. (Or to put them in
places they normally wouldn't end up.)

This first change only deals with magic shuffle, to put spells in
particular slots, and item magic, so particular magic items are turned
into specific other items, such as a "Lamp Shirt" or "Nuke Rod".