### PR TITLE
Make normal NPCs (including bats) disappear after talking

### DIFF
--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -99,6 +99,8 @@ namespace FF1Lib
 			var maps = ReadMaps();
 			var shopItemLocation = ItemLocations.CaravanItemShop1;
 
+			EnableNPCSwatter();
+
 			/*
 			flags.FreeAirship = true;
 			flags.ExperimentalFloorGeneration = true;
@@ -533,6 +535,12 @@ namespace FF1Lib
 
 			WriteSeedAndFlags(Version, seed.ToHex(), Flags.EncodeFlagsText(flags));
 			ExtraTrackingAndInitCode();
+		}
+
+		private void EnableNPCSwatter()
+		{
+			// Talk_norm is overwritten with unconditional jump to Talk_CoOGuy (say whatever then disappear)
+			PutInBank(0x0E, 0x9492, Blob.FromHex("4CA294"));
 		}
 
 		private void ExtraTrackingAndInitCode()


### PR DESCRIPTION
This simply makes the Talk_Norm NPC routine redirect to the routine for the disappearing guy in Castle of Ordeals. No flag added yet so it's just always on.

A more complicated approach would be to change the jump table for only the bats to redirect to the disappearing routine, but I figure for any NPC that says exactly one thing it is safe to make them vanish. 