### PR TITLE
Fix Circle CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,29 +15,17 @@ jobs:
           name: publish
           command: |
             set -ex
-            if [ "${CIRCLE_BRANCH}" == "alpha" ]; then
-              cd FF1Blazorizer
-              if [ "${CIRCLE_BRANCH}" == "master" ]; then
-                dotnet publish -c Release
-                git rev-parse HEAD > bin/Release/netstandard2.0/publish/FF1Blazorizer/dist/version.txt
-              else
-                dotnet publish -c Debug
-                git rev-parse HEAD > bin/Debug/netstandard2.0/publish/FF1Blazorizer/dist/version.txt
-              fi
+            cd FF1Blazorizer
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              dotnet publish -c Release
+              git rev-parse HEAD > bin/Release/netstandard2.0/publish/FF1Blazorizer/dist/version.txt
             else
-              cd FF1RandomizerOnline
-              if [ "${CIRCLE_BRANCH}" == "master" ]; then
-                dotnet publish -c Release
-                git rev-parse HEAD > bin/Release/netcoreapp2.1/publish/version.txt
-              else
-                dotnet publish -c Debug
-                git rev-parse HEAD > bin/Debug/netcoreapp2.1/publish/version.txt
-              fi
+              dotnet publish -c Debug
+              git rev-parse HEAD > bin/Debug/netstandard2.0/publish/FF1Blazorizer/dist/version.txt
             fi
       - persist_to_workspace:
           root: ~/ff1randomizer
           paths:
-            - FF1RandomizerOnline
             - FF1Blazorizer
 
   dockerize_production:


### PR DESCRIPTION
Because "CIRCLE_BRANCH" is the name of the branch being built, and
because github PRs are done from branches such as "pull/1", the if/else
logic to check for building alpha doesn't work.

Since this file is in the alpha branch, and alpha no longer includes the
FF1RandomizerOnline project, it makes sense to remove it from the build
step at least.