### PR TITLE
Add Unleashed to WarMECH Modes

### DIFF
--- a/FF1Lib/Enemies.cs
+++ b/FF1Lib/Enemies.cs
@@ -139,6 +139,32 @@ namespace FF1Lib
 				Put(ZoneFormationsOffset, newFormations.SelectMany(formation => formation.ToBytes()).ToArray());
 			}
 		}
+
+		private void UnleashWarMECH()
+		{
+			const int WarMECHsToAdd = 1;
+			const int WarMECHIndex = 6;
+			const byte WarMECHEncounter = 0x56;
+			var oldFormations = Get(ZoneFormationsOffset, ZoneFormationsSize * ZoneCount).Chunk(ZoneFormationsSize);
+			var newFormations = new List<byte>();
+
+			foreach(var zone in oldFormations)
+			{
+				var bytes = zone.ToBytes().ToList();
+				if (!bytes.Any(x => x > 0))
+				{
+					newFormations.AddRange(bytes);
+					continue;
+				}
+				bytes = bytes.Skip(WarMECHsToAdd).ToList();
+				newFormations.AddRange(bytes.Take(WarMECHIndex));
+				newFormations.AddRange(Enumerable.Repeat(WarMECHEncounter, WarMECHsToAdd));
+				newFormations.AddRange(bytes.Skip(WarMECHIndex));
+			}
+
+			Put(ZoneFormationsOffset, newFormations.ToArray());
+		}
+
 		public void ShuffleEnemyScripts(MT19337 rng, bool AllowUnsafePirates)
 		{
 			var oldEnemies = Get(EnemyOffset, EnemySize * EnemyCount).Chunk(EnemySize);

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -307,6 +307,11 @@ namespace FF1Lib
 				WarMECHNpc(flags.WarMECHMode, rng, maps);
 			}
 
+			if (flags.WarMECHMode == WarMECHMode.Unleashed)
+			{
+				UnleashWarMECH();
+			}
+
 			if (flags.FormationShuffleMode != FormationShuffleModeEnum.None)
 			{
 				ShuffleEnemyFormations(rng, flags.FormationShuffleMode);

--- a/FF1Lib/Maps.cs
+++ b/FF1Lib/Maps.cs
@@ -111,7 +111,8 @@ namespace FF1Lib
 	{
 		Vanilla,
 		Patrolling,
-		Required
+		Required,
+		Unleashed
 	}
 
 	public struct NPC
@@ -407,7 +408,8 @@ namespace FF1Lib
 			formations[6] = formations[7];
 			Put(formationOffset, formations);
 
-			MakeWarMECHUnrunnable();
+			if (mode != WarMECHMode.Unleashed)
+				MakeWarMECHUnrunnable();
 
 			if (mode == WarMECHMode.Required)
 			{

--- a/FF1RandomizerOnline/Views/Home/Randomize.cshtml
+++ b/FF1RandomizerOnline/Views/Home/Randomize.cshtml
@@ -245,6 +245,7 @@
 								<option value="0">Vanilla</option>
 								<option value="1">Patrolling</option>
 								<option value="2">Required</option>
+								<option value="3">Unleashed</option>
 							</select>
 						</div>
 						<br />


### PR DESCRIPTION
Many WarMECHs have escaped the Sky Castle and are now roaming the entire world. 

The first encounter in each zone is removed, encounter 2 through 6 are shifted up one position, the eighth encounter remains last, and WarMech is always in position 7. However, this can still be shuffled by formation shuffle if that option is set to "Shuffle Encounter Rarity".