### PR TITLE
Fix "House HP" Refill toggle.

### DIFF
--- a/FF1Blazorizer/Pages/Randomize.cshtml
+++ b/FF1Blazorizer/Pages/Randomize.cshtml
@@ -1,4 +1,4 @@
-﻿@addTagHelper *, BlazorStrap
+@addTagHelper *, BlazorStrap
 @page "/Randomize"
 @using System.ComponentModel
 @using System.IO
@@ -377,7 +377,7 @@
 				<div class="row">
 					<div class="col-md-6">
 						<CheckBox Id="houseMPRestorationCheckBox" bind-Value="@Flags.HouseMPRestoration">House MP Restoration</CheckBox>
-						<CheckBox Id="houseMPRestorationCheckBox" bind-Value="@Flags.HouseMPRestoration">House Full HP Restoration</CheckBox>
+						<CheckBox Id="housesFillHpCheckBox" bind-Value="@Flags.HousesFillHP">House Full HP Restoration</CheckBox>
 						<CheckBox Id="weaponStatsCheckBox" bind-Value="@Flags.WeaponStats">Weapon Stats</CheckBox>
 						<CheckBox Id="chanceToRunCheckBox" bind-Value="@Flags.ChanceToRun">Chance to Run</CheckBox>
 						<CheckBox Id="spellBugsCheckBox" bind-Value="@Flags.SpellBugs">Spell Fixes</CheckBox>


### PR DESCRIPTION
"House Full HP Restoration" was using the same flag as "House MP
Restoration" in Blazor. This fixes the flag that's used to be the
correct one.