### PR TITLE
Enemizer update

### DIFF
--- a/Enemizer FAQ.txt
+++ b/Enemizer FAQ.txt
@@ -1,0 +1,86 @@
+ENEMIZER FAQ
+
+Q: So, what the flip is this "Enemizer" business, anyway?
+A: Enemizer is split into two major features: Enemy generation, and Formation generation.  Enemy generation does exactly what you'd think it does - it creates a whole new set of random enemies for you to fight, with abilities and perks that are procedurally generated.  Boss enemies remain (mostly) the same, but everything else is different.  Formation generation creates new formations of enemies procedurally, using any valid combination of palettes and remaining within the constraints of the original game's programming.  If Enemy Generation is on, then Formation Generation is automatically turned on since it will be necessary to create new formations.  You can, however, turn on Formation Generation without Enemy Generation, if you like the original enemy set just fine but would rather see some new battles.
+
+Q: I've heard this causes the game to break.  What precautions do you take against that?
+A: There have been some bugs in alpha testing, which have led me to make a few decisions.  Certain randomizer features will be disabled if Enemizer is on.  These features are:
+- Formation Shuffle (this is superfluous anyway since Formation Generation is effectively an inter-zone shuffle)
+- Trap Tile Shuffle (technically this could be something useful, but there are multiple steps I would need to take to make this compatible, or I would need to write a competing function, and I would rather have some consensus on this before I start writing a bunch of branching paths in the Trap Tile Shuffle function)
+- Fun% Enemy Names and Fun% Palette Swap (Enemy Generation uses the added space that is also used in Fun% names, and Enemy Generation also generates new palettes.  Since palettes are necessary to the functioning on Formation Generation, I'd rather not mess with them)
+Certain features are also changed. These are:
+- Zozo Melmond (Formation generator will create its own zone for Melmond, rather than using the one EnableMelmondGhetto hard-codes.  Otherwise, the function works exactly the same, with necessary alterations made to the EnableMelmondGhetto function to ensure that it will be compatible with the things Enemizer does)
+If there are other issues that arise, please let me know and I'll see what is causing the issue.  I believe I have resolved most of the obvious problems but there may be new ones that crop up from time to time.
+
+Q: So is there any method to how enemies are generated?
+A: Enemies are generated on top of the original monster list (or the monster list provided by the ROM).  For most enemies, the stats of the monster are based on (A) the monster image chosen for that monster (all 52 images will provide different stats, and some monster types are just flat out stronger than others), (B) the level of the monster, based usually on where it is encountered in the vanilla game, and (C) bonuses applied to each monster, which are randomly determined (with a few traits, like Deathtouch and Stonetouch, being limited to the monster that has those traits in the base game).  The stats of Boss monsters and fiends are left completely unchanged, assuming your ROM has those monsters in the slot they would occupy in the vanilla ROM.
+
+Q: What are the bonuses an enemy may roll?
+A: HP, Experience, Gold, and MDef base values will be whatever the enemy in that slot had originally.  Their strength, absorb, accuracy, and evasion are based on the enemy class primarily, and also the number of hits is determined by enemy class.
+There are global bonuses that will only occur for one enemy in every seed.  These are:
+- Crawl multi-hit stun attack
+- Sorceror Deathtouch
+- Coctrice Stonetouch
+- Mancat Resistances + Low MDef
+- Nitemare Resistances
+Secondly, there are type bonuses which can roll once per monster group, that will be noted in the monster's name.  These are:
+- Frost (denoted by "Fr"), Ice resistance and Fire weakness
+- Red (denoted by "R."), Fire resistance and Ice weakness
+- Sea (denoted by "Sea"), Lightning weakness and Fire/Earth resistance, plus Aquatic type monster flag is set
+- Zombie (denoted by "Z."), monster gains all the resistances and weaknesses of an undead and the Undead type monster flag is set, and also gains stuntouch
+- Were (denoted by "Wr"), monster becomes a Were type and will automatically acquire poisontouch
+- Wizard (denoted by "Wz"), monster is guaranteed to have a spell list
+Thirdly, there are minor perks (and penalties) which can roll, which affect the monster's XP reward.  These are, for now:
+- Gain/Lose 10% from HP, Strength, or Absorb rating
+- Gain low resistance (or cancel a weakness).  Low resistances are Earth, Lightning, Ice, and Fire.
+- Gain low weakness (or cancel a resistance), the inverse of the above
+- Gain high resistance.  High resistances are Status, Poison, Time, and Death.
+- Gain high weaknesses, again same as the above.  High weakness/resist is slightly less valued than low weakness/resist in XP effects.
+- Plus one hit, adds a melee hit
+- Poisontouch
+- Mutetouch
+- Stuntouch or Sleeptouch
+These minor effects roll quite frequently, but not all type bonuses or minor bonuses/penalties are available to all monster classes.  Undead monster types, for example, will never gain or lose a weakness.  Any monster that gets a type bonus ("Fr" etc.) will not roll any minor perks/weaknesses.
+Finally, every enemy (except boss enemies) will have a small variance in hp, exp, gold, and strength rating.  Additionally, any enemy with multiple hits will have their damage rating reduced by 1/15 per extra hit (with the effect per hit rounded down, so an enemy with 29 damage rating will only lose 1 strength per extra hit).  This effect on multi-hit enemies is intended to keep the attack strength of multihitters reasonable enough to account for their extra damage output.
+Any enemy with a script (excepting bosses) is automatically assigned the Mage flag, since all script enemies are spellcasters now.
+
+Q: How do you ensure enemies have a spell list?
+A: They will be assigned the spell list of an enemy appropriate to that monster's level.  The scripts they are assigned are, in order of severity:
+- RockGOL
+- R.GOYLE
+- MudGOL
+- MAGE
+- EVILMAN (reserved for only the highest tier enemies)
+
+Q: What happens to spell/skill lists?
+A: Enemizer will also generate new spell lists.  Enemy skills are not altered (my preference would be to keep enemies limited to one or two skills, since the threat of the enemy pounding you repeatedly with blizzard is part of what makes skills an interesting mechanics, rather than mixing in something useless like GAZE or SNORTING with a strong skill).  However, every enemy with a pure skill list (except WarMECH) is given a spell list of spells appropriate to the strength of the skill list (so the enemy with SCORCH will use tier 1 magic, while the CREMATE enemy will use tier 3 magic).
+When generating spell lists, every spell is rated on a tier of 0-5, with 0 being a spell that will never be selected (all spells which are useless in battle or useless to the enemy at least), and 5 being reserved for FADE and NUKE.  Spells will only be replaced with a spell from the same tier, and all of the AoE spells are tier 3 or higher.  This will mean, however, that many enemies will utilize spells that no enemy would use in vanilla, like ALIT or TMPR.
+Because many enemies are guaranteed a spell list, you can expect to see a lot more magic, and generally more dangerous magic, than you would see in a standard script shuffle randomizer.  For this reason, I strongly recommend against using script shuffle when playing with Enemy Generator, but there is no reason why you can't do it if you really want to.
+
+Q: What about bosses?
+A: The fiends, Astos, and Warmech do not change their skill list at all, so if you don't use script shuffle, you will see Lich 2 open with NUKE, CUR4 on chaos, etc.  This is admittedly a weakness, but I don't have a good solution yet unless I force a script shuffle always for the bosses (which I really don't want to do).
+
+Q: What does formation generation do?
+A: Formation generation, as the name suggests, creates new formations within the constraints of the game's programming.  Therefore, enemies in a formation must share the same pattern table, there can only be two palettes for enemies in a formation, and each formation has an A-Side (which can have up to 4 unique enemies) and a B-side (which can only contain the first two selected enemies).  Aside from that, anything goes; however, to maintain some balance to the game, each formation is assigned a zone that corresponds to an experience level requirement, so early game formations tend to give low experience while late game formations can give much more.
+When rolling formations, the generator prioritizes placing enemies that haven't been placed yet, while trying to pick enemies that correspond to zones which need to be filled.  The result of this is that, generally, there is a reasonable distribution of enemy formations for all areas of the game, though there are usually only 3-4 encounters for each individual domain (and some domains are reproduced, for example the world map domains).
+
+Q: What about boss formations?
+A: There are a number of formations which are set aside as special exemptions, which have special rules on how they are drawn.  These formations are drawn before the general formations.  The special formations are:
+- Imp/Bum formation, which generates the designated noodle fight that appears in the area around Coneria.  The other side of this formation is a regular encounter.  This formation is never unrunnable and has a low surprise rating.
+- Wizard, Eye and Zombie D formations.  The B-Side of these formations is a group of a single enemy selected for a particular zone, while the A-side is a generic encounter.  These formations are always unrunnable, and the B-Sides are placed on the appropriate trap tile (and are available as random encounters, too).
+- Phantom, Garland, Astos, Warmech, Vampire, and Pirates.  The A-Side of these formation is always the boss battle, which appears in a fixed quantity (1 usually, 9 for the pirates).  The boss is placed in the third slot for enemies in the formation.  The B-Side of the formation contains two enemies that are compatible with the pattern table and the boss' palette, and appears as a random encounter somewhere in the world.  With the exception of the Pirates (which must be a 9-small), these formations are always 2 large-6 small formations.
+- Fiends and Chaos, which are simply ignored by the formation generator altogether.  There are multiple assurances made so that these monsters do not appear in any encounter outside of the ones they belong in, in addition to any designated boss monster.
+
+Q: Is Garland supposed to be a dragon?
+A: Yes, that is intended.  It gives the player information about which enemy types will NOT appear elsewhere in the seed, and I think that isn't too bad.  I could force Garland, WarMECH, etc. into their proper appearance, but it's kind of fun to guess what they will look like today.
+
+Q: Are there future expansions you intend to create?
+A: Why yes indeed, there are.  Here are my rough plans for the future:
+- Improve the variety of formations that can appear.  Right now my priority is just to get the formation generator working without crashes.  After a full recode, the formation generator works a lot smoother, and avoids many of the characteristics that caused it to crash profusely in the first version of Enemizer.
+- Allow the character to select the intensity of encounters through a slider, which modifies the XP requirements for tiers.  How to do this while preserving the delicate balance of the game and the enemies available to me is a pretty tough question, since the game's XP table was designed to produce encounters in a fairly limited distribution concerning the characteristics I want to emphasize.
+- Allow formation zones to be defined by qualities other than XP yield, for example creating a sea zone for ocean monsters.  This can be really tricky and I would need a schema for the vanilla enemies if players are just using formation shuffle.
+- General flexibility for compatibility with FF1 hacks, within a reasonable boundary.
+- More detailed enemy generation, which can also assign enemies new tiers based on specifications offered by the user interface.
+- Spell/skill randomizer which creates a whole new spellbook for you AND the enemies, and works with Item Magic.
+- General integration of the enemizer's data structures with the randomizer as a whole, so that other features of the randomizers can refer to spell tiers and such when doing things like script shuffle and so on.  This is tricky because my implementation is quite janky, and I'd need the approval of the big cheeses to make it happen.
+- Eventually, I'd like to move in the direction of procedural map generation and dungeon generation, and turn the game into a straight up roguelike.  This is going to take a lot of work and cooperation.

--- a/FF1Blazorizer/Pages/Randomize.cshtml
+++ b/FF1Blazorizer/Pages/Randomize.cshtml
@@ -100,8 +100,8 @@
 							<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Indent IsEnabled="@Flags.EnemyFormationsUnrunnable" Id="everythingUnrunnableCheckBox" bind-Value="@Flags.EverythingUnrunnable">All Encounters are Unrunnable</TriStateCheckBox>
 							<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="unrunnablesStrikeFirstAndSurpriseCheckBox" bind-Value="@Flags.UnrunnablesStrikeFirstAndSurprise">Unrunnable First Strike &amp; Surprise</TriStateCheckBox>
 							<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="enemyFormationsSurpriseCheckBox" bind-Value="@Flags.EnemyFormationsSurprise">Enemy Surprise Bonus</TriStateCheckBox>
-							<EnumDropDown UpdateToolTip="@UpdateToolTipID" TItem="FormationShuffleMode" bind-Value="@Flags.FormationShuffleMode">Enemy Formations:</EnumDropDown>
-							<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="enemyTrapTilesCheckBox" bind-Value="@Flags.EnemyTrapTiles">Enemy Forced Encounter Tiles</TriStateCheckBox>
+							<EnumDropDown UpdateToolTip="@UpdateToolTipID" TItem="FormationShuffleMode" IsEnabled="@(!Flags.RandomizeFormationEnemizer)" bind-Value="@Flags.FormationShuffleMode">Enemy Formations:</EnumDropDown>
+							<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="enemyTrapTilesCheckBox" IsEnabled="@(!Flags.RandomizeFormationEnemizer)" bind-Value="@Flags.EnemyTrapTiles">Enemy Forced Encounter Tiles</TriStateCheckBox>
 							<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Indent Id="randomTrapFormationsCheckBox" IsEnabled="@Flags.EnemyTrapTiles" bind-Value="@Flags.RandomTrapFormations">Use Random Formations</TriStateCheckBox>
 							<div class="checkbox-cell"></div>
 							<h4>WarMECH</h4>
@@ -463,8 +463,8 @@
 							<div class="checkbox-cell"></div>
 							<CheckBox UpdateToolTip="@UpdateToolTipID" Id="DisableTentSaving" bind-Value="@Flags.DisableTentSaving">Disable Tent/Cabin/House Saving on Overworld</CheckBox>
 							<CheckBox UpdateToolTip="@UpdateToolTipID" Id="DisableInnSaving" bind-Value="@Flags.DisableInnSaving">Disable Inn Saving</CheckBox>
-							<CheckBox UpdateToolTip="@UpdateToolTipID" Id="RandomizeEnemizer" bind-Value="@Flags.RandomizeEnemizer">Randomize Enemies (Enemizer)</CheckBox>
 							<CheckBox UpdateToolTip="@UpdateToolTipID" Id="RandomizeFormationEnemizer" bind-Value="@Flags.RandomizeFormationEnemizer">Randomize Formations (Enemizer)</CheckBox>
+							<CheckBox UpdateToolTip="@UpdateToolTipID" Id="RandomizeEnemizer" IsEnabled="@Flags.RandomizeFormationEnemizer" bind-Value="@Flags.RandomizeEnemizer">Randomize Enemies (Enemizer)</CheckBox>
 						</div>
 						<div class="col-md-12">
 						</div>

--- a/FF1Blazorizer/Pages/Randomize.cshtml
+++ b/FF1Blazorizer/Pages/Randomize.cshtml
@@ -463,7 +463,8 @@
 							<div class="checkbox-cell"></div>
 							<CheckBox UpdateToolTip="@UpdateToolTipID" Id="DisableTentSaving" bind-Value="@Flags.DisableTentSaving">Disable Tent/Cabin/House Saving on Overworld</CheckBox>
 							<CheckBox UpdateToolTip="@UpdateToolTipID" Id="DisableInnSaving" bind-Value="@Flags.DisableInnSaving">Disable Inn Saving</CheckBox>
-							<CheckBox UpdateToolTip="@UpdateToolTipID" Id="RandomizeFormationEnemizer" bind-Value="@Flags.RandomizeFormationEnemizer">Randomizer Formations (Enemizer)</CheckBox>
+							<CheckBox UpdateToolTip="@UpdateToolTipID" Id="RandomizeEnemizer" bind-Value="@Flags.RandomizeEnemizer">Randomize Enemies (Enemizer)</CheckBox>
+							<CheckBox UpdateToolTip="@UpdateToolTipID" Id="RandomizeFormationEnemizer" bind-Value="@Flags.RandomizeFormationEnemizer">Randomize Formations (Enemizer)</CheckBox>
 						</div>
 						<div class="col-md-12">
 						</div>

--- a/FF1Lib/BugFixes.cs
+++ b/FF1Lib/BugFixes.cs
@@ -186,5 +186,10 @@ namespace FF1Lib
 			Put(0x2DE1D, Blob.FromHex("FF"));
 			Put(0x2DE21, Blob.FromHex("FF"));
 		}
+
+		public void FixEnemyPalettes()
+		{
+			Data[0x2E382] = 0xEA; // remove an extraneous LSR A when drawing monsters in a Large-Small mixed formation, so that the enemy in the third monster slot in such formations uses the correct palette
+		}
 	}
 }

--- a/FF1Lib/Enemies.cs
+++ b/FF1Lib/Enemies.cs
@@ -39,10 +39,16 @@ namespace FF1Lib
 
 		public abstract class Enemy
 		{
+			public const int Imp = 0;
 			public const int Pirate = 15;
+			public const int Crawl = 24;
 			public const int Phantom = 51;
+			public const int Mancat = 55;
+			public const int Coctrice = 81;
+			public const int Sorceror = 104;
 			public const int Garland = 105;
 			public const int Astos = 113;
+			public const int Nitemare = 117;
 			public const int WarMech = 118;
 			public const int Lich = 119;
 			public const int Lich2 = 120;

--- a/FF1Lib/Enemizer.cs
+++ b/FF1Lib/Enemizer.cs
@@ -3095,7 +3095,7 @@ namespace FF1Lib
 					{
 						availablemons = enemiesInTileset[f.tileset].Where(mon => NotFeatured(mon) && mon != f.Top).ToList();
 						if (availablemons.Count == 0)
-							availablemons = enemiesInTileset[f.tileset].ToList(); // if all other mons in this tileset have been featured, all mons in this tileset are eligible as a second mon
+							availablemons = enemiesInTileset[f.tileset].Where(mon=> mon != f.Top).ToList(); // if all other mons in this tileset have been featured, all mons in this tileset are eligible as a second mon
 					}
 					f.id[1] = availablemons.PickRandom(rng); // and pick a random mon from the available IDs to be mon 2 (and the primary monster of the A-side)
 					// we will attempt to hit a zone with the A-Side but if we can't we'll just try to make an encounter as close as possible to the goal

--- a/FF1Lib/Enemizer.cs
+++ b/FF1Lib/Enemizer.cs
@@ -10,9 +10,27 @@ namespace FF1Lib
 	public partial class FF1Rom : NesRom
 	{
 		public const int GenericTilesetsCount = 13;
+		public const int EnemySkillCount = 26;
+		public const int EnemySkillSize = 5;
+		public const int EnemySkillOffset = 0x303F0;
 
 		public class Enemizer
 		{
+			enum MonsterPerks
+			{
+				PERK_GAINSTAT10, // increases a minor stat by 10%, +2% XP
+				PERK_LOSESTAT10, // reduces a minor stat by 10%, -2% XP
+				PERK_LOWRESIST, // adds a low resist (fire/ice/lit/earth), +4% XP
+				PERK_HIGHRESIST, // adds a high resist (status/poison/time/death), +3% XP
+				PERK_LOWWEAKNESS, // adds a low weakness, -5% XP
+				PERK_HIGHWEAKNESS, // adds a high weakness, -3% XP 
+				PERK_PLUSONEHIT, // adds an extra hit, +5% XP for 2hitter, +3% for 3hitter, +2% for 4hitter and +1% for any hits beyond that
+				PERK_POISONTOUCH, // adds poisontouch if no status ailment already exists
+				PERK_STUNSLEEPTOUCH, // adds stun or sleep touch, +3% XP if stun touch is selected
+				PERK_MUTETOUCH, // adds mute touch, +2% XP
+				NUM_PERKS // total number of perks that are available for seletion
+			};
+
 			enum TrapTiles
 			{
 				TRAP_IMAGES,
@@ -54,6 +72,119 @@ namespace FF1Lib
 				TRAP_KRAKEN2,
 				TRAP_TIAMAT2,
 				NUM_TRAP_TILES
+			}
+
+			public class SpellData
+			{
+				public byte accuracy;
+				public byte effect;
+				public byte elem;
+				public byte targeting;
+				public byte routine;
+				public byte gfx;
+				public byte palette;
+
+				public byte[] CompressData()
+				{
+					byte[] spellInfo = new byte[7];
+					spellInfo[0] = accuracy;
+					spellInfo[1] = effect;
+					spellInfo[2] = elem;
+					spellInfo[3] = targeting;
+					spellInfo[4] = routine;
+					spellInfo[5] = gfx;
+					spellInfo[6] = palette;
+					spellInfo[7] = 0x00; // last byte is always 00
+					return spellInfo;
+				}
+			}
+
+			public class EnemySkillData
+			{
+				public byte accuracy;
+				public byte effect;
+				public byte elem;
+				public byte targeting;
+				public byte routine;
+			}
+
+			public class EnemyData
+			{
+				public int exp;
+				public int gp;
+				public int hp;
+				public int morale;
+				public byte AIscript;
+				public int agility;
+				public int absorb;
+				public int num_hits;
+				public int accuracy;
+				public int damage;
+				public int critrate;
+				public byte atk_elem;
+				public byte atk_ailment;
+				public byte monster_type;
+				public int mdef;
+				public byte elem_weakness;
+				public byte elem_resist;
+
+				public byte[] CompressData() // compresses the information of the enemy into an array of bytes to be placed in the game code
+				{
+					byte[] enemyInfo = new byte[20];
+					if (exp < 0)
+						exp = 0; // make sure experience isn't a negative number
+					enemyInfo[0] = (byte)(exp & 0xFF); // experience bytes are inverted from the usual format
+					enemyInfo[1] = (byte)((exp >> 8) & 0xFF);
+					enemyInfo[2] = (byte)(gp & 0xFF); // as is gold
+					enemyInfo[3] = (byte)((gp >> 8) & 0xFF);
+					enemyInfo[4] = (byte)(hp & 0xFF); // and hp
+					enemyInfo[5] = (byte)((hp >> 8) & 0xFF);
+					enemyInfo[6] = (byte)morale; // morale is 0-255
+					enemyInfo[7] = AIscript;
+					enemyInfo[8] = (byte)agility;
+					enemyInfo[9] = (byte)absorb;
+					enemyInfo[10] = (byte)num_hits;
+					enemyInfo[11] = (byte)accuracy;
+					enemyInfo[12] = (byte)damage;
+					enemyInfo[13] = (byte)critrate;
+					enemyInfo[14] = atk_elem;
+					enemyInfo[15] = atk_ailment;
+					enemyInfo[16] = monster_type;
+					enemyInfo[17] = (byte)mdef;
+					enemyInfo[18] = elem_weakness;
+					enemyInfo[19] = elem_resist;
+					return enemyInfo;
+				}
+			}
+
+			public class EnemyScript
+			{
+				public byte spell_chance;
+				public byte skill_chance;
+				public byte[] spell_list = new byte[8];
+				public byte[] skill_list = new byte[4];
+
+				public byte[] compressData()
+				{
+					byte[] scriptData = new byte[16];
+					scriptData[0] = spell_chance;
+					scriptData[1] = skill_chance;
+					scriptData[2] = spell_list[0];
+					scriptData[3] = spell_list[1];
+					scriptData[4] = spell_list[2];
+					scriptData[5] = spell_list[3];
+					scriptData[6] = spell_list[4];
+					scriptData[7] = spell_list[5];
+					scriptData[8] = spell_list[6];
+					scriptData[9] = spell_list[7];
+					scriptData[10] = 0xFF;
+					scriptData[11] = skill_list[0];
+					scriptData[12] = skill_list[1];
+					scriptData[13] = skill_list[2];
+					scriptData[14] = skill_list[3];
+					scriptData[15] = 0xFF;
+					return scriptData;
+				}
 			}
 
 			public class Formation
@@ -113,31 +244,78 @@ namespace FF1Lib
 				public List<int> moncount = new List<int> { };
 			}
 
+			public class EnemyPicPlusCount
+			{
+				char count;
+				byte picID;
+				EnemyPicPlusCount(char num, byte pict)
+				{
+					count = num;
+					picID = pict;
+				}
+			}
+
+			public byte[] spellDataFile = new byte[MagicSize * MagicCount];
+			public SpellData[] spells = new SpellData[MagicCount];
+			public byte[] spelltiers_human = new byte[]
+			{
+				0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0
+			};
+			public byte[] spelltiers_enemy = new byte[]
+			{
+				1, 0, 1, 3, 1, 2, 1, 1,
+				0, 2, 2, 1, 2, 1, 2, 2,
+				2, 0, 2, 2, 3, 3, 3, 2,
+				0, 0, 2, 1, 2, 3, 0, 3,
+				3, 0, 0, 3, 4, 4, 0, 3,
+				0, 0, 3, 3, 4, 3, 4, 3,
+				4, 0, 3, 4, 4, 4, 2, 1,
+				0, 5, 4, 4, 5, 4, 4, 4
+			};
+			public byte[] skillDataFile = new byte[EnemySkillCount * EnemySkillSize];
+			public EnemySkillData[] skills = new EnemySkillData[EnemySkillCount];
+			public byte[] skilltiers_human = new byte[]
+			{
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+			};
+			public byte[] skilltiers_enemy = new byte[]
+			{
+				3, 2, 3, 1, 2, 1, 4, 3, 3, 4, 4, 4, 5, 3, 4, 3, 4, 4, 4, 1, 5, 2, 2, 1, 5, 5
+			};
+			public byte[] enemyDataFile = new byte[EnemySize * EnemyCount];
+			public EnemyData[] enemyStats = new EnemyData[EnemyCount];
+			public string[] enemyNames = new string[EnemyCount];
+			public int numEnemyNameCharacters = 0;
+			public byte[] enemyScriptDataFile = new byte[ScriptSize * ScriptCount];
+			public EnemyScript[] enemyScripts = new EnemyScript[ScriptCount];
 			public byte[] formationData = new byte[FormationDataSize * FormationDataCount];
+			public Formation[] formationInfo = new Formation[FormationDataCount];
 			public List<byte>[] enemiesInTileset = new List<byte>[GenericTilesetsCount];
 			public List<byte>[] palettesInTileset = new List<byte>[GenericTilesetsCount];
-			// initialize these arrays with their vanilla values.  there is no easy way to read these values and tie them to monsters so we initialize by hand.
-			// note: if using a hack changes the pattern table assignments or palettes for monsters, this will not work and cause problems
 			public List<byte> enemyTilesets;
 			public List<byte> enemyPalettes;
 			public List<bool> enemySmallOrBig;
 			public List<int> enemyPics;
-			public List<byte> uniqueEnemyIDs = new List<byte> { 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C,
-														 0x1D, 0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F, 0x30, 0x31, 0x32, 0x34, 0x35, 0x36, 0x37,
-														 0x38, 0x39, 0x3A, 0x3B, 0x3C, 0x3D, 0x3E, 0x3F, 0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50,
-														 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5A, 0x5B, 0x5C, 0x5D, 0x5E, 0x5F, 0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x68, 0x6A, 0x6B,
-														 0x6C, 0x6D, 0x6F, 0x70, 0x72, 0x73, 0x74, 0x75 };
+			public List<int> enemyImage; // this combines tileset and pic
+			public List<byte> uniqueEnemyIDs = new List<byte> { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19,
+														0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F, 0x30, 0x31, 0x32, 0x34,
+														0x35, 0x36, 0x37, 0x38, 0x39, 0x3A, 0x3B, 0x3C, 0x3D, 0x3E, 0x3F, 0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D,
+														0x4E, 0x4F, 0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5A, 0x5B, 0x5C, 0x5D, 0x5E, 0x5F, 0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67,
+														0x68, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F, 0x70, 0x72, 0x73, 0x74, 0x75 };
 
 			public byte[] traptile_formations = new byte[(int)TrapTiles.NUM_TRAP_TILES]; // formation pointers for each trap tile
 			public int[] traptile_addresses = new int[(int)TrapTiles.NUM_TRAP_TILES]; // ROM addresses of trap tiles
 
-			public int[] enemyXPLUT = new int[EnemyCount];
 			public List<int>[] enemyZones = new List<int>[EnemyCount];
-			public List<byte>[] enemyPaired = new List<byte>[EnemyCount];
-			public List<List<int>> fmarkers = new List<List<int>> { };
 
 			public bool[] featured = new bool[EnemyCount];
-			public bool allfeatured = false;
 			public int[] zonecountmin; // counter to tell the enemizer how many enemies we want to roll for each zone
 			public int[] zonecountmax;
 			public List<byte>[] zone; // array of lists which contain the formation indices we have assigned to each zone
@@ -147,15 +325,24 @@ namespace FF1Lib
 			public int[][] zoneclone; // list of addresses which are clones of other domain addresses - the first entry in the array is the base to read from, the other entries will copy that
 
 			public byte[] domainData = new byte[ZoneFormationsSize * ZoneCount];
+			public byte imp_encounter = 0x00; // note the location of the imp encounter
+			public byte wizard_encounter = 0x1C; // note the location of the wizard encounter
 			public byte phantom_encounter = 0x46; // note the location of the phantom encounter, which will not be placed as a random (but can move around)
+			public byte zombieD_encounter = 0x4B; // note the location of the zombieD encounter
 			public byte warmech_encounter = 0x56; // note the location of the warmech encounter, which will not be placed as a random (we will not move this around since it is needed for other randomizer stuff)
-
+			public byte eye_encounter = 0x69; // note the location of the eye encounter
+			public byte lich1_encounter = 0x73; // lich encounter (we stop making formations after this point, boss encounters have special formations)
+			public byte vamp_encounter = 0x7C; // vamp encounter
+			public byte astos_encounter = 0x7D; // astos encounter
+			public byte pirate_encounter = 0x7E; // pirate encounter
+			public byte garland_encounter = 0x7F;
 			public Enemizer()
 			{
 				enemyTilesets = Enumerable.Repeat((byte)0x00, EnemyCount).ToList();
 				enemyPalettes = Enumerable.Repeat((byte)0x00, EnemyCount).ToList();
 				enemyPics = Enumerable.Repeat(0x00, EnemyCount).ToList();
 				enemySmallOrBig = Enumerable.Repeat(false, EnemyCount).ToList();
+				enemyImage = Enumerable.Repeat(0x00, EnemyCount).ToList();
 				for (int i = 0; i < GenericTilesetsCount; ++i)
 				{
 					enemiesInTileset[i] = new List<byte> { };
@@ -183,8 +370,6 @@ namespace FF1Lib
 					zone[i] = new List<byte> { };
 				for (int i = 0; i < EnemyCount; ++i)
 					enemyZones[i] = new List<int> { };
-				for (int i = 0; i < EnemyCount; ++i)
-					enemyPaired[i] = new List<byte> { };
 				zonemons = new List<byte>[zonecountmin.Length];
 				for (int i = 0; i < zone.Length; ++i)
 					zonemons[i] = new List<byte> { };
@@ -338,11 +523,88 @@ namespace FF1Lib
 					featured[mon] = false;
 			}
 
+			public SpellData decompressSpellData(byte[] rawData)
+			{
+				SpellData sp = new SpellData();
+				if (rawData.Length != MagicSize)
+					return sp;
+				sp.accuracy = rawData[0];
+				sp.effect = rawData[1];
+				sp.elem = rawData[2];
+				sp.targeting = rawData[3];
+				sp.routine = rawData[4];
+				sp.gfx = rawData[5];
+				sp.palette = rawData[6];
+				return sp;
+			}
+
+			public EnemyData decompressEnemyData(byte[] rawData)
+			{
+				EnemyData e = new EnemyData();
+				if (rawData.Length != EnemySize)
+					return e; // return a blank enemy if rawdata is not the right size
+				e.exp = rawData[0] + rawData[1] * 256;
+				e.gp = rawData[2] + rawData[3] * 256;
+				e.hp = rawData[4] + rawData[5] * 256;
+				e.morale = rawData[6];
+				e.AIscript = rawData[7];
+				e.agility = rawData[8];
+				e.absorb = rawData[9];
+				e.num_hits = rawData[10];
+				e.accuracy = rawData[11];
+				e.damage = rawData[12];
+				e.critrate = rawData[13];
+				e.atk_elem = rawData[14];
+				e.atk_ailment = rawData[15];
+				e.monster_type = rawData[16];
+				e.mdef = rawData[17];
+				e.elem_weakness = rawData[18];
+				e.elem_resist = rawData[19];
+				return e;
+			}
+
+			public EnemyScript decompressEnemyScript(byte[] rawData)
+			{
+				EnemyScript s = new EnemyScript();
+				if (rawData.Length != ScriptSize)
+				{
+					s.spell_chance = 0;
+					s.skill_chance = 0;
+					s.spell_list[0] = 0xFF;
+					s.spell_list[1] = 0xFF;
+					s.spell_list[2] = 0xFF;
+					s.spell_list[3] = 0xFF;
+					s.spell_list[4] = 0xFF;
+					s.spell_list[5] = 0xFF;
+					s.spell_list[6] = 0xFF;
+					s.spell_list[7] = 0xFF;
+					s.skill_list[0] = 0xFF;
+					s.skill_list[1] = 0xFF;
+					s.skill_list[2] = 0xFF;
+					s.skill_list[3] = 0xFF;
+				}
+				s.spell_chance = rawData[0];
+				s.skill_chance = rawData[1];
+				s.spell_list[0] = rawData[2];
+				s.spell_list[1] = rawData[3];
+				s.spell_list[2] = rawData[4];
+				s.spell_list[3] = rawData[5];
+				s.spell_list[4] = rawData[6];
+				s.spell_list[5] = rawData[7];
+				s.spell_list[6] = rawData[8];
+				s.spell_list[7] = rawData[9];
+				s.skill_list[0] = rawData[11];
+				s.skill_list[1] = rawData[12];
+				s.skill_list[2] = rawData[13];
+				s.skill_list[3] = rawData[14];
+				return s;
+			}
+
 			public Formation decompressFormation(byte[] rawData)
 			{
 				Formation f = new Formation();
-				if (rawData.Length < 16)
-					return f; // return a blank formation if rawdata is not large enough
+				if (rawData.Length != FormationDataSize)
+					return f; // return a blank formation if rawdata is not the right size
 				f.shape = (rawData[0] & 0xF0) >> 4;
 				f.tileset = (byte)(rawData[0] & 0x0F);
 				f.pics = rawData[1];
@@ -372,15 +634,12 @@ namespace FF1Lib
 
 			public void LogAndCompressFormation(Formation f, int slot)
 			{
-				int minXP_a = 0, minXP_b = 0, maxXP_a = 0, maxXP_b = 0;
 				for (int i = 0; i < 4; ++i)
 				{
 					if (f.id[i] == 0xFF)
 						continue;
 					if (f.monMin[i] > 0)
 						featured[f.id[i]] = true;
-					minXP_a += f.monMin[i] * enemyXPLUT[f.id[i]];
-					maxXP_a += f.monMax[i] * enemyXPLUT[f.id[i]];
 				}
 				for (int i = 0; i < 2; ++i)
 				{
@@ -388,14 +647,30 @@ namespace FF1Lib
 						continue;
 					if (f.monMin[i + 4] > 0)
 						featured[f.id[i]] = true;
-					minXP_b += f.monMin[i + 4] * enemyXPLUT[f.id[i]];
-					maxXP_b += f.monMax[i + 4] * enemyXPLUT[f.id[i]];
 				}
 				PutF(slot * FormationDataSize, f.CompressData());
 			}
 
-			public void ReadEnemyDataFromFormation(Formation f)
+			public void ReadSpellDataFromMagicBytes(SpellData sp, int index)
 			{
+				spells[index] = sp;
+			}
+
+			public void ReadEnemyDataFromEnemies(EnemyData e, int index)
+			{
+				enemyStats[index] = e;
+			}
+
+			public void ReadScriptDataFromScript(EnemyScript s, int index)
+			{
+				enemyScripts[index] = s;
+			}
+
+			public void ReadEnemyDataFromFormation(Formation f, int index)
+			{
+				// enter the formation into the formations array
+				formationInfo[index] = f;
+				// pull information about the enemy's graphical data and other things that are held in formation data rather than the enemy data proper
 				if (f.tileset < 0x00 || f.tileset > GenericTilesetsCount - 1)
 				{
 					enemyTilesets[f.id[0]] = f.tileset;
@@ -427,6 +702,7 @@ namespace FF1Lib
 							enemySmallOrBig[f.id[i]] = true;
 						else
 							enemySmallOrBig[f.id[i]] = false;
+						enemyImage[f.id[i]] = (int)enemyTilesets[f.id[i]] << 2 | pict;
 						bool paletteassigned = (f.paletteassignment & (0b10000000 >> i)) != 0;
 						if (paletteassigned)
 							enemyPalettes[f.id[i]] = f.pal2;
@@ -450,234 +726,2813 @@ namespace FF1Lib
 
 			public void PrintFormationInfo()
 			{
-				if (allfeatured)
-					Console.WriteLine("All mons have been featured");
-				else
-				{
-					int monsfeatured = 0;
-					foreach (bool yes in featured)
-					{
-						if (yes)
-							monsfeatured++;
-					}
-					Console.WriteLine(monsfeatured + " mons have been featured");
-				}
 				for (int i = 0; i < zonecountmin.Length; ++i)
 				{
 					Console.WriteLine("Zone " + i + " " + zone[i].Count + "/" + zonecountmin[i]);
 				}
 			}
 
-			public bool DoFormations(MT19337 rng)
+			public bool DoEnemies(MT19337 rng)
 			{
-				phantom_encounter = 0x03; // moving the phantom encounter to 0x03 A-Side and noting this for the domain generator
-
-				const byte startingformation = 0x04; // where we start creating random formations
-				const byte warmechformation = 0x56; // warmech's encounter - this must be at 0x56 in order to ensure compatibility with patrolling or required WarMech
-				const byte bossformations = 0x73; // number of formations for which special exceptions are made (imps, marsh guardian, ice guardian, phantom).  these encounters are rolled before the main loop.
-				byte cur = startingformation; // we start counting at formation 0x04 and work up to 0x72
-
-				// Draw obligatory formations first and exclude boss fights from the formation pool
-				ENF_Imps(rng);    // formations 0x00 and 0x80
-				ENF_Wizards(rng); // formations 0x01 and 0x81
-				ENF_Eye(rng);     // formations 0x02 and 0x82
-				ENF_Phantom(rng); // formations 0x03 and 0x83
-				ENF_VampireZombieD(rng); // formations 0x7C and 0xFC (we will put the ordeals trap tile on the B-Side of Vampire to save space)
-				ENF_Warmech(rng); // formations 0x56 and 0xD6
-				ENF_Pirates(rng); // formations 0x7E and 0xFE
-				ENF_Garland(rng); // formations 0x7F and 0xFF
-
-				// build enemy lists and zone lists
-				for (byte i = 0; i < enemyZones.Length; ++i)
+				int num_enemy_name_chars = 0;
+				for(int i = 0; i < EnemyCount; ++i)
 				{
-					if (GetTileset(i) > 0x0C)
-						continue; // skip over bosses
-					if (i == Enemy.Astos || i == Enemy.Pirate || i == Enemy.Garland || i == Enemy.Phantom || i == Enemy.WarMech)
-						continue; // don't include these enemies in the list
-					int limit = Large(i) ? 4 : 9;
-					int lowerlimit = Large(i) ? 3 : 5;
-					for (int j = 0; j < zonecountmin.Length; ++j)
+					num_enemy_name_chars += enemyNames[i].Length;
+				}
+				Console.WriteLine(num_enemy_name_chars);
+				// set enemy default tier list.  these listings are based on a combination of where the enemy is placed in the game, its xp yield, its rough difficulty, whether it has a script or not, and gut feels
+				// -1 indicates a monster with special rules for enemy generation
+				int[] enemyTierList = new int[] { -1, 0, 0, 1, 1, 3, 1, 6, 5, 4, 6, 6, 0, 1, 4, -1,
+												  1, 2, 5, 0, 7, 0, 3, 1, 2, 2, 4, 2, 2, 5, 1, 2,
+												  5, 2, 5, 3, 4, 4, 5, 1, 2, 3, 5, 0, 1, 1, 2, 8,
+												  5, 5, 7, -1, 4, 5, 4, 4, 4, 5, 3, 4, 5, 7, 1, 3,
+												  4, 5, 5, 6, 6, 1, 2, 2, 7, 0, 1, 5, 4, 6, 7, 3,
+												  5, 2, 3, 5, 5, 7, 9, 2, 4, 4, 5, 4, 7, 4, 5, 6,
+												  8, 6, 6, 6, 7, 6, 8, 2, 4, -1, 8, 8, 5, 6, 9, 6,
+												  7, -1, 4, 7, 1, 5, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
+				List<int> enemyImageLUT = new List<int>   { 0b00000000, 0b00000010, 0b00000001, 0b00000011, 0b00000100, 0b00000110, 0b00000101, 0b00000111,
+															0b00001000, 0b00001010, 0b00001001, 0b00001011, 0b00001100, 0b00001110, 0b00001101, 0b00001111,
+															0b00010000, 0b00010010, 0b00010001, 0b00010011, 0b00010100, 0b00010110, 0b00010101, 0b00010111,
+															0b00011000, 0b00011010, 0b00011001, 0b00011011, 0b00011100, 0b00011110, 0b00011101, 0b00011111,
+															0b00100000, 0b00100010, 0b00100001, 0b00100011, 0b00100100, 0b00100110, 0b00100101, 0b00100111,
+															0b00101000, 0b00101010, 0b00101001, 0b00101011, 0b00101100, 0b00101110, 0b00101101, 0b00101111,
+															0b00110000, 0b00110010, 0b00110001, 0b00110011 }; // these are the default tilesets + pics of the enemies we wish to shuffle
+				List<string>[] monsterClassVariants = new List<string>[52]; // monster class modifiers that have effects on stats
+				monsterClassVariants[0] = new List<string> { "Fr", "R.", "Z.", "Wr", "Wz", "Sea" }; // imp variants with special perks
+				monsterClassVariants[1] = new List<string> { "Fr", "R.", "Z.", "Wz", "Sea" }; // iguana variants with special perks
+				monsterClassVariants[2] = new List<string> { "Fr", "R.", "Z.", "Wr", "Wz" }; // wolf variants with special perks
+				monsterClassVariants[3] = new List<string> { "Fr", "R.", "Z.", "Wz", "Sea" }; // giant variants with special perks
+				monsterClassVariants[4] = new List<string> { "Fr", "Z.", "Wr", "Wz" }; // sahag variants with special perks
+				monsterClassVariants[5] = new List<string> { "Fr", "Z." }; // shark variants with special perks
+				monsterClassVariants[6] = new List<string> { "Fr", "R.", "Z.", "Wz" }; // pirate variants with special perks
+				monsterClassVariants[7] = new List<string> { "Fr", "Z." }; // oddeye variants with special perks
+				monsterClassVariants[8] = new List<string> { "Wz" }; // bone variants with special perks
+				monsterClassVariants[9] = new List<string> { "Fr", "R.", "Z.", "Wz", "Sea" }; // ogre variants with special perks
+				monsterClassVariants[10] = new List<string> { "Fr", "R.", "Z.", "Wr", "Wz", "Sea" }; // creep variants with special perks
+				monsterClassVariants[11] = new List<string> { "Fr", "R.", "Z.", "Wr" }; // hyena variants with special perks
+				monsterClassVariants[12] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // asp variants with special perks
+				monsterClassVariants[13] = new List<string> { "Fr", "R.", "Z.", "Wr", "Wz", "Sea" }; // bull variants with special perks
+				monsterClassVariants[14] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // crab variants with special perks
+				monsterClassVariants[15] = new List<string> { "Fr", "R.", "Z.", "Wz", "Sea" }; // troll variants with special perks
+				monsterClassVariants[16] = new List<string> { "Wz" }; // ghost variants with special perks
+				monsterClassVariants[17] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // worm variants with special perks
+				monsterClassVariants[18] = new List<string> { "Sea" }; // wight variants with special perks
+				monsterClassVariants[19] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // eye variants with special perks
+				monsterClassVariants[20] = new List<string> { "Fr", "R.", "Z.", "Wz", "Sea" }; // medusa variants with special perks
+				monsterClassVariants[21] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // pede variants with special perks
+				monsterClassVariants[22] = new List<string> { "Fr", "R.", "Z.", "Wz" }; // catman variants with special perks
+				monsterClassVariants[23] = new List<string> { "Fr", "R.", "Z.", "Wr" }; // tiger variants with special perks
+				monsterClassVariants[24] = new List<string> { "Wz" }; // vamp variants with special perks
+				monsterClassVariants[25] = new List<string> { }; // large elem variants with special perks
+				monsterClassVariants[26] = new List<string> { "Fr", "R.", "Z.", "Wz", "Sea" }; // goyle variants with special perks
+				monsterClassVariants[27] = new List<string> { }; // drake 1 variants with special perks
+				monsterClassVariants[28] = new List<string> { "Wz" }; // flan variants with special perks
+				monsterClassVariants[29] = new List<string> { "Fr", "R.", "Z.", "Wz", "Sea" }; // manticore variants with special perks
+				monsterClassVariants[30] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // spider variants with special perks
+				monsterClassVariants[31] = new List<string> { "Fr", "R.", "Z." }; // ankylo variants with special perks
+				monsterClassVariants[32] = new List<string> { "Wz" }; // mummy variants with special perks
+				monsterClassVariants[33] = new List<string> { "Fr", "R.", "Z.", "Wr", "Wz" }; // wyvern variants with special perks
+				monsterClassVariants[34] = new List<string> { "Fr", "R.", "Z." }; // bird variants with special perks
+				monsterClassVariants[35] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // tyro variants with special perks
+				monsterClassVariants[36] = new List<string> { "Fr", "Z." }; // caribe variants with special perks
+				monsterClassVariants[37] = new List<string> { "Fr", "Z.", "Wz" }; // ocho variants with special perks
+				monsterClassVariants[38] = new List<string> { "Fr", "Z.", "Wr" }; // gator variants with special perks
+				monsterClassVariants[39] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // hydra variants with special perks
+				monsterClassVariants[40] = new List<string> {  }; // bot variants with special perks
+				monsterClassVariants[41] = new List<string> { "Fr", "Z.", "Sea" }; // naga variants with special perks
+				monsterClassVariants[42] = new List<string> { }; // small elem variants with special perks
+				monsterClassVariants[43] = new List<string> { "Z.", "Wr", "Wz" }; // chimera variants with special perks
+				monsterClassVariants[44] = new List<string> { "Z.", "Wz" }; // piscodemon variants with special perks
+				monsterClassVariants[45] = new List<string> {  }; // dragon 2 variants with special perks
+				monsterClassVariants[46] = new List<string> { "Fr", "R.", "Z.", "Wz" }; // knight variants with special perks
+				monsterClassVariants[47] = new List<string> {  }; // golem variants with special perks
+				monsterClassVariants[48] = new List<string> { "Fr", "R.", "Z.", "Wz" }; // badman variants with special perks
+				monsterClassVariants[49] = new List<string> { "Fr", "R.", "Z.", "Wr", "Sea" }; // pony variants with special perks
+				monsterClassVariants[50] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // elf variants with special perks
+				monsterClassVariants[51] = new List<string> { }; // mech variants with special perks
+				List<string>[] monsterNameVariants = new List<string>[52]; // name variants for monsters to prevent duplicates
+				bool[] monsterBaseNameUsed = new bool[52]; // true if the base name has been used, false if not
+				for(int i = 0; i < 52; ++i)
+				{
+					monsterBaseNameUsed[i] = false; // if enemy is not part of a variant class, by default it uses the base name for the monster
+					monsterNameVariants[i] = new List<string> { "A.", "B.", "C.", "D.", "E.", "F.", "G.", "H.", "I.", "K.", "L.", "M.", "N.", "P.", "S.", "T.", "V.", "W.", "X." };
+				}
+				monsterBaseNameUsed[25] = true; // large elemental
+				monsterBaseNameUsed[27] = true; // dragon 1
+				monsterBaseNameUsed[42] = true; // small elemental
+				monsterBaseNameUsed[45] = true; // dragon 2
+				enemyImageLUT.Shuffle(rng); // shuffle the LUT - whatever image was there in vanilla will be replaced with what is at its position in the LUT
+				enemyImage.RemoveRange(Enemy.Lich, Enemy.Chaos - Enemy.Lich); // remove Lich 1 thru Chaos from the enemyImage array so they're not shuffled to a generic enemy
+				enemyImage.Shuffle(rng); // and shuffle the enemy images themselves
+				int whatIsPirate = enemyImageLUT[enemyImage[Enemy.Pirate]]; // find out what monster was assigned to the pirate
+				for (int i = 0; i < enemyImageLUT.Count(); ++i)
+				{
+					if (enemyImageLUT[i] == 0b00000110)
 					{
-						if (enemyXPLUT[i] <= zonexpreqs[j, 2] && enemyXPLUT[i] * limit >= zonexpreqs[j, 1])
-						{
-							zonemons[j].Add(i);
-							enemyZones[i].Add(j);
-						}
+						enemyImageLUT[i] = whatIsPirate; // assign whatever what given the pirate image the image that was assigned to the pirate monster's slot
+						break;
 					}
 				}
-				// reserve so many slots for different surprise rates and unrunnables
-				int[,] surprisetiers = { { 10, 19 }, { 24, 36 }, { 48, 62 }, { 70, 100 } };
-				const int surp1 = 12;
-				const int surp2 = 15;
-				const int surp3 = 5;
-				const int surp4 = 3;
-				int[] surpcount = { surp1, surp2, surp3, surp4 };
+				enemyImageLUT[enemyImage[Enemy.Pirate]] = 0b00000110; // and now assign the pirate himself his proper slot
 
-				// main loop
-				uniqueEnemyIDs.Shuffle(rng);
-				int stage = 0;
-				int failcount_draw = 0;
-				while (cur < bossformations)
+				// generate the palettes for each tileset
+				for (int i = 0; i < GenericTilesetsCount; ++i)
 				{
-					if (cur == warmechformation)
+					palettesInTileset[i].Clear();
+					while (palettesInTileset[i].Count < 4)
 					{
-						cur++;
-						continue;
+						int newPal = rng.Between(0, 0x3F);
+						if (palettesInTileset[i].Contains((byte)newPal))
+							continue;
+						palettesInTileset[i].Add((byte)newPal);
 					}
-					int goalzone1 = -1, goalzone2 = -1, picker1 = -1, picker2 = -1;
-					Formation f = new Formation();
-					if (ENF_DrawMons_Zone(rng, f, ref goalzone1, ref goalzone2, ref picker1, ref picker2, ref stage))
+				}
+
+				// clear the list of enemies in each tileset
+				enemiesInTileset[0].Clear();
+				enemiesInTileset[1].Clear();
+				enemiesInTileset[2].Clear();
+				enemiesInTileset[3].Clear();
+				enemiesInTileset[4].Clear();
+				enemiesInTileset[5].Clear();
+				enemiesInTileset[6].Clear();
+				enemiesInTileset[7].Clear();
+				enemiesInTileset[8].Clear();
+				enemiesInTileset[9].Clear();
+				enemiesInTileset[10].Clear();
+				enemiesInTileset[11].Clear();
+				enemiesInTileset[12].Clear();
+
+				// List of elementals already selected
+				List<int> elementalsSelected = new List<int> { 0, 1, 2, 3, 4, 5, 6, 7, 8 };
+				List<int> dragonsSelected = new List<int> { 0, 1, 2, 3, 4, 5, 6, 7, 8 };
+
+				// create lists of palettes used for each enemy image
+				List<byte>[] enemyImagePalettes = new List<byte>[52];
+				for(int i = 0; i < 52; ++i)
+				{
+					enemyImagePalettes[i] = new List<byte> { };
+				}
+
+				// now start generating the enemies themselves.  we stop before Lich and make special exceptions for various monsters
+				for (byte i = 0; i < Enemy.Lich; ++i)
+				{
+					// set up variables we want to work with
+					List<MonsterPerks> perks = new List<MonsterPerks> { MonsterPerks.PERK_GAINSTAT10, MonsterPerks.PERK_LOSESTAT10 }; // list of perks this monster is eligible to receive
+
+					// assign the monster's pic
+					enemyImage[i] = enemyImageLUT[enemyImage[i]];
+					int enemyTileset = (enemyImage[i] & 0b00111100) >> 2;
+					if(enemyTileset < 0 || enemyTileset > 12)
 					{
-						failcount_draw++;
-						continue;
+						// enemy not in a valid tileset - abort enemizer
+						return false;
 					}
-
-					// decide which picker we will use to generate the encounter
-					/* For now we are using a generic picker that is not too complicated, this can be modified in the future */
-					int outcome = RollFormation(rng, f, ref goalzone1, ref goalzone2, ref picker1, ref picker2, ref stage);
-					if (outcome == -2)
+					enemyPics[i] = enemyImage[i] & 0b00000011;
+					enemyTilesets[i] = (byte)enemyTileset;
+					bool wasSmallOrBig = enemySmallOrBig[i]; // remember whether the base enemy was a small or big
+					if ((enemyImage[i] & 1) == 1) // and determine whether the new image is a small or a big
+						enemySmallOrBig[i] = true;
+					else
+						enemySmallOrBig[i] = false;
+					// assign the monster's palette.  do not allow the same palette to be used for the same pic
+					byte thisEnemyPalette = palettesInTileset[enemyTileset].PickRandom(rng);
+					while (enemyImagePalettes[enemyImage[i]].Contains(thisEnemyPalette))
 					{
-						continue; // if this function returns true, our formation rolling failed and we have to restart
+						thisEnemyPalette = palettesInTileset[enemyTileset].PickRandom(rng);
 					}
-
-					if (ENF_ApproveFormation(f, goalzone1, goalzone2))
+					enemyImagePalettes[enemyImage[i]].Add(thisEnemyPalette);
+					enemyPalettes[i] = thisEnemyPalette;
+					// generate the stats for each monster
+					if(enemyTierList[i] == -1)
 					{
-						enemyPaired[f.Top].Add(f.id[1]);
-						enemyPaired[f.id[1]].Add(f.Top);
-
-						zone[goalzone1].Add((byte)(cur | 0x80));
-						zone[goalzone2].Add(cur);
-						int maxXPB = 0;
-						int maxXPA = 0;
-						for(int i = 4; i < 6; ++i)
+						// generate special monsters
+						switch(i)
 						{
-							if (f.id[i - 4] != 0xFF)
-								maxXPB += enemyXPLUT[f.id[i - 4]] * f.monMax[i];
+							case Enemy.Imp:
+								enemyNames[i] = "BUM";
+								break;
+							case Enemy.Pirate:
+								break;
+							case Enemy.Phantom:
+								break;
+							case Enemy.Garland:
+								break;
+							case Enemy.Astos:
+								break;
+							case Enemy.WarMech:
+								break;
 						}
-						for (int i = 0; i < 4; ++i)
+					}
+					else
+					{
+						enemiesInTileset[enemyTileset].Add(i); // add enemy to enemiesInTileset unless it is a boss
+						// adjust HP, EXP, and GP if enemy changes size
+						if (wasSmallOrBig && !enemySmallOrBig[i]) // large became small
 						{
-							if (f.id[i] != 0xFF)
-								maxXPA += enemyXPLUT[f.id[i]] * f.monMax[i];
+							enemyStats[i].hp *= 4;
+							enemyStats[i].hp /= 5;
+							enemyStats[i].exp *= 9;
+							enemyStats[i].exp /= 10;
+							enemyStats[i].gp *= 9;
+							enemyStats[i].gp /= 10;
 						}
-
-						// set surprise rate and unrunnability flags
-						f.unrunnable = rng.Between(0, 29) + (goalzone1 > goalzone2 ? goalzone1 : goalzone2) >= 32 ? true : false; // unrunnable chance is higher for later zones
-						if(f.unrunnable)
+						else if (!wasSmallOrBig && enemySmallOrBig[i]) // small became large
 						{
-							f.surprise = 4; // set surprise rate to default for unrunnables
+							enemyStats[i].hp *= 5;
+							enemyStats[i].hp /= 4;
+							enemyStats[i].exp *= 10;
+							enemyStats[i].exp /= 9;
+							enemyStats[i].gp *= 10;
+							enemyStats[i].gp /= 9;
+						}
+						int elemental = 9; // track elemental affinity for certain classes of monsters (elementals and dragons)
+						// generate BASE stats for generic monsters and their base name
+						switch (enemyImage[i])
+						{
+							case 0: // Imp
+								enemyNames[i] = "IMP";
+								enemyStats[i].num_hits = rng.Between(1, 3);
+								enemyStats[i].critrate = rng.Between(1, 5);
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 5);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 3);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000100;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 1: // Iguana
+								enemyNames[i] = "SAUR";
+								enemyStats[i].num_hits = rng.Between(1, 3);
+								enemyStats[i].critrate = rng.Between(1, 5);
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 5);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 5);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 2);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000010;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 2: // Wolf
+								enemyNames[i] = "WOLF";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = rng.Between(1, 5);
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 5);
+								enemyStats[i].absorb = 0;
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 6);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000000;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								break;
+							case 3: // Giant
+								enemyNames[i] = "GIANT";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = rng.Between(1, 5);
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 6);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i],6);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 3);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000100;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								break;
+							case 4: // Sahag
+								enemyNames[i] = "SAHAG";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 2);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 3);
+								enemyStats[i].agility = 72 + enemyStats[i].exp / 40;
+								if (enemyStats[i].agility > 100)
+									enemyStats[i].agility = 100;
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00100000;
+								enemyStats[i].elem_resist = 0b10010000;
+								enemyStats[i].elem_weakness = 0b01000000;
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 5: // Shark
+								enemyNames[i] = "SHARK";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 6);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 5);
+								enemyStats[i].absorb = rng.Between(0, 8);
+								enemyStats[i].agility = 72 + enemyStats[i].exp / 40;
+								if (enemyStats[i].agility > 100)
+									enemyStats[i].agility = 100;
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00100000;
+								enemyStats[i].elem_resist = 0b10010000;
+								enemyStats[i].elem_weakness = 0b01000000;
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								break;
+							case 6: // Pirate
+								enemyNames[i] = "BRUTE";
+								enemyStats[i].num_hits = rng.Between(1, 2);
+								enemyStats[i].critrate = rng.Between(1, 5);
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000000;
+								enemyStats[i].elem_resist = 0b10000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 7: // Oddeye
+								enemyNames[i] = "EYE";
+								enemyStats[i].num_hits = rng.Between(1, 4);
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 2);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 5);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 2);
+								enemyStats[i].agility = enemyStats[i].exp > 400 ? rollEnemyEvade(enemyTierList[i], 4) : rollEnemyEvade(enemyTierList[i], 7);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00100000;
+								enemyStats[i].elem_resist = 0b10010000;
+								enemyStats[i].elem_weakness = 0b01000000;
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 8: // Skeleton
+								enemyNames[i] = "BONE";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = rng.Between(1, 2);
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 5);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 2);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00001000;
+								enemyStats[i].elem_resist = 0b00101011;
+								enemyStats[i].elem_weakness = 0b00010000;
+								break;
+							case 9: // Hyena
+								enemyNames[i] = "DOG";
+								enemyStats[i].num_hits = rng.Between(1, 2);
+								enemyStats[i].critrate = rng.Between(1, 3);
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
+								enemyStats[i].absorb = rng.Between(0, 12);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 5);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000000;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 10: // Creep
+								enemyNames[i] = "CRAWL";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 6);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000000;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00010000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 11: // Ogre
+								enemyNames[i] = "OGRE";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = rng.Between(1, 5);
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 5);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000100;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								break;
+							case 12: // Asp
+								enemyNames[i] = "ASP";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = rng.Between(1, 31);
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 3);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 5);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000010;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 13: // Bull
+								enemyNames[i] = "BULL";
+								enemyStats[i].num_hits = 2;
+								enemyStats[i].critrate = rng.Between(1, 3);
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 5);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 5);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000000;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 14: // Crab
+								enemyNames[i] = "CRAB";
+								enemyStats[i].num_hits = rng.Between(2, 4);
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 5);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 3);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 6);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000000;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								break;
+							case 15: // Troll
+								enemyNames[i] = "TROLL";
+								enemyStats[i].num_hits = 3;
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b10000000;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 16: // Spectral Undead
+								enemyNames[i] = "GHOST";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 6);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 3);
+								enemyStats[i].absorb = rng.Between(0, 4) == 4 ? rollEnemyAbsorb(enemyTierList[i], 4) : rng.Between(0, 8);
+								enemyStats[i].agility = rng.Between(0, 2) == 2 ? rollEnemyEvade(enemyTierList[i], 4) : rollEnemyEvade(enemyTierList[i], 7);
+								enemyStats[i].atk_elem = 0b00000001;
+								enemyStats[i].atk_ailment = enemyStats[i].exp < 150 ? (byte)0b00001000 : (byte)0b00010000; // darkness for low xp enemies, stun for high xp enemies
+								enemyStats[i].monster_type = 0b00001001;
+								enemyStats[i].elem_resist = 0b10101011;
+								enemyStats[i].elem_weakness = 0b00010000;
+								break;
+							case 17: // Worm
+								enemyNames[i] = "WORM";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 5);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 7);
+								enemyStats[i].absorb = enemyStats[i].exp < 100 ? rng.Between(0, 10) : (enemyStats[i].exp > 1200 ? rng.Between(10, 40) : rng.Between(10, 20));
+								enemyStats[i].agility = rng.Between(0, 60);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000000;
+								enemyStats[i].elem_resist = 0b10000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 18: // Zombie Undead
+								enemyNames[i] = "WIGHT";
+								enemyStats[i].num_hits = rng.Between(0, 4) == 4 || enemyStats[i].exp < 100 ? 1 : 3;
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = enemyStats[i].num_hits == 3 ? rollEnemyStrength(enemyTierList[i], 2) : rollEnemyStrength(enemyTierList[i], 4);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 2);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 2);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 5);
+								enemyStats[i].atk_elem = 0b00000001;
+								enemyStats[i].atk_ailment = enemyStats[i].exp > 80 ? (byte)0b00010000 : (byte)0b00000000;
+								enemyStats[i].monster_type = 0b00001000;
+								enemyStats[i].elem_resist = 0b00101011;
+								enemyStats[i].elem_weakness = 0b00010000;
+								break;
+							case 19: // Eyes that are totally not Beholders plz no sue
+								enemyNames[i] = "DRUJ";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 6);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 2);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b01000000;
+								enemyStats[i].elem_resist = 0b10000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								if (enemyStats[i].AIscript == 0xFF)
+									enemyStats[i].AIscript = ENE_PickForcedAIScript(enemyTierList[i]);
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 20: // Medusa
+								enemyNames[i] = "LAMIA";
+								enemyStats[i].num_hits = rng.Between(0, 1) == 1 ? 1 : rng.Between(6, 10);
+								enemyStats[i].critrate = rng.Between(1, 5);
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 2);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 2);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 5);
+								enemyStats[i].atk_elem = 0b00000001;
+								enemyStats[i].atk_ailment = enemyStats[i].exp > 200 ? (byte)0b00010000 : (byte)0b00000000;
+								enemyStats[i].monster_type = 0b00000000;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								break;
+							case 21: // Pede
+								enemyNames[i] = "PEDE";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 7);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 5);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 5);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000000;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								break;
+							case 22: // Were
+								enemyNames[i] = "CAT";
+								enemyStats[i].num_hits = rng.Between(2, 3);
+								enemyStats[i].critrate = rng.Between(1, 2);
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 5);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 5);
+								enemyStats[i].atk_elem = 0b00000010;
+								enemyStats[i].atk_ailment = 0b00000100;
+								enemyStats[i].monster_type = 0b00010000;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								break;
+							case 23: // Tiger
+								enemyNames[i] = "TIGER";
+								enemyStats[i].num_hits = 2;
+								enemyStats[i].critrate = rng.Between(20, 100);
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
+								enemyStats[i].absorb = 8;
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 5);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000000;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 24: // Blah, it's a Vampire!
+								enemyNames[i] = "VAMP";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = rng.Between(1, 5);
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 6);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 5);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 6);
+								enemyStats[i].atk_elem = 0b00000001;
+								enemyStats[i].atk_ailment = 0b00010000;
+								enemyStats[i].monster_type = 0b10001001;
+								enemyStats[i].elem_resist = 0b10101011;
+								enemyStats[i].elem_weakness = 0b00010000;
+								break;
+							case 25: // Large Elemental
+								if (elementalsSelected.Count > 0)
+									elemental = elementalsSelected.PickRandom(rng);
+								rollLargeElemental(rng, ref enemyStats[i], enemyTierList[i], elemental);
+								switch (elemental)
+								{
+									case 1:
+										enemyNames[i] = "EARTH";
+										break;
+									case 2:
+										enemyNames[i] = "STORM";
+										break;
+									case 3:
+										enemyNames[i] = "ICE";
+										break;
+									case 4:
+										enemyNames[i] = "FIRE";
+										break;
+									case 5:
+										enemyNames[i] = "DEATH";
+										break;
+									case 6:
+										enemyNames[i] = "CRONO";
+										break;
+									case 7:
+										enemyNames[i] = "VENOM";
+										break;
+									case 8:
+										enemyNames[i] = "DJINN";
+										break;
+									default:
+										enemyNames[i] = "FORCE";
+										break;
+								}
+								if (elemental != 9)
+									elementalsSelected.Remove(elemental);
+								break;
+							case 26: // Gargoyle
+								enemyNames[i] = "GOYLE";
+								enemyStats[i].num_hits = 4;
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 3);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 5);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000001;
+								enemyStats[i].elem_resist = 0b10000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 27: // Dragon Type 1
+								if (dragonsSelected.Count > 0)
+									elemental = dragonsSelected.PickRandom(rng);
+								rollDragon(rng, ref enemyStats[i], enemyTierList[i], elemental);
+								switch(elemental)
+								{
+									case 1:
+										enemyNames[i] = "Earth D";
+										break;
+									case 2:
+										enemyNames[i] = "Elec D";
+										break;
+									case 3:
+										enemyNames[i] = "Ice D";
+										break;
+									case 4:
+										enemyNames[i] = "Fire D";
+										break;
+									case 5:
+										enemyNames[i] = "Death D";
+										break;
+									case 6:
+										enemyNames[i] = "Time D";
+										break;
+									case 7:
+										enemyNames[i] = "Gas D";
+										break;
+									case 8:
+										enemyNames[i] = "Magic D";
+										break;
+									default:
+										enemyNames[i] = "DRAKE";
+										break;
+								}
+								if (elemental != 9)
+									dragonsSelected.Remove(elemental);
+								break;
+							case 28: // Slime
+								enemyNames[i] = "FLAN";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 6);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 2);
+								enemyStats[i].absorb = rng.Between(0, 2) == 2 ? rng.Between(0, 12) : 255;
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 1);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000001;
+								enemyStats[i].elem_weakness = (byte)(rng.Between(1, 6) << 4); // can be fire, ice, fire+ice, lit, fire+lit, or ice+lit weak
+								enemyStats[i].elem_resist = (byte)((0b11111111 ^ enemyStats[i].elem_weakness) & 0b11111011); // resist all other elements except time
+								break;
+							case 29: // Manticore
+								enemyNames[i] = "MANT";
+								enemyStats[i].num_hits = rng.Between(2, 3);
+								enemyStats[i].critrate = rng.Between(1, 3);
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 5);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 2);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 7);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000000;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 30: // Spider
+								enemyNames[i] = "BUG";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 3);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000000;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 31: // Ankylo
+								enemyNames[i] = "ANK";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = rng.Between(1, 3);
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 7);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 6);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 7);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000000;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								break;
+							case 32: // Mummy
+								enemyNames[i] = "MUMMY";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = rng.Between(1, 3);
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 3);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 5);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 3);
+								enemyStats[i].atk_elem = 0b00000001;
+								enemyStats[i].atk_ailment = 0b00100000;
+								enemyStats[i].monster_type = 0b00001000;
+								enemyStats[i].elem_resist = 0b00101011;
+								enemyStats[i].elem_weakness = 0b00010000;
+								break;
+							case 33: // Wyvern
+								enemyNames[i] = "WYRM";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 5);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 6);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
+								enemyStats[i].agility = 72 + enemyStats[i].exp / 40;
+								if (enemyStats[i].agility > 100)
+									enemyStats[i].agility = 100;
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000010;
+								enemyStats[i].elem_resist = 0b10000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								break;
+							case 34: // Jerk Bird
+								enemyNames[i] = "BIRD";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 3);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 3);
+								enemyStats[i].absorb = rng.Between(0, 8);
+								enemyStats[i].agility = 72;
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000000;
+								enemyStats[i].elem_resist = 0b10000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 35: // Steak
+								enemyNames[i] = "TYRO";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = rng.Between(20, 40);
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 7);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 7);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 2);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 6);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000010;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								break;
+							case 36: // Pirahna
+								enemyNames[i] = "FISH";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 2);
+								enemyStats[i].agility = 72;
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00100000;
+								enemyStats[i].elem_resist = 0b10010000;
+								enemyStats[i].elem_weakness = 0b01000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								break;
+							case 37: // Ocho
+								enemyNames[i] = "OCHO";
+								enemyStats[i].num_hits = 3;
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 6);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 5);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
+								enemyStats[i].atk_elem = 0b00000010;
+								enemyStats[i].atk_ailment = 0b00000100;
+								enemyStats[i].monster_type = 0b00100000;
+								enemyStats[i].elem_resist = 0b10010000;
+								enemyStats[i].elem_weakness = 0b01000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 38: // Gator
+								enemyNames[i] = "GATOR";
+								enemyStats[i].num_hits = rng.Between(2, 3);
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 6);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 5);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
+								enemyStats[i].agility = 48;
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00100010;
+								enemyStats[i].elem_resist = 0b10010000;
+								enemyStats[i].elem_weakness = 0b01000000;
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 39: // Hydra
+								enemyNames[i] = "HYDRA";
+								enemyStats[i].num_hits = 4;
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 5);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 5);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000010;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 40: // Robot
+								enemyNames[i] = "BOT";
+								enemyStats[i].num_hits = rng.Between(1, 2);
+								enemyStats[i].critrate = rng.Between(1, 5);
+								enemyStats[i].damage = enemyStats[i].num_hits == 1 ? rollEnemyStrength(enemyTierList[i], 7) : rollEnemyStrength(enemyTierList[i], 5);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 6);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 7);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 6);
+								enemyStats[i].atk_elem = 0b00000001;
+								enemyStats[i].atk_ailment = enemyStats[i].num_hits == 1 ? (byte)0b00000000 : (byte)0b00010000;
+								enemyStats[i].monster_type = 0b00000000;
+								enemyStats[i].elem_resist = 0b00001011;
+								enemyStats[i].elem_weakness = 0b01000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 41: // Naga
+								enemyNames[i] = "NAGA";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 1);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 7);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 2);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 6);
+								enemyStats[i].atk_elem = 0b00000010;
+								enemyStats[i].atk_ailment = 0b00000100;
+								enemyStats[i].monster_type = 0b01000000;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								if (enemyStats[i].AIscript == 0xFF)
+									enemyStats[i].AIscript = ENE_PickForcedAIScript(enemyTierList[i]);
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								break;
+							case 42: // Small Elemental
+								enemyNames[i] = "AIR";
+								if (elementalsSelected.Count > 0)
+									elemental = elementalsSelected.PickRandom(rng);
+								rollSmallElemental(rng, ref enemyStats[i], enemyTierList[i], elemental);
+								switch (elemental)
+								{
+									case 1:
+										enemyNames[i] = "SHARD";
+										break;
+									case 2:
+										enemyNames[i] = "WIND";
+										break;
+									case 3:
+										enemyNames[i] = "WATER";
+										break;
+									case 4:
+										enemyNames[i] = "FLARE";
+										break;
+									case 5:
+										enemyNames[i] = "DOOM";
+										break;
+									case 6:
+										enemyNames[i] = "TIME";
+										break;
+									case 7:
+										enemyNames[i] = "BANE";
+										break;
+									case 8:
+										enemyNames[i] = "MAGIC";
+										break;
+									default:
+										enemyNames[i] = "AIR";
+										break;
+								}
+								if (elemental != 9)
+									elementalsSelected.Remove(elemental);
+								break;
+							case 43: // Chimera
+								enemyNames[i] = "BEAST";
+								enemyStats[i].num_hits = 4;
+								enemyStats[i].critrate = rng.Between(1, 3);
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 6);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 6);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 6);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000010;
+								enemyStats[i].elem_resist = 0b10010000;
+								enemyStats[i].elem_weakness = 0b00100000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 44: // Piscodemon
+								enemyNames[i] = "SQUID";
+								enemyStats[i].num_hits = rng.Between(2, 3);
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 5);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 5);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 6);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000000;
+								enemyStats[i].elem_resist = 0b00110011;
+								enemyStats[i].elem_weakness = 0b00000000;
+								break;
+							case 45: // Dragon Type 2
+								if (dragonsSelected.Count > 0)
+									elemental = dragonsSelected.PickRandom(rng);
+								rollDragon(rng, ref enemyStats[i], enemyTierList[i], elemental);
+								switch (elemental)
+								{
+									case 1:
+										enemyNames[i] = "Earth D";
+										break;
+									case 2:
+										enemyNames[i] = "Elec D";
+										break;
+									case 3:
+										enemyNames[i] = "Ice D";
+										break;
+									case 4:
+										enemyNames[i] = "Fire D";
+										break;
+									case 5:
+										enemyNames[i] = "Death D";
+										break;
+									case 6:
+										enemyNames[i] = "Time D";
+										break;
+									case 7:
+										enemyNames[i] = "Gas D";
+										break;
+									case 8:
+										enemyNames[i] = "Magic D";
+										break;
+									default:
+										enemyNames[i] = "DRAGON";
+										break;
+								}
+								if (elemental != 9)
+									dragonsSelected.Remove(elemental);
+								break;
+							case 46: // Knight Type 1
+								enemyNames[i] = "KNIGHT";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = rng.Between(1, 10);
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 5);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 5);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 5);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 5);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000000;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 47: // Golem
+								enemyNames[i] = "GOLEM";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 6);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
+								enemyStats[i].absorb = rng.Between(7, 60);
+								if (enemyStats[i].exp > 4000)
+									enemyStats[i].absorb = (enemyStats[i].absorb * 2) + 30;
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000000;
+								enemyStats[i].elem_resist = 0b11111011;
+								if(enemyStats[i].absorb > 60)
+								{
+									switch(rng.Between(0, 2))
+									{
+										case 0:
+											enemyStats[i].elem_resist &= 0b10111111;
+											break;
+										case 1:
+											enemyStats[i].elem_resist &= 0b11011111;
+											break;
+										case 2:
+											enemyStats[i].elem_resist &= 0b11101111;
+											break;
+									}
+								}
+								enemyStats[i].elem_weakness = 0b00000000;
+								break;
+							case 48: // Knight Type 2
+								enemyNames[i] = "RANGER";
+								enemyStats[i].num_hits = rng.Between(1, 2);
+								enemyStats[i].critrate = rng.Between(1, 5);
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 6);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 6);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 6);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000000;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 49: // Pony
+								enemyNames[i] = "PONY";
+								enemyStats[i].num_hits = rng.Between(2, 4);
+								enemyStats[i].critrate = rng.Between(1, 3);
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 5);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 5);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 6);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b00000000;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								break;
+							case 50: // Elf
+								enemyNames[i] = "ELF";
+								enemyStats[i].num_hits = 1;
+								enemyStats[i].critrate = rng.Between(1, 5);
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 6);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 7);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b01000000;
+								enemyStats[i].elem_resist = 0b00000000;
+								enemyStats[i].elem_weakness = 0b00000000;
+								if (enemyStats[i].AIscript == 0xFF)
+									enemyStats[i].AIscript = ENE_PickForcedAIScript(enemyTierList[i]);
+								perks.Add(MonsterPerks.PERK_LOWRESIST);
+								perks.Add(MonsterPerks.PERK_HIGHRESIST);
+								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+								perks.Add(MonsterPerks.PERK_POISONTOUCH);
+								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+								perks.Add(MonsterPerks.PERK_MUTETOUCH);
+								break;
+							case 51: // War Machine
+								enemyNames[i] = "MECH";
+								enemyStats[i].num_hits = 2;
+								enemyStats[i].critrate = 1;
+								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 7);
+								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 7);
+								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 7);
+								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
+								enemyStats[i].atk_elem = 0b00000000;
+								enemyStats[i].atk_ailment = 0b00000000;
+								enemyStats[i].monster_type = 0b10000000;
+								enemyStats[i].elem_resist = 0b00111011;
+								enemyStats[i].elem_weakness = 0b01000000;
+								enemyStats[i].exp *= 9;
+								enemyStats[i].exp /= 8;
+								break;
+						}
+						bool hasGlobalPerk = false;
+						bool didntChooseVariantClass = true; // false if this monster rolled a variant class and thus doesn't need a name modifier
+						// if enemy has a global perk, apply it now and skip all other perks
+						if (i == Enemy.Crawl)
+						{
+							// Global Perk - multi-hitter with weak attacks but stun touch guaranteed (overrides existing atk ailment)
+							enemyStats[i].atk_elem = 0b00000001;
+							enemyStats[i].atk_ailment = 0b00010000;
+							enemyStats[i].num_hits = 8;
+							enemyStats[i].damage = 1;
+							hasGlobalPerk = true;
+						}
+						else if(i == Enemy.Coctrice)
+						{
+							// Global Perk - stonetouch (overrides other atk_elem and ailment), -1 hit if num_hits > 1
+							enemyStats[i].atk_elem = 0b00000010;
+							enemyStats[i].atk_ailment = 0b00000010;
+							if (enemyStats[i].num_hits > 1)
+								enemyStats[i].num_hits--;
+							hasGlobalPerk = true;
+						}
+						else if(i == Enemy.Mancat)
+						{
+							// Global Perk - Mancat (resistance to all elements except time and no weaknesses)
+							enemyStats[i].elem_resist = 0b11111011;
+							enemyStats[i].elem_weakness = 0b00000000;
+							hasGlobalPerk = true;
+						}
+						else if(i == Enemy.Sorceror)
+						{
+							// Global Perk - deathtouch
+							enemyStats[i].atk_elem = 0b00000000;
+							enemyStats[i].atk_ailment = 0b00000001;
+							hasGlobalPerk = true;
+						}
+						else if(i == Enemy.Nitemare)
+						{
+							// Global Perk - resist all except one low element and time, weak to selected element
+							switch(rng.Between(0,2))
+							{
+								case 0:
+									enemyStats[i].elem_resist = 0b10111011;
+									enemyStats[i].elem_weakness = 0b01000000;
+									break;
+								case 1:
+									enemyStats[i].elem_resist = 0b11011011;
+									enemyStats[i].elem_weakness = 0b00100000;
+									break;
+								case 2:
+									enemyStats[i].elem_resist = 0b11101011;
+									enemyStats[i].elem_weakness = 0b00010000;
+									break;
+							}
 						}
 						else
 						{
-							if (cur + surpcount.Sum() >= bossformations)
+							// else, roll the chance for an enemy to get a class modifier.  Each class of monster can have Frost, Red, Zombie, Were, and Wizard variants, though some monster classes can't use some of these
+							// this perk restricts the monster from rolling any other perks
+							if (rng.Between(0, 11) < monsterClassVariants[enemyImage[i]].Count())
 							{
-								// automatically roll a surprise chance
-								int s_roll = rng.Between(1, surpcount.Sum());
-								int s_tier = -1;
-								if (s_roll <= surpcount[0])
-									s_tier = 0;
-								else if (s_roll <= surpcount[0] + surpcount[1] && s_roll > surpcount[0])
-									s_tier = 1;
-								else if (s_roll <= surpcount[0] + surpcount[1] + surpcount[2] && s_roll > surpcount[0] + surpcount[1])
-									s_tier = 2;
-								else if (s_roll <= surpcount[0] + surpcount[1] + surpcount[2] + surpcount[3] && s_roll > surpcount[0] + surpcount[1] + surpcount[2])
-									s_tier = 3;
-								if (s_tier == -1)
+								didntChooseVariantClass = false;
+								string classModifier = monsterClassVariants[enemyImage[i]].PickRandom(rng);
+								switch (classModifier) // apply the traits of this enemy class
 								{
-									f.surprise = (byte)rng.Between(3, 9);
+									case "Wz":
+										if(enemyStats[i].AIscript == 0xFF)
+										{
+											enemyStats[i].AIscript = ENE_PickForcedAIScript(enemyTierList[i]);
+										}
+										break;
+									case "Fr":
+										enemyStats[i].elem_resist |= 0b00100000;
+										enemyStats[i].elem_resist &= 0b11101111;
+										enemyStats[i].elem_weakness |= 0b00010000;
+										enemyStats[i].elem_weakness &= 0b11011111;
+										enemyStats[i].atk_elem = 0b00100000;
+										break;
+									case "R.":
+										enemyStats[i].elem_resist |= 0b00010000;
+										enemyStats[i].elem_resist &= 0b11011111;
+										enemyStats[i].elem_weakness |= 0b00100000;
+										enemyStats[i].elem_weakness &= 0b11101111;
+										enemyStats[i].atk_elem = 0b00010000;
+										break;
+									case "Z.":
+										enemyStats[i].elem_resist |= 0b00101011;
+										enemyStats[i].elem_resist &= 0b11101111;
+										enemyStats[i].elem_weakness |= 0b00010000;
+										enemyStats[i].elem_weakness &= 0b11010100;
+										enemyStats[i].monster_type |= 0b00001000;
+										if(enemyStats[i].atk_ailment == 0)
+										{
+											enemyStats[i].atk_ailment = 0b00010000;
+											enemyStats[i].atk_elem = 0b00000001;
+										}
+										break;
+									case "Sea":
+										enemyStats[i].elem_resist |= 0b10010000;
+										enemyStats[i].elem_resist &= 0b10111111;
+										enemyStats[i].elem_weakness |= 0b01000000;
+										enemyStats[i].elem_weakness &= 0b01101111;
+										enemyStats[i].monster_type |= 0b00100000;
+										break;
+									case "Wr":
+										enemyStats[i].atk_ailment = 0b00000100;
+										enemyStats[i].atk_elem = 0b00000010;
+										enemyStats[i].monster_type |= 0b00010000;
+										break;
+								}
+								enemyNames[i] = classModifier + enemyNames[i]; // change the enemy's name
+								monsterClassVariants[enemyImage[i]].Remove(classModifier); // remove this variant from the list of variants available for this enemy image
+							}
+						}
+						if(didntChooseVariantClass)
+						{
+							// else, roll minor perks.  there is a 75% chance to gain a perk, then 62.5%, 50%, and so on.  monsters cannot gain more than 4 perks
+							int num_perks = 0;
+							if(!hasGlobalPerk)
+							{
+								while (rng.Between(0, 7) > 1 + num_perks && num_perks < 4)
+								{
+									// select from the list of available perks
+									MonsterPerks this_perk = perks.PickRandom(rng);
+									bool didPerkRoll = true;
+									switch (this_perk)
+									{
+										case MonsterPerks.PERK_GAINSTAT10: // pick a random stat to increase by 10%, +3% XP
+											switch (rng.Between(0, 2))
+											{
+												case 0:
+													enemyStats[i].hp *= 11;
+													enemyStats[i].hp /= 10;
+													break;
+												case 1:
+													enemyStats[i].damage *= 11;
+													enemyStats[i].damage /= 10;
+													break;
+												case 2:
+													enemyStats[i].absorb *= 11;
+													enemyStats[i].absorb /= 10;
+													break;
+											}
+											enemyStats[i].exp *= 103;
+											enemyStats[i].exp /= 100;
+											break;
+										case MonsterPerks.PERK_LOSESTAT10: // pick a random stat to decrease by 10%, -3% XP
+											switch (rng.Between(0, 2))
+											{
+												case 0:
+													enemyStats[i].hp *= 9;
+													enemyStats[i].hp /= 10;
+													break;
+												case 1:
+													enemyStats[i].damage *= 9;
+													enemyStats[i].damage /= 10;
+													break;
+												case 2:
+													enemyStats[i].absorb *= 9;
+													enemyStats[i].absorb /= 10;
+													break;
+											}
+											enemyStats[i].exp *= 97;
+											enemyStats[i].exp /= 100;
+											break;
+										case MonsterPerks.PERK_LOWRESIST: // pick a low resist or remove the corresponding weakness, +4% XP
+											switch (rng.Between(0, 3))
+											{
+												case 0:
+													if ((enemyStats[i].elem_weakness & 0b10000000) == 0b10000000)
+														enemyStats[i].elem_weakness &= 0b01111111;
+													else
+														enemyStats[i].elem_resist |= 0b10000000;
+													break;
+												case 1:
+													if ((enemyStats[i].elem_weakness & 0b01000000) == 0b01000000)
+														enemyStats[i].elem_weakness &= 0b10111111;
+													else
+														enemyStats[i].elem_resist |= 0b01000000;
+													break;
+												case 2:
+													if ((enemyStats[i].elem_weakness & 0b00100000) == 0b00100000)
+														enemyStats[i].elem_weakness &= 0b11011111;
+													else
+														enemyStats[i].elem_resist |= 0b00100000;
+													break;
+												case 3:
+													if ((enemyStats[i].elem_weakness & 0b00010000) == 0b00001000)
+														enemyStats[i].elem_weakness &= 0b11101111;
+													else
+														enemyStats[i].elem_resist |= 0b00010000;
+													break;
+											}
+											enemyStats[i].exp *= 104;
+											enemyStats[i].exp /= 100;
+											break;
+										case MonsterPerks.PERK_LOWWEAKNESS: // pick a low weakness (or cancel a resist, or ignore for earth resist), -5% XP
+											switch (rng.Between(0, 3))
+											{
+												case 0:
+													if ((enemyStats[i].elem_resist & 0b10000000) == 0b10000000)
+														didPerkRoll = false;
+													else
+														enemyStats[i].elem_weakness |= 0b10000000;
+													break;
+												case 1:
+													if ((enemyStats[i].elem_resist & 0b01000000) == 0b01000000)
+														enemyStats[i].elem_resist &= 0b10111111;
+													else
+														enemyStats[i].elem_weakness |= 0b01000000;
+													break;
+												case 2:
+													if ((enemyStats[i].elem_resist & 0b00100000) == 0b00100000)
+														enemyStats[i].elem_resist &= 0b11011111;
+													else
+														enemyStats[i].elem_weakness |= 0b00100000;
+													break;
+												case 3:
+													if ((enemyStats[i].elem_resist & 0b00010000) == 0b00010000)
+														enemyStats[i].elem_resist &= 0b11101111;
+													else
+														enemyStats[i].elem_weakness |= 0b00010000;
+													break;
+											}
+											if (didPerkRoll)
+											{
+												enemyStats[i].exp *= 95;
+												enemyStats[i].exp /= 100;
+											}
+											break;
+										case MonsterPerks.PERK_HIGHRESIST:  // pick a high resist and remove the corresponding weakness, +3% XP
+											switch (rng.Between(0, 3))
+											{
+												case 0:
+													enemyStats[i].elem_resist |= 0b00001000;
+													enemyStats[i].elem_weakness &= 0b11110111;
+													break;
+												case 1:
+													enemyStats[i].elem_resist |= 0b00000100;
+													enemyStats[i].elem_weakness &= 0b11111011;
+													break;
+												case 2:
+													enemyStats[i].elem_resist |= 0b00000010;
+													enemyStats[i].elem_weakness &= 0b11111101;
+													break;
+												case 3:
+													enemyStats[i].elem_resist |= 0b00000001;
+													enemyStats[i].elem_weakness &= 0b11111110;
+													break;
+											}
+											enemyStats[i].exp *= 103;
+											enemyStats[i].exp /= 100;
+											break;
+										case MonsterPerks.PERK_HIGHWEAKNESS:
+											switch (rng.Between(0, 3))
+											{
+												case 0:
+													if ((enemyStats[i].elem_resist & 0b00001000) == 0b00001000)
+														enemyStats[i].elem_resist &= 0b11110111;
+													else
+														enemyStats[i].elem_weakness |= 0b00001000;
+													break;
+												case 1:
+													if ((enemyStats[i].elem_resist & 0b00000100) == 0b00000100)
+														enemyStats[i].elem_resist &= 0b11111011;
+													else
+														enemyStats[i].elem_weakness |= 0b00000100;
+													break;
+												case 2:
+													if ((enemyStats[i].elem_resist & 0b00000010) == 0b00000010)
+														enemyStats[i].elem_resist &= 0b11111101;
+													else
+														enemyStats[i].elem_weakness |= 0b00000010;
+													break;
+												case 3:
+													if ((enemyStats[i].elem_resist & 0b00000001) == 0b00000001)
+														enemyStats[i].elem_resist &= 0b11111110;
+													else
+														enemyStats[i].elem_weakness |= 0b00000001;
+													break;
+											}
+											if (didPerkRoll)
+											{
+												enemyStats[i].exp *= 97;
+												enemyStats[i].exp /= 100;
+											}
+											break;
+										case MonsterPerks.PERK_PLUSONEHIT: // +1 hit, +5/3/2/1... XP for an addition hit
+											enemyStats[i].num_hits++;
+											switch (enemyStats[i].num_hits)
+											{
+												case 2:
+													enemyStats[i].exp *= 21;
+													enemyStats[i].exp /= 20;
+													break;
+												case 3:
+													enemyStats[i].exp *= 103;
+													enemyStats[i].exp /= 100;
+													break;
+												case 4:
+													enemyStats[i].exp *= 51;
+													enemyStats[i].exp /= 50;
+													break;
+												default:
+													enemyStats[i].exp *= 101;
+													enemyStats[i].exp /= 100;
+													break;
+											}
+											break;
+										case MonsterPerks.PERK_POISONTOUCH: // adds poisontouch if enemy has no atk_ailment already, no XP increase
+											if (enemyStats[i].atk_ailment == 0)
+											{
+												enemyStats[i].atk_ailment = 0b00000100;
+												enemyStats[i].atk_elem = 0b00000010;
+											}
+											break;
+										case MonsterPerks.PERK_STUNSLEEPTOUCH: // adds stun or sleep touch if enemy has no atk_ailment already
+											if (enemyStats[i].atk_ailment == 0)
+											{
+												enemyStats[i].atk_ailment = rng.Between(0, 1) == 0 ? (byte)0b00100000 : (byte)0b00010000;
+												enemyStats[i].atk_elem = 0b00000001;
+												enemyStats[i].exp *= 103;
+												enemyStats[i].exp /= 100;
+											}
+											break;
+										case MonsterPerks.PERK_MUTETOUCH: // adds mute touch if enemy has no atk_ailment already
+											if (enemyStats[i].atk_ailment == 0)
+											{
+												enemyStats[i].atk_ailment = 0b01000000;
+												enemyStats[i].atk_elem = 0b00000001;
+												enemyStats[i].exp *= 51;
+												enemyStats[i].exp /= 50;
+											}
+											break;
+									}
+									num_perks++;
+								}
+							}
+							// if enemy's vanilla name has already been used, add a name modifier
+							if(elemental == 9) // don't make alternate names for elementals
+							{
+								if (monsterBaseNameUsed[enemyImage[i]])
+								{
+									string nameModifier = monsterNameVariants[enemyImage[i]].PickRandom(rng);
+									enemyNames[i] = nameModifier + enemyNames[i];
 								}
 								else
+									monsterBaseNameUsed[enemyImage[i]] = true;
+							}
+						}
+						if (enemyStats[i].AIscript != 0xFF) // set monster type to Mage if it has a script
+							enemyStats[i].monster_type |= 0b01000000;
+						for(int j = 1; j < enemyStats[i].num_hits; ++j) // for each hit past the first, reduce the base damage by one for every 15 points of damage rating
+						{
+							enemyStats[i].damage = enemyStats[i].damage - enemyStats[i].damage / 15;
+						}
+						enemyStats[i].damage = rng.Between(enemyStats[i].damage - enemyStats[i].damage / 25, enemyStats[i].damage + enemyStats[i].damage / 25); // variance for damage rating
+						enemyStats[i].hp = rng.Between(enemyStats[i].hp - enemyStats[i].hp / 30, enemyStats[i].hp + enemyStats[i].hp / 30); // variance for hp rating
+						enemyStats[i].gp = rng.Between(enemyStats[i].gp - enemyStats[i].gp / 20, enemyStats[i].gp + enemyStats[i].gp / 20); // variance for gp reward
+						enemyStats[i].exp = rng.Between(enemyStats[i].exp - enemyStats[i].exp / 40, enemyStats[i].exp + enemyStats[i].exp / 40); // variance for exp reward
+					}
+				}
+				// remove palettes from tilesets where there are no mons using those palettes
+				for(int i = 0; i < GenericTilesetsCount; ++i)
+				{
+					List<byte> palRemoveList = new List<byte> { };
+					foreach(byte pal in palettesInTileset[i])
+					{
+						bool nopalettematch = true;
+						foreach(byte mon in enemiesInTileset[i])
+						{
+							if(enemyPalettes[mon] == pal)
+							{
+								nopalettematch = false;
+								break;
+							}
+						}
+						if(nopalettematch)
+						{
+							palRemoveList.Add(pal);
+						}
+					}
+					foreach(byte pal in palRemoveList)
+					{
+						palettesInTileset[i].Remove(pal);
+					}
+				}
+				// modify scripts - all scripts that are skills-only gain a magic list full of spells in the same tier (with 24/128 chance of activating)
+				// each spell is then selected from a list of spells available for that tier.  it is not possible to promote to a higher tier
+				// skills will remain the same
+				for(int i = 0; i < ScriptCount - 10; ++i) // exclude the last 10 scripts
+				{
+					if(enemyScripts[i].spell_chance == 0)
+					{
+						byte whichSpell = 0; // index for CURE, a tier 1 enemy spell
+						switch (ENE_GetEnemySkillTier(enemyScripts[i].skill_list[0]))
+						{
+							case 2:
+								whichSpell = 5; // these are just spell indices of spells that correspond to the tier, we will replace them later
+								break;
+							case 3:
+								whichSpell = 21;
+								break;
+							case 4:
+								whichSpell = 37;
+								break;
+							case 5:
+								whichSpell = 0xFF; // if a tier 5 is encountered, we don't fill the spell list (the skill is nasty enough!) - by default this only applies to warmech
+								break;
+						}
+						for(byte j = 0; j < 8; ++j)
+						{
+							enemyScripts[i].spell_list[j] = whichSpell;
+						}
+						if(whichSpell != 0xFF)
+							enemyScripts[i].spell_chance = 24;
+					}
+					// start replacing each spell with another spell from the same tier
+					for(byte j = 0; j < 8; ++j)
+					{
+						if (enemyScripts[i].spell_list[j] == 0xFF)
+							continue; // skip blank spells
+						int whichTier = ENE_GetEnemySpellTier(enemyScripts[i].spell_list[j]);
+						List<byte> eligibleSpellIDs = new List<byte> { };
+						for(byte k = 0; k < 64; ++k)
+						{
+							if (ENE_GetEnemySpellTier(k) == whichTier)
+								eligibleSpellIDs.Add(k);
+						}
+						enemyScripts[i].spell_list[j] = eligibleSpellIDs.PickRandom(rng);
+					}
+				}
+
+				num_enemy_name_chars = 0;
+				for (int i = 0; i < EnemyCount; ++i)
+				{
+					num_enemy_name_chars += enemyNames[i].Length;
+				}
+				Console.WriteLine(num_enemy_name_chars);
+				return true;
+			}
+
+			public int rollEnemyStrength(int tier, int level)
+			{
+				int[,] returnValue = new int[,] {
+					{ 3, 6, 11, 16, 19, 25, 33, 40, 50, 61},
+					{ 4, 9, 15, 19, 22, 29, 38, 45, 55, 68},
+					{ 6, 12, 17, 22, 26, 32, 43, 50, 60, 75},
+					{ 8, 14, 20, 25, 30, 37, 49, 55, 67, 85},
+					{ 9, 16, 22, 28, 34, 42, 54, 61, 75, 92},
+					{ 10, 18, 25, 31, 38, 47, 60, 70, 82, 100},
+					{ 12, 20, 28, 35, 42, 53, 70, 85, 95, 110} };
+				if (tier < 0 || level < 1 || tier > 9 || level > 7)
+					return 0; // return 0 if the tier/level are out of bounds
+				return returnValue[level - 1, tier];
+			}
+
+			public int rollEnemyAccuracy(int tier, int level)
+			{
+				int[,] returnValue = new int[,] {
+					{ 1, 6, 11, 16, 19, 25, 33, 40, 50, 61},
+					{ 2, 9, 15, 19, 22, 29, 38, 45, 55, 68},
+					{ 4, 12, 17, 22, 26, 32, 43, 50, 60, 75},
+					{ 6, 14, 20, 25, 30, 37, 49, 55, 67, 85},
+					{ 8, 16, 22, 28, 34, 42, 54, 61, 75, 92},
+					{ 10, 18, 25, 31, 38, 47, 60, 70, 82, 100},
+					{ 12, 20, 30, 40, 50, 60, 70, 85, 95, 110} };
+				if (tier < 0 || level < 1 || tier > 9 || level > 7)
+					return 0; // return 0 if the tier/level are out of bounds
+				return returnValue[level - 1, tier];
+			}
+
+			public int rollEnemyAbsorb(int tier, int level)
+			{
+				int[,] returnValue = new int[,] {
+					{ 1, 2, 3, 4, 5, 6, 7, 8, 10, 12},
+					{ 2, 3, 5, 7, 9, 12, 14, 17, 20, 24},
+					{ 3, 5, 7, 9, 12, 14, 17, 20, 24, 30},
+					{ 4, 6, 9, 12, 15, 18, 21, 25, 29, 40},
+					{ 5, 8, 11, 14, 18, 22, 26, 30, 34, 46},
+					{ 8, 12, 16, 20, 25, 30, 35, 40, 45, 53},
+					{ 10, 14, 19, 25, 30, 36, 42, 49, 56, 68 } };
+				if (tier < 0 || level < 1 || tier > 9 || level > 7)
+					return 0; // return 0 if the tier/level are out of bounds
+				return returnValue[level - 1, tier];
+			}
+
+			public int rollEnemyEvade(int tier, int level)
+			{
+				int[,] returnValue = new int[,] {
+					{ 1, 3, 6, 8, 10, 12, 15, 18, 21, 24},
+					{ 3, 6, 9, 12, 15, 18, 21, 24, 27, 30},
+					{ 6, 9, 12, 16, 21, 26, 30, 35, 40, 45},
+					{ 9, 14, 20, 25, 30, 36, 42, 48, 54, 60},
+					{ 20, 24, 30, 36, 42, 48, 54, 60, 70, 80},
+					{ 36, 42, 48, 54, 60, 66, 72, 78, 90, 102},
+					{ 48, 54, 64, 72, 80, 90, 100, 115, 125, 140} };
+				if (tier < 0 || level < 1 || tier > 9 || level > 7)
+					return 0; // return 0 if the tier/level are out of bounds
+				return returnValue[level - 1, tier];
+			}
+
+			public void rollLargeElemental(MT19337 rng, ref EnemyData thisEnemy, int tier, int element)
+			{
+				switch(element)
+				{
+					case 1: // Earth Elemental
+						thisEnemy.num_hits = 1;
+						thisEnemy.critrate = 1;
+						thisEnemy.damage = rollEnemyStrength(tier, 7);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 7);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 5);
+						thisEnemy.agility = rollEnemyEvade(tier, 2);
+						thisEnemy.atk_elem = 0b10000000;
+						thisEnemy.atk_ailment = 0b00000000;
+						thisEnemy.monster_type = 0b00000001;
+						thisEnemy.elem_resist = 0b11101011;
+						thisEnemy.elem_weakness = 0b00010000;
+						break;
+					case 2: // Lightning Elemental
+						thisEnemy.num_hits = 1;
+						thisEnemy.critrate = 20;
+						thisEnemy.damage = rollEnemyStrength(tier, 5);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 5);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 2);
+						thisEnemy.agility = rollEnemyEvade(tier, 6);
+						thisEnemy.atk_elem = 0b01000000;
+						thisEnemy.atk_ailment = 0b00100000;
+						thisEnemy.monster_type = 0b00000001;
+						thisEnemy.elem_resist = 0b11011001;
+						thisEnemy.elem_weakness = 0b00000110;
+						break;
+					case 3: // Ice Elemental
+						thisEnemy.num_hits = 1;
+						thisEnemy.critrate = 1;
+						thisEnemy.damage = rollEnemyStrength(tier, 5);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 7);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 6);
+						thisEnemy.agility = rollEnemyEvade(tier, 2);
+						thisEnemy.atk_elem = 0b00100000;
+						thisEnemy.atk_ailment = 0b00010000;
+						thisEnemy.monster_type = 0b00000001;
+						thisEnemy.elem_resist = 0b11101011;
+						thisEnemy.elem_weakness = 0b00010000;
+						break;
+					case 4: // Fire Elemental
+						thisEnemy.num_hits = 1;
+						thisEnemy.critrate = 1;
+						thisEnemy.damage = rollEnemyStrength(tier, 6);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 7);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 5);
+						thisEnemy.agility = rollEnemyEvade(tier, 2);
+						thisEnemy.atk_elem = 0b00010000;
+						thisEnemy.atk_ailment = 0b00000000;
+						thisEnemy.monster_type = 0b00000001;
+						thisEnemy.elem_resist = 0b11011011;
+						thisEnemy.elem_weakness = 0b00100000;
+						break;
+					case 5: // Death Elemental
+						thisEnemy.num_hits = 2;
+						thisEnemy.critrate = 1;
+						thisEnemy.damage = rollEnemyStrength(tier, 7);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 4);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 4);
+						thisEnemy.agility = rollEnemyEvade(tier, 4);
+						thisEnemy.atk_elem = 0b00001000;
+						thisEnemy.atk_ailment = 0b00001000;
+						thisEnemy.monster_type = 0b00001001;
+						thisEnemy.elem_resist = 0b10101011;
+						thisEnemy.elem_weakness = 0b00010000;
+						break;
+					case 6: // Time Elemental
+						thisEnemy.num_hits = rng.Between(4, 6);
+						thisEnemy.critrate = 1;
+						thisEnemy.damage = rollEnemyStrength(tier, 4);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 4);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 4);
+						thisEnemy.agility = rollEnemyEvade(tier, 5);
+						thisEnemy.atk_elem = 0b00000100;
+						thisEnemy.atk_ailment = 0b00010000;
+						thisEnemy.monster_type = 0b00000001;
+						thisEnemy.elem_resist = 0b10001111;
+						thisEnemy.elem_weakness = 0b01110000;
+						break;
+					case 7: // Poison Elemental
+						thisEnemy.num_hits = 1;
+						thisEnemy.critrate = 1;
+						thisEnemy.damage = rollEnemyStrength(tier, 6);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 7);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 2);
+						thisEnemy.agility = rollEnemyEvade(tier, 6);
+						thisEnemy.atk_elem = 0b00000010;
+						thisEnemy.atk_ailment = 0b00000100;
+						thisEnemy.monster_type = 0b10000001;
+						thisEnemy.elem_resist = 0b10001011;
+						thisEnemy.elem_weakness = 0b00000000;
+						break;
+					case 8: // Status Elemental
+						thisEnemy.num_hits = 1;
+						thisEnemy.critrate = 3;
+						thisEnemy.damage = rollEnemyStrength(tier, 4);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 7);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 5);
+						thisEnemy.agility = rollEnemyEvade(tier, 5);
+						thisEnemy.atk_elem = 0b00000001;
+						thisEnemy.atk_ailment = 0b01000000;
+						thisEnemy.monster_type = 0b00000001;
+						thisEnemy.elem_resist = 0b11111011;
+						thisEnemy.elem_weakness = 0b00000000;
+						if (thisEnemy.AIscript == 0xFF)
+						{
+							thisEnemy.AIscript = ENE_PickForcedAIScript(tier);
+						}
+						break;
+					default: // Raw Mana Elemental
+						thisEnemy.num_hits = 1;
+						thisEnemy.critrate = 1;
+						thisEnemy.damage = rollEnemyStrength(tier, 5);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 5);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 5);
+						thisEnemy.agility = rollEnemyEvade(tier, 2);
+						thisEnemy.atk_elem = 0b00000000;
+						thisEnemy.atk_ailment = 0b00000000;
+						thisEnemy.monster_type = 0b00000001;
+						thisEnemy.elem_resist = 0b11111011;
+						thisEnemy.elem_weakness = 0b00000000;
+						break;
+				}
+			}
+
+			public void rollSmallElemental(MT19337 rng, ref EnemyData thisEnemy, int tier, int element)
+			{
+				switch (element)
+				{
+					case 1: // Earth Elemental
+						thisEnemy.num_hits = 1;
+						thisEnemy.critrate = 1;
+						thisEnemy.damage = rollEnemyStrength(tier, 6);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 7);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 5);
+						thisEnemy.agility = rollEnemyEvade(tier, 2);
+						thisEnemy.atk_elem = 0b10000000;
+						thisEnemy.atk_ailment = 0b00000000;
+						thisEnemy.monster_type = 0b00000001;
+						thisEnemy.elem_resist = 0b10101011;
+						thisEnemy.elem_weakness = 0b01010000;
+						break;
+					case 2: // Lightning Elemental
+						thisEnemy.num_hits = 1;
+						thisEnemy.critrate = 10;
+						thisEnemy.damage = rollEnemyStrength(tier, 5);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 5);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 2);
+						thisEnemy.agility = rollEnemyEvade(tier, 6);
+						thisEnemy.atk_elem = 0b01000000;
+						thisEnemy.atk_ailment = 0b00100000;
+						thisEnemy.monster_type = 0b00000001;
+						thisEnemy.elem_resist = 0b11011001;
+						thisEnemy.elem_weakness = 0b00000110;
+						break;
+					case 3: // Water Elemental
+						thisEnemy.num_hits = 1;
+						thisEnemy.critrate = 1;
+						thisEnemy.damage = rollEnemyStrength(tier, 6);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 6);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 4);
+						thisEnemy.agility = rollEnemyEvade(tier, 5);
+						thisEnemy.atk_elem = 0b00100000;
+						thisEnemy.atk_ailment = 0b00000000;
+						thisEnemy.monster_type = 0b00000001;
+						thisEnemy.elem_resist = 0b10011011;
+						thisEnemy.elem_weakness = 0b00100000;
+						break;
+					case 4: // Fire Elemental
+						thisEnemy.num_hits = 1;
+						thisEnemy.critrate = 1;
+						thisEnemy.damage = rollEnemyStrength(tier, 5);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 6);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 3);
+						thisEnemy.agility = rollEnemyEvade(tier, 6);
+						thisEnemy.atk_elem = 0b00010000;
+						thisEnemy.atk_ailment = 0b00000000;
+						thisEnemy.monster_type = 0b00000001;
+						thisEnemy.elem_resist = 0b10011001;
+						thisEnemy.elem_weakness = 0b00100000;
+						break;
+					case 5: // Death Elemental
+						thisEnemy.num_hits = 2;
+						thisEnemy.critrate = 1;
+						thisEnemy.damage = rollEnemyStrength(tier, 7);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 4);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 4);
+						thisEnemy.agility = rollEnemyEvade(tier, 4);
+						thisEnemy.atk_elem = 0b00001000;
+						thisEnemy.atk_ailment = 0b00001000;
+						thisEnemy.monster_type = 0b00001001;
+						thisEnemy.elem_resist = 0b10101011;
+						thisEnemy.elem_weakness = 0b00010000;
+						break;
+					case 6: // Time Elemental
+						thisEnemy.num_hits = rng.Between(2, 5);
+						thisEnemy.critrate = 1;
+						thisEnemy.damage = rollEnemyStrength(tier, 4);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 4);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 4);
+						thisEnemy.agility = rollEnemyEvade(tier, 5);
+						thisEnemy.atk_elem = 0b00000100;
+						thisEnemy.atk_ailment = 0b00010000;
+						thisEnemy.monster_type = 0b00000001;
+						thisEnemy.elem_resist = 0b10001111;
+						thisEnemy.elem_weakness = 0b01110000;
+						break;
+					case 7: // Poison Elemental
+						thisEnemy.num_hits = 1;
+						thisEnemy.critrate = 1;
+						thisEnemy.damage = rollEnemyStrength(tier, 6);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 7);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 2);
+						thisEnemy.agility = rollEnemyEvade(tier, 6);
+						thisEnemy.atk_elem = 0b00000010;
+						thisEnemy.atk_ailment = 0b00100000;
+						thisEnemy.monster_type = 0b10000001;
+						thisEnemy.elem_resist = 0b10001011;
+						thisEnemy.elem_weakness = 0b00000100;
+						break;
+					case 8: // Status Elemental
+						thisEnemy.num_hits = 2;
+						thisEnemy.critrate = 3;
+						thisEnemy.damage = rollEnemyStrength(tier, 4);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 4);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 4);
+						thisEnemy.agility = rollEnemyEvade(tier, 4);
+						thisEnemy.atk_elem = 0b00000001;
+						thisEnemy.atk_ailment = 0b01000000;
+						thisEnemy.monster_type = 0b00000001;
+						thisEnemy.elem_resist = 0b11111011;
+						thisEnemy.elem_weakness = 0b00000000;
+						if(thisEnemy.AIscript == 0xFF)
+						{
+							thisEnemy.AIscript = ENE_PickForcedAIScript(tier);
+						}
+						break;
+					default: // Air Elemental
+						thisEnemy.num_hits = 1;
+						thisEnemy.critrate = 1;
+						thisEnemy.damage = rollEnemyStrength(tier, 5);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 6);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 2);
+						thisEnemy.agility = rollEnemyEvade(tier, 7);
+						thisEnemy.atk_elem = 0b00000000;
+						thisEnemy.atk_ailment = 0b00000000;
+						thisEnemy.monster_type = 0b00000001;
+						thisEnemy.elem_resist = 0b10001011;
+						thisEnemy.elem_weakness = 0b00000000;
+						break;
+				}
+			}
+
+			public void rollDragon(MT19337 rng, ref EnemyData thisEnemy, int tier, int element)
+			{
+				switch (element)
+				{
+					case 1: // Earth Elemental
+						thisEnemy.num_hits = 1;
+						thisEnemy.critrate = 1;
+						thisEnemy.damage = rollEnemyStrength(tier, 6);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 4);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 7);
+						thisEnemy.agility = rollEnemyEvade(tier, 1);
+						thisEnemy.atk_elem = 0b10000000;
+						thisEnemy.atk_ailment = 0b00000000;
+						thisEnemy.monster_type = 0b00000010;
+						thisEnemy.elem_resist = 0b11100000;
+						thisEnemy.elem_weakness = 0b00000010;
+						break;
+					case 2: // Lightning Elemental
+						thisEnemy.num_hits = 1;
+						thisEnemy.critrate = 5;
+						thisEnemy.damage = rollEnemyStrength(tier, 7);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 6);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 3);
+						thisEnemy.agility = rollEnemyEvade(tier, 6);
+						thisEnemy.atk_elem = 0b01000000;
+						thisEnemy.atk_ailment = 0b00000000;
+						thisEnemy.monster_type = 0b00000010;
+						thisEnemy.elem_resist = 0b11000000;
+						thisEnemy.elem_weakness = 0b00010000;
+						break;
+					case 3: // Ice Elemental
+						thisEnemy.num_hits = 1;
+						thisEnemy.critrate = 1;
+						thisEnemy.damage = rollEnemyStrength(tier, 5);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 6);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 2);
+						thisEnemy.agility = rollEnemyEvade(tier, 7);
+						thisEnemy.atk_elem = 0b00100000;
+						thisEnemy.atk_ailment = 0b00000000;
+						thisEnemy.monster_type = 0b00000010;
+						thisEnemy.elem_resist = 0b10100010;
+						thisEnemy.elem_weakness = 0b01010000;
+						break;
+					case 4: // Fire Elemental
+						thisEnemy.num_hits = 1;
+						thisEnemy.critrate = 1;
+						thisEnemy.damage = rollEnemyStrength(tier, 7);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 7);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 5);
+						thisEnemy.agility = rollEnemyEvade(tier, 6);
+						thisEnemy.atk_elem = 0b00010000;
+						thisEnemy.atk_ailment = 0b00000000;
+						thisEnemy.monster_type = 0b00000010;
+						thisEnemy.elem_resist = 0b10010000;
+						thisEnemy.elem_weakness = 0b00100010;
+						break;
+					case 5: // Death Elemental
+						thisEnemy.num_hits = 1;
+						thisEnemy.critrate = 1;
+						thisEnemy.damage = rollEnemyStrength(tier, 6);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 6);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 6);
+						thisEnemy.agility = rollEnemyEvade(tier, 3);
+						thisEnemy.atk_elem = 0b00001000;
+						thisEnemy.atk_ailment = 0b00010000;
+						thisEnemy.monster_type = 0b00001010;
+						thisEnemy.elem_resist = 0b10101011;
+						thisEnemy.elem_weakness = 0b00010000;
+						break;
+					case 6: // Time Elemental
+						thisEnemy.num_hits = 1;
+						thisEnemy.critrate = 12;
+						thisEnemy.damage = rollEnemyStrength(tier, 6);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 7);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 6);
+						thisEnemy.agility = rollEnemyEvade(tier, 6);
+						thisEnemy.atk_elem = 0b00000100;
+						thisEnemy.atk_ailment = 0b00010000;
+						thisEnemy.monster_type = 0b00000011;
+						thisEnemy.elem_resist = 0b10001111;
+						thisEnemy.elem_weakness = 0b01110000;
+						break;
+					case 7: // Poison Elemental
+						thisEnemy.num_hits = 1;
+						thisEnemy.critrate = 1;
+						thisEnemy.damage = rollEnemyStrength(tier, 6);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 5);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 2);
+						thisEnemy.agility = rollEnemyEvade(tier, 6);
+						thisEnemy.atk_elem = 0b00000010;
+						thisEnemy.atk_ailment = 0b00000000;
+						thisEnemy.monster_type = 0b00000010;
+						thisEnemy.elem_resist = 0b10000000;
+						thisEnemy.elem_weakness = 0b00100000;
+						break;
+					case 8: // Status Elemental
+						thisEnemy.num_hits = 1;
+						thisEnemy.critrate = 3;
+						thisEnemy.damage = rollEnemyStrength(tier, 4);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 5);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 5);
+						thisEnemy.agility = rollEnemyEvade(tier, 5);
+						thisEnemy.atk_elem = 0b00000001;
+						thisEnemy.atk_ailment = 0b01000000;
+						thisEnemy.monster_type = 0b00000011;
+						thisEnemy.elem_resist = 0b01110001;
+						thisEnemy.elem_weakness = 0b00000000;
+						if (thisEnemy.AIscript == 0xFF)
+						{
+							thisEnemy.AIscript = ENE_PickForcedAIScript(tier);
+						}
+						break;
+					default: // Standard Dragon
+						thisEnemy.num_hits = 1;
+						thisEnemy.critrate = 1;
+						thisEnemy.damage = rollEnemyStrength(tier, 6);
+						thisEnemy.accuracy = rollEnemyAccuracy(tier, 6);
+						thisEnemy.absorb = rollEnemyAbsorb(tier, 6);
+						thisEnemy.agility = rollEnemyEvade(tier, 6);
+						thisEnemy.atk_elem = 0b00000000;
+						thisEnemy.atk_ailment = 0b00000000;
+						thisEnemy.monster_type = 0b00000010;
+						thisEnemy.elem_resist = 0b00000000;
+						thisEnemy.elem_weakness = 0b00000000;
+						break;
+				}
+			}
+
+			public byte ENE_PickForcedAIScript(int tier)
+			{
+				if (tier >= 0 && tier <= 2)
+					return 0x1A; // tier 0-2 uses RockGOL script
+				else if (tier >= 3 && tier <= 4)
+					return 0x0D; // tier 3-4 uses R.GOYLE script
+				else if (tier == 5)
+					return 0x19; // tier 5 uses MudGOL script
+				else if (tier >= 6 && tier <= 7)
+					return 0x1D; // tier 6-7 uses MAGE script
+				else if (tier >= 8 && tier <= 9)
+					return 0x1C; // tier 8-9 uses EVILMAN script
+				else
+					return 0xFF; // invalid tier returns no script
+			}
+
+			public int ENE_GetEnemySkillTier(byte skill)
+			{
+				if (skill >= 64)
+					return 0;
+				return skilltiers_enemy[skill];
+			}
+
+			public int ENE_GetEnemySpellTier(byte spell)
+			{
+				if (spell >= 64)
+					return 0;
+				return spelltiers_enemy[spell];
+			}
+
+			public bool DoFormations(MT19337 rng, bool didEnemies)
+			{
+				// sort enemies into zones
+				foreach(byte mon in uniqueEnemyIDs) // only sort through generic enemies that appear in uniqueEnemyIDs
+				{
+					int limit = Large(mon) ? 4 : 9;
+					for(int i = 0; i < zonecountmin.Length; ++i)
+					{
+						if(enemyStats[mon].exp <= zonexpreqs[i, 2] && enemyStats[mon].exp * limit >= zonexpreqs[i, 0])
+						{
+							enemyZones[mon].Add(i);
+							zonemons[i].Add(mon);
+						}
+					}
+				}
+				// roll special encounters for: imp, phantom, warmech, vampire, astos, pirates, garland (and ignore fiend encounters
+				ENF_DrawBumFight(rng, 0x00);
+				ENF_DrawForcedSingleFight(rng, 3, 0x01); // this is the wizard fight
+				ENF_DrawForcedSingleFight(rng, 6, 0x02); // this is the eye fight
+				ENF_DrawForcedSingleFight(rng, 6, 0x03); // this is the zombieD fight
+				ENF_DrawBossEncounter(rng, Enemy.Phantom, 1, 0x02, true, 4, 0x04);
+				ENF_DrawBossEncounter(rng, ENF_PickAVamp(rng), 1, 0x02, true, 4, 0x7C); // vampire fight tries to pick a vampire, or any monster < 3000 xp (yes, this can mean fighting a literal Bum!)
+				ENF_DrawBossEncounter(rng, Enemy.Astos, 1, 0x02, true, 4, 0x7D);
+				ENF_DrawBossEncounter(rng, Enemy.Pirate, 9, 0x00, true, 4, 0x7E);
+				ENF_DrawBossEncounter(rng, Enemy.Garland, 1, 0x02, true, 4, 0x7F);
+				ENF_DrawBossEncounter(rng, Enemy.WarMech, 1, 0x02, false, 75, warmech_encounter);
+				imp_encounter = 0x80; // resetting important encounter IDs
+				wizard_encounter = 0x81;
+				eye_encounter = 0x82;
+				zombieD_encounter = 0x83;
+				phantom_encounter = 0x04;
+				// reserve so many slots for different surprise rates and unrunnables
+				int[,] surprisetiers = { { 10, 19 }, { 24, 36 }, { 48, 62 }, { 70, 100 } };
+				const int surp1 = 9;
+				const int surp2 = 12;
+				const int surp3 = 4;
+				const int surp4 = 2;
+				int[] surpcount = { surp1, surp2, surp3, surp4 };
+				const int regularformations = 0x05; // we start rolling formations from where we stopped rolling special-case formations
+				const int bossformations = 0x73; // we stop rolling formations once we reach boss formations
+				for(byte i = regularformations; i < bossformations; ++i) // general loop for formation generation
+				{
+					if (i == imp_encounter || i == phantom_encounter || i == warmech_encounter)
+						continue; // don't do these encounters (we will roll them as special exceptions)
+					Formation f = new Formation(); // this is the formation we are hoping to write
+					// we will start narrowing down the list of monsters we can feature
+					List<byte> availablemons = new List<byte> { };
+					// first, we check if all monsters have been featured yet
+					if(uniqueEnemyIDs.Where(NotFeatured).Count() == 0)
+					{
+						// if we have featured all monsters, reset the featured array
+						foreach (byte mon in uniqueEnemyIDs)
+						{
+							featured[mon] = false;
+						}
+					}
+					// first, we determine which zones we have yet to reach the minimum for.  if they have yet to reach the minimum, they can join the union if the mon hasn't been featured yet
+					for(int j = 0; j < zonecountmin.Length; ++j)
+					{
+						if(zone[j].Count < zonecountmin[j])
+						{
+							availablemons = availablemons.Union(zonemons[j].Where(NotFeatured)).ToList();
+						}
+					}
+					// if we have already met the minimums for each zone, then any zone which has not reached its maximum can be chosen, if they have not been featured yet in this cycle
+					if(availablemons.Count == 0)
+					{
+						for (int j = 0; j < zonecountmax.Length; ++j)
+						{
+							if (zone[j].Count < zonecountmax[j])
+							{
+								availablemons = availablemons.Union(zonemons[j].Where(NotFeatured)).ToList();
+							}
+						}
+					}
+					// if we still don't have any mons available, then we can freely pick from all mon IDs that have yet to be featured
+					if (availablemons.Count == 0)
+					{
+						availablemons = uniqueEnemyIDs.Where(NotFeatured).ToList();
+						// and if we simply don't have mons available because they've all been featured, all mons are considered available (this should never execute)
+						if(availablemons.Count == 0)
+						{
+							availablemons = uniqueEnemyIDs.ToList();
+						}
+					}
+					// now we pick one of the availablemons at random as our first mon
+					f.Top = availablemons.PickRandom(rng);
+					f.tileset = enemyTilesets[f.Top]; // and we pick the corresponding tileset
+					// we need to select which zone we are aiming to fill on the B-Side (and if we require a Large-only or Small-only formation to do that, we set the shape of the formation accordingly)
+					List<int> availablezones = enemyZones[f.Top].Where(index => zone[index].Count < zonecountmin[index]).ToList();
+					if (availablezones.Count == 0) // if there are no zones available that haven't reached their mincount, check for maxcount instead
+						availablezones = enemyZones[f.Top].Where(index => zone[index].Count < zonecountmax[index]).ToList();
+					if (availablezones.Count == 0) // and if we've filled mincount and maxcount, just list all available zones
+						availablezones = enemyZones[f.Top].ToList();
+					if(availablezones.Count == 0) // and if by some freak chance the enemy has not been assigned any zones, write an error report to Console and abort Formation shuffle
+					{
+						Console.WriteLine(f.Top);
+						Console.WriteLine(enemyStats[f.Top].exp);
+						Console.WriteLine("This Enemy Has No Zones");
+						return false;
+					}
+					int zoneB = availablezones.PickRandom(rng); // the B-Side zone we are trying to fill
+					int limit = Large(f.Top) ? 2 : 6;
+					if (enemyStats[f.Top].exp * limit < zonexpreqs[zoneB, 1])
+						f.shape = Large(f.Top) ? 0x01 : 0x00;
+					else
+					{
+						if (rng.Between(0, 2) == 0)
+							f.shape = Large(f.Top) ? 0x01 : 0x00;
+						else
+							f.shape = 0x02;
+					}
+					// now we look for what we can pick for the second mon
+					if(f.shape == 0x00)
+					{
+						availablemons = enemiesInTileset[f.tileset].Where(mon => Small(mon) && NotFeatured(mon) && mon != f.Top).ToList();
+						if (availablemons.Count == 0)
+							availablemons = enemiesInTileset[f.tileset].Where(Small).ToList();
+					}
+					else if (f.shape == 0x01)
+					{
+						availablemons = enemiesInTileset[f.tileset].Where(mon => Large(mon) && NotFeatured(mon) && mon != f.Top).ToList();
+						if (availablemons.Count == 0)
+							availablemons = enemiesInTileset[f.tileset].Where(Large).ToList();
+					}
+					else
+					{
+						availablemons = enemiesInTileset[f.tileset].Where(mon => NotFeatured(mon) && mon != f.Top).ToList();
+						if (availablemons.Count == 0)
+							availablemons = enemiesInTileset[f.tileset].ToList(); // if all other mons in this tileset have been featured, all mons in this tileset are eligible as a second mon
+					}
+					f.id[1] = availablemons.PickRandom(rng); // and pick a random mon from the available IDs to be mon 2 (and the primary monster of the A-side)
+					// we will attempt to hit a zone with the A-Side but if we can't we'll just try to make an encounter as close as possible to the goal
+					availablezones = enemyZones[f.id[1]].Where(index => zone[index].Count < zonecountmin[index]).ToList();
+					if (availablezones.Count == 0) // if there are no zones available that haven't reached their mincount, check for maxcount instead
+						availablezones = enemyZones[f.id[1]].Where(index => zone[index].Count < zonecountmax[index]).ToList();
+					if (availablezones.Count == 0) // and if we've filled mincount and maxcount, just list all available zones
+						availablezones = enemyZones[f.id[1]].ToList();
+					if (availablezones.Count == 0) // and if by some freak chance the enemy has not been assigned any zones, write an error report to Console and abort Formation shuffle
+					{
+						Console.WriteLine(f.id[1]);
+						Console.WriteLine(enemyStats[f.id[1]].exp);
+						Console.WriteLine("This Enemy Has No Zones");
+						return false;
+					}
+					int zoneA = availablezones.PickRandom(rng);
+					// now we set the palettes
+					f.pal1 = enemyPalettes[f.Top];
+					if (enemyPalettes[f.Top] != enemyPalettes[f.id[1]])
+						f.pal2 = enemyPalettes[f.id[1]];
+					else // if first and second enemies in the formation have the same palette, draw a second palette at random
+					{
+						List<byte> availablepalettes = palettesInTileset[f.tileset].Where(pal => pal != f.pal1).ToList();
+						if (availablepalettes.Count == 0)
+							f.pal2 = f.pal1; // if there is only one palette in the tileset, just set the second palette to the same value as the first
+						else
+							f.pal2 = availablepalettes.PickRandom(rng);
+					}
+					// and we draw any monsters that conform to both the tileset and palette choices as the third and fourth monsters (if there are more than two, they are dropped after a shuffle of the list)
+					availablemons = enemiesInTileset[f.tileset].Where(mon => mon != f.Top && mon != f.id[1] && (enemyPalettes[mon] == f.pal1 || enemyPalettes[mon] == f.pal2)).ToList();
+					switch (f.shape)
+					{
+						case 0x00:
+							availablemons = availablemons.Where(Small).ToList();
+							break;
+						case 0x01:
+							availablemons = availablemons.Where(Large).ToList();
+							break;
+					}
+					if (availablemons.Count > 0)
+					{
+						availablemons.Shuffle(rng);
+						f.id[2] = availablemons[0];
+						if (availablemons.Count > 1)
+							f.id[3] = availablemons[1];
+					}
+					// now we can decide how many monsters to aim for in the formation.  we call two functions, one to draw the B-side, and another to draw the A-side
+					zoneB = ENF_Picker_BSide(rng, f, zoneB, 0);
+					zoneA = ENF_Picker_ASide(rng, f, zoneA, 1);
+					if(zoneA == -1 || zoneB == -1)
+					{
+						featured[f.Top] = true;
+						featured[f.id[1]] = true;
+						--i;
+						continue; // loop again after setting the problematic monsters to featured status so they are de-prioritized and won't cause an infinite loop problem
+					}
+					// assign the pic and palette bytes to each monster slot
+					ENF_AssignPicAndPaletteBytes(f);
+					// set surprise rate and unrunnability flags
+					f.unrunnable = rng.Between(0, 29) + (zoneA > zoneB ? zoneA : zoneB) >= 32 ? true : false; // unrunnable chance is higher for later zones
+					if (f.unrunnable)
+						f.surprise = 4;
+					else
+					{
+						if(bossformations - surpcount.Sum() <= i)
+						{
+							// automatically roll a surprise chance
+							int s_roll = rng.Between(1, surpcount.Sum());
+							int s_tier = -1;
+							if (s_roll <= surpcount[0])
+								s_tier = 0;
+							else if (s_roll <= surpcount[0] + surpcount[1] && s_roll > surpcount[0])
+								s_tier = 1;
+							else if (s_roll <= surpcount[0] + surpcount[1] + surpcount[2] && s_roll > surpcount[0] + surpcount[1])
+								s_tier = 2;
+							else if (s_roll <= surpcount[0] + surpcount[1] + surpcount[2] + surpcount[3] && s_roll > surpcount[0] + surpcount[1] + surpcount[2])
+								s_tier = 3;
+							if (s_tier == -1)
+							{
+								f.surprise = (byte)rng.Between(3, 9);
+							}
+							else
+							{
+								f.surprise = (byte)rng.Between(surprisetiers[s_tier, 0], surprisetiers[s_tier, 1]);
+								surpcount[s_tier]--;
+							}
+						}
+						else
+						{
+							// random chance to roll additional surprise rate
+							int s_tier = -1;
+							int s_roll = rng.Between(regularformations, bossformations);
+							if (s_roll > bossformations - surp4)
+								s_tier = 3;
+							else if (s_roll > bossformations - surp4 - surp3)
+								s_tier = 2;
+							else if (s_roll > bossformations - surp4 - surp3 - surp2)
+								s_tier = 1;
+							else if (s_roll > bossformations - surp4 - surp3 - surp2 - surp1)
+								s_tier = 0;
+							if (s_tier == -1)
+							{
+								f.surprise = (byte)rng.Between(3, 9);
+							}
+							else
+							{
+								if (surpcount[s_tier] > 0)
 								{
 									f.surprise = (byte)rng.Between(surprisetiers[s_tier, 0], surprisetiers[s_tier, 1]);
 									surpcount[s_tier]--;
 								}
-							}
-							else
-							{
-								// random chance to roll additional surprise rate
-								int s_tier = -1;
-								int s_roll = rng.Between(startingformation, bossformations);
-								if (s_roll > bossformations - surp4)
-									s_tier = 3;
-								else if (s_roll > bossformations - surp4 - surp3)
-									s_tier = 2;
-								else if (s_roll > bossformations - surp4 - surp3 - surp2)
-									s_tier = 1;
-								else if (s_roll > bossformations - surp4 - surp3 - surp2 - surp1)
-									s_tier = 0;
-								if (s_tier == -1)
+								else
 								{
 									f.surprise = (byte)rng.Between(3, 9);
 								}
-								else
+							}
+						}
+					}
+					// add the A-Side and B-Side to their respective zones
+					zone[zoneA].Add(i);
+					zone[zoneB].Add((byte)(i | 0x80));
+					// log and compress this formation
+					LogAndCompressFormation(f, i);
+				}
+				PrintFormationInfo();
+				return true;
+			}
+
+			public int ENF_Picker_BSide(MT19337 rng, Formation f, int zone, int priority)
+			{
+				// draw B-Side formation, prioritizing the priority monster (defaults to f.id[0] if given an invalid priority)
+				if (priority < 0 || priority > 1)
+					priority = 0;
+				if (f.id[priority] == 0xFF)
+					priority = 0;
+				if (f.Top == 0xFF)
+					return -1; // do not draw mons if there is no valid mon as priority
+				f.monMin[priority + 4] = 1; // there will always be at least one mon of the priority
+				f.monMax[priority + 4] = 1;
+				int minXP = enemyStats[f.id[priority]].exp;
+				int maxXP = enemyStats[f.id[priority]].exp;
+				// add to the maxcount for priority until we reach the minimum-maximum for this zone, or we run out of space in this formation to place more
+				int smallLimit = 0, largeLimit = 0;
+				switch(f.shape)
+				{
+					case 0x00:
+						smallLimit = 9;
+						largeLimit = 0;
+						break;
+					case 0x01:
+						smallLimit = 0;
+						largeLimit = 4;
+						break;
+					case 0x02:
+						smallLimit = 6;
+						largeLimit = 2;
+						break;
+				}
+				if (Large(f.id[priority]))
+					largeLimit--;
+				else
+					smallLimit--;
+				while(smallLimit > 0 && largeLimit > 0 && maxXP < zonexpreqs[zone, 1])
+				{
+					f.monMax[priority + 4]++;
+					if (Large(f.id[priority]))
+						largeLimit--;
+					else
+						smallLimit--;
+					maxXP += enemyStats[f.id[priority]].exp;
+					if (maxXP > zonexpreqs[zone, 2])
+					{
+						f.monMax[priority + 4]--;
+						if (Large(f.id[priority]))
+							largeLimit++;
+						else
+							smallLimit++;
+						maxXP -= enemyStats[f.id[priority]].exp;
+						break;
+					}
+				}
+				// now, we can add to the maxcount from either mon until we surpass the max XP for this zone, but monsters that don't contribute enough to zone requirements will not be selected
+				List<int> validindices = new List<int> { priority };
+				for(int i = 0; i < 1; ++i)
+				{
+					if (f.id[i] == 0xFF)
+						continue; // don't include mons with an invalid index
+					int sizeFactor = Large(f.id[i]) ? 6 : 12;
+					if (enemyStats[f.id[i]].exp > zonexpreqs[zone, 2] / sizeFactor)
+						validindices.Add(i); // valid monsters must contribute experience equal to 1/12th of the xp cap for this zone
+				}
+				while((smallLimit > 0 || largeLimit > 0) && validindices.Count > 0 && rng.Between(0, 14) > 0) // there is a 6.66% chance of ending new monster addition every cycle
+				{
+					int index = validindices.PickRandom(rng);
+					if(maxXP + enemyStats[f.id[index]].exp <= zonexpreqs[zone, 2] && ((Large(f.id[index]) && largeLimit > 0) || (Small(f.id[index]) && smallLimit > 0)))
+					{
+						f.monMax[index + 4]++;
+						maxXP += enemyStats[f.id[index]].exp;
+						if (Large(f.id[index]))
+							largeLimit--;
+						else
+							smallLimit--;
+					}
+					else
+					{
+						validindices.Remove(index);
+					}
+				}
+				// now that we have the maximums, we determine the minimums. first, we ensure that we can hit the minimum for this zone
+				validindices = new List<int> { };
+				for (int i = 0; i < 1; ++i)
+				{
+					if (f.monMax[i + 4] > 0)
+						validindices.Add(i); // add any monster that has a maxcount
+				}
+				while (minXP < zonexpreqs[zone, 0] && validindices.Count > 0)
+				{
+					int index = validindices.PickRandom(rng);
+					if (f.monMin[index + 4] < f.monMax[index + 4])
+					{
+						f.monMin[index + 4]++;
+						minXP += enemyStats[f.id[index]].exp;
+					}
+					else
+						validindices.Remove(index);
+				}
+				// set the minimums to a random number between the current minimum and the maximum
+				if (f.monMax[4] > 0)
+					f.monMin[4] = rng.Between(f.monMin[4], f.monMax[4]);
+				if (f.monMax[5] > 0)
+					f.monMin[5] = rng.Between(f.monMin[5], f.monMax[5]);
+				// if we were able to conform to all requirements of the zone, return false, but if we couldn't conform to the zone requirements return true so we know to calc the new zone
+				return ENF_Calc_BSide_Zone(f);
+			}
+
+			public int ENF_Picker_ASide(MT19337 rng, Formation f, int zone, int priority)
+			{
+				// draw A-Side formation, prioritizing the priority monster (defaults to f.id[0] if given an invalid priority)
+				if (priority < 0 || priority > 3)
+					priority = 0;
+				if (f.id[priority] == 0xFF)
+					priority = 0;
+				if (f.Top == 0xFF)
+					return -1; // do not draw mons if there is no valid mon as priority
+				f.monMin[priority] = 1; // there will always be at least one mon of the priority
+				f.monMax[priority] = 1;
+				int minXP = enemyStats[f.id[priority]].exp;
+				int maxXP = enemyStats[f.id[priority]].exp;
+				int smallLimit = 0, largeLimit = 0;
+				switch (f.shape)
+				{
+					case 0x00:
+						smallLimit = 9;
+						largeLimit = 0;
+						break;
+					case 0x01:
+						smallLimit = 0;
+						largeLimit = 4;
+						break;
+					case 0x02:
+						smallLimit = 6;
+						largeLimit = 2;
+						break;
+				}
+				if (Large(f.id[priority]))
+					largeLimit--;
+				else
+					smallLimit--;
+				// unlike the B-Side where we force the priority monster to be placed early, here there is no such requirement.  we just start adding to maxcounts
+				List<int> validindices = new List<int> { }; // no weighting selection towards priority in A-Side
+				List<int> trashindices = new List<int> { }; // list of "trash mons" that may be optionally added in after general mon selection
+				for (int i = 0; i < 3; ++i)
+				{
+					if (f.id[i] == 0xFF)
+						continue; // don't include mons with an invalid index
+					int sizeFactor = Large(f.id[i]) ? 6 : 12;
+					if (enemyStats[f.id[i]].exp > zonexpreqs[zone, 2] / sizeFactor)
+						validindices.Add(i); // valid monsters must contribute experience equal to 1/12th of the xp cap for this zone
+					else if (Small(f.id[i]))
+						trashindices.Add(i);
+				}
+				if(validindices.Count == 0) // if we have no valid indices (possible if some zones), we use the minimum-maximum instead of total max
+				{
+					trashindices.Clear();
+					for (int i = 0; i < 3; ++i)
+					{
+						if (f.id[i] == 0xFF)
+							continue; // don't include mons with an invalid index
+						int sizeFactor = Large(f.id[i]) ? 6 : 12;
+						if (enemyStats[f.id[i]].exp > zonexpreqs[zone, 1] / sizeFactor)
+							validindices.Add(i); // valid monsters must contribute experience equal to 1/12th of the xp cap for this zone
+						else if (Small(f.id[i]))
+							trashindices.Add(i);
+					}
+				}
+				while ((smallLimit > 0 || largeLimit > 0) && validindices.Count > 0)
+				{
+					if (rng.Between(0, 14) == 0 && maxXP > zonexpreqs[zone, 1])
+						break; // 6.66% chance of ending the while loop if we have already met the minimum-maximum
+					int index = validindices.PickRandom(rng);
+					if (maxXP + enemyStats[f.id[index]].exp <= zonexpreqs[zone, 2] && ((Large(f.id[index]) && largeLimit > 0) || (Small(f.id[index]) && smallLimit > 0)))
+					{
+						f.monMax[index]++;
+						maxXP += enemyStats[f.id[index]].exp;
+						if (Large(f.id[index]))
+							largeLimit--;
+						else
+							smallLimit--;
+					}
+					else
+					{
+						validindices.Remove(index);
+					}
+				}
+				// now, hopefully, we got the minimum-maximums we wanted from that.  time to raise minimums
+				validindices = new List<int> { };
+				for (int i = 0; i < 3; ++i)
+				{
+					if (f.id[i] == 0xFF)
+						continue;
+					if (f.monMax[i] > 0)
+						validindices.Add(i); // add any monster that has a maxcount
+				}
+				while (minXP < zonexpreqs[zone, 0] && validindices.Count > 0)
+				{
+					int index = validindices.PickRandom(rng);
+					if (f.monMin[index] < f.monMax[index])
+					{
+						f.monMin[index]++;
+						minXP += enemyStats[f.id[index]].exp;
+					}
+					else
+						validindices.Remove(index);
+				}
+				// set the minimums to a random number between the current minimum and the maximum
+				for(int i = 0; i < 3; ++i)
+				{
+					f.monMin[i] = rng.Between(f.monMin[i], f.monMax[i]);
+				}
+				// if there is space, we can add 1-2 of each trash index (so long as they do not exceed the zone's maximum).  only smalls can be trash mons.
+				if(trashindices.Count > 0 && smallLimit > 0)
+				{
+					for(int i = 0; i < trashindices.Count; ++i)
+					{
+						if(rng.Between(0, 2) == 0) // 33% chance of rejecting a trash index
+						{
+							if(Small(f.id[trashindices[i]]))
+							{
+								if(maxXP + enemyStats[f.id[trashindices[i]]].exp < zonexpreqs[zone, 2])
 								{
-									if (surpcount[s_tier] > 0)
+									smallLimit--;
+									f.monMax[trashindices[i]]++;
+									maxXP += enemyStats[f.id[trashindices[i]]].exp;
+								}
+								if(rng.Between(0, 1) == 0) // 50% chance of adding a second trash mon of the same type
+								{
+									if (maxXP + enemyStats[f.id[trashindices[i]]].exp < zonexpreqs[zone, 2])
 									{
-										f.surprise = (byte)rng.Between(surprisetiers[s_tier, 0], surprisetiers[s_tier, 1]);
-										surpcount[s_tier]--;
-									}
-									else
-									{
-										f.surprise = (byte)rng.Between(3, 9);
+										smallLimit--;
+										f.monMax[trashindices[i]]++;
+										maxXP += enemyStats[f.id[trashindices[i]]].exp;
 									}
 								}
 							}
 						}
-						
-
-						// log the formation we have created and put it in the bank
-						LogAndCompressFormation(f, cur);
-
-						// decrement formations left and loop again
-						cur++;
 					}
 				}
-				PrintFormationInfo();
-				return true; // we have succeeded
+				// if we were able to conform to all requirements of the zone, return false, but if we couldn't conform to the zone requirements return true so we know to calc the new zone
+				return ENF_Calc_ASide_Zone(f);
 			}
 
-			public void ENF_StandardAssignments(Formation f, MT19337 rng)
+			public int ENF_Calc_BSide_Zone(Formation f)
 			{
-				// draw palettes
-				f.pal1 = GetPalette(f.Top);
-				f.pal2 = GetPalette(f.id[1]);
-				if (f.pal2 == f.pal1) // pick a second palette at random if pal2 = pal1 or this palette combo has already been used
+				// calculates a zone for the encounter to fit if we couldn't reach our goal zone (return -1 if the zone is completely invalid)
+				int return_value = -1;
+				List<int> acceptableValues = new List<int> { };
+				int minXP = 0, maxXP = 0;
+				if(f.monMax[4] > 0)
 				{
-					List<byte> legalPalettes = new List<byte> { };
-					foreach (byte pal in palettesInTileset[f.tileset])
-					{
-						if (pal != f.pal1)
-						{
-							legalPalettes.Add(pal);
-						}
-					}
-					if (legalPalettes.Count > 0)
-						f.pal2 = legalPalettes.PickRandom(rng);
+					minXP += f.monMin[4] * enemyStats[f.id[0]].exp;
+					maxXP += f.monMax[4] * enemyStats[f.id[0]].exp;
 				}
-
-				// draw monsters from those which are legal for these conditions
-				List<byte> legalMonsters = new List<byte> { f.Top, f.id[1] };
-				enemiesInTileset[f.tileset].Shuffle(rng);
-				foreach (byte mon in enemiesInTileset[f.tileset])
+				if(f.monMax[5] > 0)
 				{
-					if (mon == f.Top || mon == f.id[1])
+					minXP += f.monMin[5] * enemyStats[f.id[1]].exp;
+					maxXP += f.monMax[5] * enemyStats[f.id[1]].exp;
+				}
+				for(int i = 0; i < zonecountmin.Length; ++i)
+				{
+					if (minXP >= zonexpreqs[i, 0] && maxXP >= zonexpreqs[i, 1] && maxXP <= zonexpreqs[i, 2])
+						acceptableValues.Add(i);
+				}
+				List<int> mincountValues = acceptableValues.Where(id => zone[id].Count < zonecountmin[id]).ToList();
+				if (mincountValues.Count == 0)
+					mincountValues = acceptableValues.Where(id => zone[id].Count < zonecountmax[id]).ToList();
+				if (mincountValues.Count > 0)
+					return_value = mincountValues.Max();
+				else
+				{
+					if(acceptableValues.Count > 0)
+						return_value = acceptableValues.Max();
+				}
+				return return_value;
+			}
+
+			public int ENF_Calc_ASide_Zone(Formation f)
+			{
+				// calculates a zone for the encounter to fit if we couldn't reach our goal zone (return -1 if the zone is completely invalid)
+				int return_value = -1;
+				List<int> acceptableValues = new List<int> { };
+				int minXP = 0, maxXP = 0;
+				for(int i = 0; i < 3; ++i)
+				{
+					if (f.id[i] == 0xFF)
 						continue;
-					if (enemyPalettes[mon] == f.pal1 || enemyPalettes[mon] == f.pal2)
+					if(f.monMax[i] > 0)
 					{
-						legalMonsters.Add(mon);
+						minXP += f.monMin[i] * enemyStats[f.id[i]].exp;
+						maxXP += f.monMax[i] * enemyStats[f.id[i]].exp;
 					}
 				}
-
-				// if there are large or small mons in the list when the first two are larges or smalls, there is a 50% chance that the formation will convert to a 2/6 mixed, otherwise the monster is dropped
-				for (int i = 0; i < 4 && i < legalMonsters.Count; ++i)
+				for (int i = 0; i < zonecountmin.Length; ++i)
 				{
-					if (Large(legalMonsters[i]) && f.shape == 0x01 || Small(legalMonsters[i]) && f.shape == 0x00 || f.shape == 0x02)
-					{
-						f.id[i] = legalMonsters[i];
-					}
+					if (minXP >= zonexpreqs[i, 0] && maxXP >= zonexpreqs[i, 1] && maxXP <= zonexpreqs[i, 2])
+						acceptableValues.Add(i);
 				}
-
-				// set palette and pics bytes, and determine the limits for each monster
-				ENF_AssignPicAndPaletteBytes(f);
+				List<int> mincountValues = acceptableValues.Where(id => zone[id].Count < zonecountmin[id]).ToList();
+				if (mincountValues.Count == 0)
+					mincountValues = acceptableValues.Where(id => zone[id].Count < zonecountmax[id]).ToList();
+				if (mincountValues.Count > 0)
+					return_value = mincountValues.Max();
+				else
+				{
+					if (acceptableValues.Count > 0)
+						return_value = acceptableValues.Max();
+				}
+				return return_value;
 			}
 
 			public void ENF_AssignPicAndPaletteBytes(Formation f)
@@ -692,587 +3547,175 @@ namespace FF1Lib
 				}
 			}
 
-			public int ENF_GetRandomZone(MT19337 rng)
+			public void ENF_DrawForcedSingleFight(MT19337 rng, int zoneB, byte id)
 			{
-				List<int> validzones = new List<int> { };
-				for (int i = 0; i < zonecountmin.Length; ++i)
-				{
-					if (zone[i].Count < zonecountmin[i])
-						validzones.Add(i);
-				}
-				if (validzones.Count == 0)
-					return -2;
-				return validzones.PickRandom(rng);
-			}
-
-			public bool ENF_DrawMons_Zone(MT19337 rng, Formation f, ref int zone1, ref int zone2, ref int picker1, ref int picker2, ref int stage) // draw a monster to fill a zone.
-			{
-				if (stage == 0)
-				{
-					// look up a random zone that has yet to be filled
-					zone1 = ENF_GetRandomZone(rng);
-					if (zone1 == -2)
-					{
-						stage = 1; // we are ready to move to the next stage
-					}
-					else
-					{
-						// pick a monster compatible with the zone
-						List<byte> availablemons = zonemons[zone1].Where(NotFeatured).ToList();
-						if (availablemons.Count == 0)
-							f.Top = zonemons[zone1].PickRandom(rng);
-						else
-							f.Top = availablemons.PickRandom(rng);
-					}
-				}
-				if (stage == 1)
-				{
-					// look up unique enemy ID
-					List<byte> availablemons = uniqueEnemyIDs.Where(NotFeatured).ToList();
-					if (availablemons.Count == 0)
-						stage = 2;
-					else
-					{
-						f.Top = availablemons.PickRandom(rng);
-						zone1 = enemyZones[f.Top].PickRandom(rng);
-					}
-				}
-				if (stage == 2)
-				{
-					// pick a zone freely and a mon to match
-					zone1 = rng.Between(0, zonemons.Length - 1);
-					f.Top = zonemons[zone1].PickRandom(rng);
-				}
-
-				f.tileset = GetTileset(f.Top); // get the tileset for top mon
-				// pick second mon from this tileset
-				enemiesInTileset[f.tileset].Shuffle(rng);
-				foreach (byte mon in enemiesInTileset[f.tileset])
-				{
-					// reject second monster IF:
-					// -second mon is the same as first mon
-					// -second mon has already been paired with first mon
-					if (mon == f.Top)
-						continue;
-					if (enemyPaired[f.Top].Contains(mon))
-						continue;
-					f.id[1] = mon;
-				}
-				if (f.id[1] == 0xFF)
-				{
-					Console.WriteLine("Could not select mon2");
-					return true; // if we could not select a mon, return true to indicate a failure and roll another pair
-				}
-				// set shape according to mons
-				f.shape = Large(f.Top) ? 0x01 : 0x00;
-				if (Large(f.Top) != Large(f.id[1]))
-					f.shape = 0x02;
-				// decide which picker we will use for the first and second formation, and the second formation's zone
-				List<int> validpickers = new List<int> { 0 }; // we will always have the option to do single mon
-				// mixed-group picker - allowed if second monster is the same shape and if tier requirements are maintained (for minimum and maximum) with half the limit for each mon
-				if (Large(f.Top) == Large(f.id[1]))
-				{
-					int limit = GetMonLimit(f.Top, f.shape) / 2;
-					if (enemyXPLUT[f.Top] + enemyXPLUT[f.id[1]] <= zonexpreqs[zone1, 2] && (enemyXPLUT[f.Top] + enemyXPLUT[f.id[1]]) * limit >= zonexpreqs[zone1, 1])
-					{
-						validpickers.Add(1);
-					}
-				}
-				// big-and-small picker - allowed if shape is 2-6 and two large / 6 small can still fit the zone requirements for experience
-				if (f.shape == 0x02)
-				{
-					int limit1 = GetMonLimit(f.Top, f.shape), limit2 = GetMonLimit(f.id[1], f.shape);
-					int modifier1 = Large(f.Top) ? 1 : 2;
-					int modifier2 = Large(f.id[1]) ? 1 : 2;
-					if (enemyXPLUT[f.Top] * modifier1 + enemyXPLUT[f.id[1]] * modifier2 <= zonexpreqs[zone1, 2] && enemyXPLUT[f.Top] * limit1 + enemyXPLUT[f.id[1]] * limit2 >= zonexpreqs[zone1, 1])
-						validpickers.Add(2);
-					else if (enemyXPLUT[f.Top] * limit1 < zonexpreqs[zone1, 1])
-						return true; // don't allow mixed formations if the formation can't reach zone xp minimum requirements with 2-6 mixed and the second monster
-				}
-				picker1 = validpickers.PickRandom(rng);
-				ENF_StandardAssignments(f, rng);
-				// now select a zone and picker for the A-Side
-				validpickers.Clear();
-				validpickers.Add(0);
-				if (Large(f.Top) == Large(f.id[1]))
-					validpickers.Add(1);
-				if (f.shape == 0x02)
-					validpickers.Add(2);
-
-				List<int> validzones = enemyZones[f.id[1]].Where(id => zone[id].Count < zonecountmax[id]).ToList();
-				validzones.Shuffle(rng);
-				for (int i = 0; i < validzones.Count; ++i)
-				{
-					validpickers.Shuffle(rng);
-					for (int j = 0; j < validpickers.Count; ++j)
-					{
-						if ((validpickers[j] == 0 && validzones[i] != zone1) || validpickers[j] != picker1 || validzones[i] != zone1)
-						{
-							picker2 = validpickers[j];
-							zone2 = validzones[i];
-						}
-						if (picker2 != -1)
-							break;
-					}
-					if (zone2 != -1)
-						break;
-				}
-				if (picker2 == -1 || zone2 == -1)
-				{
-					return true;
-				}
-				return false;
-			}
-
-			public bool ENF_ApproveFormation(Formation f, int goalzone1, int goalzone2)
-			{
-				if (f.monMax[0] == 0 && f.monMax[1] == 0 && f.monMax[2] == 0 && f.monMax[3] == 0 || f.monMax[4] == 0 && f.monMax[5] == 0)
-					return false; // do not allow empty formations
-				int minXPB = 0;
-				int minXPA = 0;
-				int maxXPB = 0;
-				int maxXPA = 0;
-				for (int i = 4; i < 6; ++i)
-				{
-					if (f.id[i - 4] != 0xFF)
-					{
-						minXPB += enemyXPLUT[f.id[i - 4]] * f.monMin[i];
- 						maxXPB += enemyXPLUT[f.id[i - 4]] * f.monMax[i];
-					}
-				}
-				for (int i = 0; i < 4; ++i)
-				{
-					if (f.id[i] != 0xFF)
-					{
-						minXPA += enemyXPLUT[f.id[i]] * f.monMin[i];
-						maxXPA += enemyXPLUT[f.id[i]] * f.monMax[i];
-					}
-				}
-				if(goalzone1 != -1 && goalzone2 != -1)
-					if (maxXPB > zonexpreqs[goalzone1, 2] || maxXPA > zonexpreqs[goalzone2, 2] || minXPB < zonexpreqs[goalzone1, 0] || minXPA < zonexpreqs[goalzone2, 0])
-						return false;
-				List<int> newmarker1 = new List<int> { };
-				List<int> newmarker2 = new List<int> { };
-				for(int i = 0; i < 4; ++i)
-				{
-					if (f.id[i] == 0xFF)
-						continue;
-					if(f.monMax[i] > 0)
-					{
-						newmarker1.Add(f.id[i] + f.monMax[i] * 0x100);
-					}
-					if (i < 2)
-					{
-						if (f.monMax[i + 4] > 0)
-						{
-							newmarker2.Add(f.id[i] + f.monMax[i + 4] * 0x100);
-						}
-					}
-				}
-				if (newmarker1.Count == 0 || newmarker2.Count == 0)
-					return false; // do not allow empty formations
-				if(newmarker1.Count == newmarker2.Count)
-				{
-					if (newmarker1.Contains(newmarker2[0]))
-					{
-						if (newmarker2.Count == 1)
-							return false;
-						else if (newmarker1.Contains(newmarker2[1]))
-							return false;
-					}
-				}
-				bool nomatch = true;
-				if (fmarkers.Count == 0)
-				{
-					fmarkers.Add(newmarker1);
-					fmarkers.Add(newmarker2);
-					return nomatch;
-				}
-				if (nomatch)
-				{
-					for (int i = 0; i < fmarkers.Count; ++i)
-					{
-						nomatch = false;
-						for(int j = 0; j < newmarker1.Count; ++j)
-						{
-							if(!fmarkers[i].Contains(newmarker1[j]))
-							{
-								nomatch = true;
-								break;
-							}
-						}
-						if (nomatch)
-						{
-							if(fmarkers[i].Count <= 2)
-							{
-								nomatch = false;
-								for (int j = 0; j < newmarker2.Count; ++j)
-								{
-									if (!fmarkers[i].Contains(newmarker2[j]))
-									{
-										nomatch = true;
-										break;
-									}
-								}
-							}
-						}
-					}
-				}
-				if (nomatch)
-				{
-					fmarkers.Add(newmarker1);
-					fmarkers.Add(newmarker2);
-				}
+				// draws an encounter whose B-Side is always a group of one monster type, pulled from the specified.  it will always produce a fight near the maximum XP for this zone.
+				// the A-Side will be a random assortment of monsters that may or may not include the B-Side monster.  if it is possible to fit the zone requirement in a 2-6 formation, that will always be selected
+				// this formation is always unrunnable (this routine is used for the replacements for the Wizard, Eye, and Zombie Dragon fight replacements)
+				Formation f = new Formation();
+				f.Top = zonemons[zoneB].PickRandom(rng);
+				f.tileset = enemyTilesets[f.Top];
+				int limit = Large(f.Top) ? 2 : 6;
+				if (enemyStats[f.Top].exp * limit < zonexpreqs[zoneB, 2])
+					f.shape = Large(f.Top) ? 0x01 : 0x00;
 				else
+					f.shape = 0x02;
+				f.monMax[4] = zonexpreqs[zoneB, 2] / enemyStats[f.Top].exp;
+				if (f.monMax[4] > GetMonLimit(f.Top, f.shape))
+					f.monMax[4] = GetMonLimit(f.Top, f.shape);
+				f.monMin[4] = zonexpreqs[zoneB, 1] / enemyStats[f.Top].exp;
+				if (f.monMin[4] > f.monMax[4])
+					f.monMin[4] = f.monMax[4];
+				if(f.monMax[4] == 0) // this should never execute but just in case
 				{
-					Console.WriteLine("Formation rejected for duplication");
+					f.monMin[4] = 1;
+					f.monMax[4] = 1;
 				}
-				return nomatch;
+				if (f.monMin[4] == 0)
+					f.monMin[4] = 1;
+				// draw all potential mons for A-Side
+				List<byte> availablemons = enemiesInTileset[f.tileset].Where(mon => mon != f.Top).ToList();
+				switch(f.shape)
+				{
+					case 0x00:
+						availablemons = availablemons.Where(Small).ToList();
+						break;
+					case 0x01:
+						availablemons = availablemons.Where(Large).ToList();
+						break;
+				}
+				f.id[1] = availablemons.PickRandom(rng);
+				f.pal1 = enemyPalettes[f.Top];
+				f.pal2 = enemyPalettes[f.id[1]]; // if these are both the same, i don't really care
+				availablemons = enemiesInTileset[f.tileset].Where(mon => mon != f.Top && mon != f.id[1] && (enemyPalettes[mon] == f.pal1 || enemyPalettes[mon] == f.pal2)).ToList();
+				switch (f.shape)
+				{
+					case 0x00:
+						availablemons = availablemons.Where(Small).ToList();
+						break;
+					case 0x01:
+						availablemons = availablemons.Where(Large).ToList();
+						break;
+				}
+				if (availablemons.Count > 0)
+				{
+					availablemons.Shuffle(rng);
+					f.id[2] = availablemons[0];
+					if (availablemons.Count > 1)
+						f.id[3] = availablemons[1];
+				}
+				int zoneA = enemyZones[f.id[1]].PickRandom(rng); // pick a random zone to aim for from the second mon
+				// now we actually run the generic picker
+				zoneA = ENF_Picker_ASide(rng, f, zoneA, 1);
+				zone[zoneB].Add((byte)(id | 0x80));
+				if (zoneA != -1)
+					zone[zoneA].Add(id); // if for some reason we didn't fill any valid zone from the A-side, we simply don't add it to any zones (and thus it will never be seen)
+				f.surprise = 4;
+				f.unrunnable = true; // these fights are always unrunnable
+				// put on the finishing touches and log and compress this formation
+				ENF_AssignPicAndPaletteBytes(f);
+				LogAndCompressFormation(f, id);
 			}
 
-			public int RollFormation(MT19337 rng, Formation f, ref int zone1, ref int zone2, ref int picker1, ref int picker2, ref int stage)
+			public void ENF_DrawBossEncounter(MT19337 rng, int bossmonster, int quantity, byte shape, bool unrunnable, byte surpriserate, byte id)
 			{
-				bool failure = false;
-				switch (picker1) // B-Side is created first
+				// draws a boss encounter on the A side, with the specified monster, quantity thereof, and shape on the A-Side, and information about runnability (true for most, but false for warmech) / surprise rate
+				// the B-Side will feature one or two monsters from the same tileset that are compatible with the boss' palette and another palette chosen at random
+				// the B-Side will be available as a random encounter.
+				Formation f = new Formation();
+				f.id[2] = (byte)bossmonster; // we place the boss monster in the third slot
+				f.tileset = enemyTilesets[f.id[2]];
+				f.pal1 = enemyPalettes[f.id[2]];
+				f.shape = shape;
+				f.monMin[2] = quantity;
+				f.monMax[2] = quantity; // always produce the necessary number of enemies
+				// draw mons for B-Side
+				List<byte> availablemons = enemiesInTileset[f.tileset].ToList();
+				switch (f.shape)
 				{
-					case 0:
-						failure = ENF_SingleMon(rng, f, ref zone1, 0, true);
+					case 0x00:
+						availablemons = availablemons.Where(Small).ToList();
 						break;
-					case 1:
-						failure = ENF_MixedTwo(rng, f, ref zone1, true);
-						break;
-					case 2:
-						failure = ENF_BigAndSmall(rng, f, ref zone2, true);
-						break;
-					case 3:
+					case 0x01:
+						availablemons = availablemons.Where(Large).ToList();
 						break;
 				}
-				switch (picker2) // then A-Side is created
+				if(availablemons.Count > 0)
 				{
-					case 0:
-						failure = ENF_SingleMon(rng, f, ref zone2, 1, false);
-						break;
-					case 1:
-						failure = ENF_MixedTwo(rng, f, ref zone2, false);
-						break;
-					case 2:
-						failure = ENF_BigAndSmall(rng, f, ref zone2, false);
-						break;
-					case 3:
-						break;
-				}
-				return 0;
-			}
-
-			public bool ENF_SingleMon(MT19337 rng, Formation f, ref int tier, int p, bool sideB)
-			{
-				int o = sideB ? 4 : 0; // set offset so we increase the monmax of 4-5 if we are rolling for B-Side formations
-				int limit = GetMonLimit(f.id[p], f.shape);
-				int maxXPgoal = rng.Between(zonexpreqs[tier, 1], zonexpreqs[tier, 2]);
-				f.monMax[p + o] = maxXPgoal / enemyXPLUT[f.id[p]];
-				if (f.monMax[p + o] < 1)
-					f.monMax[p + o] = 1;
-				if (f.monMax[p + o] > limit)
-					f.monMax[p + o] = limit;
-				f.monMin[p + o] = zonexpreqs[tier, 0] / enemyXPLUT[f.id[p]] + 1;
-				if (f.monMin[p + o] * 3 < f.monMax[p + o])
-					f.monMin[p + o] = f.monMax[p + o] / 3 + 1;
-				if (f.monMin[p + o] > f.monMax[p + o])
-					f.monMin[p + o] = f.monMax[p + o];
-				return false;
-			}
-
-			public bool ENF_MixedTwo(MT19337 rng, Formation f, ref int tier, bool sideB)
-			{
-				int o = sideB ? 4 : 0; // set offset so we increase the monmax of 4-5 if we are rolling for B-Side formations
-				int limit = GetMonLimit(f.Top, f.shape);
-				int modifier = Large(f.Top) ? 1 : 2;
-				int maxXPgoal = rng.Between(zonexpreqs[tier, 1], zonexpreqs[tier, 2]);
-				f.monMax[o] = modifier;
-				f.monMin[o] = modifier;
-				f.monMax[o + 1] = modifier;
-				f.monMin[o + 1] = modifier;
-				int moncount = modifier * 2;
-				int maxxp = modifier * (enemyXPLUT[f.Top] + enemyXPLUT[f.id[1]]);
-				List<int> validIDs = new List<int> { 0, 1 };
-				if(!sideB && rng.Between(0,2) > 0)
-				{
-					if (f.id[2] != 0xFF)
-						if(Large(f.id[2]) == Large(f.Top))
-							validIDs.Add(2);
-					if (f.id[3] != 0xFF)
-						if(Large(f.id[3]) == Large(f.Top))
-							validIDs.Add(3);
-				}
-				while (maxxp < maxXPgoal && moncount < limit && validIDs.Count > 0)
-				{
-					int p = validIDs.PickRandom(rng);
-					if (maxxp + enemyXPLUT[f.id[p]] <= zonexpreqs[tier, 2])
+					f.Top = availablemons.PickRandom(rng);
+					f.pal2 = enemyPalettes[f.Top];
+					availablemons = availablemons.Where(mon => mon != f.Top && mon != f.id[2] && (enemyPalettes[mon] == f.pal1 || enemyPalettes[mon] == f.pal2)).ToList();
+					if (availablemons.Count > 0)
 					{
-						f.monMax[p + o]++;
-						maxxp += enemyXPLUT[f.id[p]];
-						moncount++;
-						if (maxxp < zonexpreqs[tier, 0])
-							f.monMin[p + o]++;
+						f.id[1] = availablemons.PickRandom(rng);
 					}
-					else
-					{
-						validIDs.Remove(p);
-					}
-				}
-				if (f.monMin[o] * 3 < f.monMax[o])
-					f.monMin[o] = f.monMax[o] / 3 + 1;
-				if (f.monMin[o] > f.monMax[o])
-					f.monMin[o] = f.monMax[o];
-				if (f.monMin[o + 1] * 3 < f.monMax[o + 1])
-					f.monMin[o + 1] = f.monMax[o + 1] / 3 + 1;
-				if (f.monMin[o + 1] > f.monMax[o + 1])
-					f.monMin[o + 1] = f.monMax[o + 1];
-				return false;
+					int zoneB = enemyZones[f.Top].PickRandom(rng);
+					zoneB = ENF_Picker_BSide(rng, f, zoneB, 0);
+					if (zoneB != -1)
+						zone[zoneB].Add((byte)(id | 0x80)); // if for some reason we didn't fill any valid zone from the B-side, we simply don't add it to any zones (and thus it will never be seen)
+				}			
+				// if for some reason there were no available mons, then a B-Side is not drawn at all and no formation is added to the zones, so this slot will remain unused.  this shouldn't happen, though
+				ENF_AssignPicAndPaletteBytes(f);
+				LogAndCompressFormation(f, id);
 			}
 
-			public bool ENF_PartyMix(MT19337 rng, Formation f, ref int tier)
+			public void ENF_DrawBumFight(MT19337 rng, byte id)
 			{
-				return false;
-			}
-
-			public bool ENF_BigAndSmall(MT19337 rng, Formation f, ref int tier, bool sideB)
-			{
-				int o = sideB ? 4 : 0; // set offset so we increase the monmax of 4-5 if we are rolling for B-Side formations
-				int maxXPgoal = rng.Between(zonexpreqs[tier, 1], zonexpreqs[tier, 2]);
-				int limit1 = GetMonLimit(f.Top, f.shape);
-				int limit2 = GetMonLimit(f.id[1], f.shape);
-				int mod1 = Large(f.Top) ? 1 : 2;
-				int mod2 = Large(f.id[1]) ? 1 : 2;
-				f.monMax[o] = mod1;
-				f.monMin[o] = mod1;
-				f.monMax[o + 1] = mod2;
-				f.monMin[o + 1] = mod2;
-				int smalllimit = 4;
-				int largelimit = 1;
-				int maxxp = f.monMax[o] * mod1 + f.monMax[o + 1] * mod2;
-				List<int> validIDs = new List<int> { 0, 1 };
-				if (!sideB && rng.Between(0, 1) > 0)
+				// draws the bum fight around Coneria Castle.  this will always be 3-4 weak noodle enemies (default IMPs) that are placed on the B-Side.  the A-side will be a generic battle which may or may not
+				// include more bums
+				Formation f = new Formation();
+				f.Top = Enemy.Imp;
+				f.tileset = enemyTilesets[f.Top];
+				f.shape = Large(f.Top) ? 0x01 : 0x00;
+				f.pal1 = enemyPalettes[f.Top];
+				f.monMin[4] = 3;
+				f.monMax[4] = 4;
+				// draw mons for A-Side
+				List<byte> availablemons = enemiesInTileset[f.tileset].Where(mon => mon != f.Top && enemyPalettes[mon] != f.pal1).ToList();
+				switch (f.shape)
 				{
-					if (f.id[2] != 0xFF)
-						validIDs.Add(2);
-					if (f.id[3] != 0xFF)
-						validIDs.Add(3);
-				}
-				while (maxxp < maxXPgoal)
-				{
-					int p = validIDs.PickRandom(rng);
-					if (maxxp + enemyXPLUT[f.id[p]] <= zonexpreqs[tier, 2])
-					{
-						if ((Large(f.id[p]) && largelimit > 0) || (Small(f.id[p]) && smalllimit > 0))
-						{
-							f.monMax[p + o]++;
-							maxxp += enemyXPLUT[f.id[p]];
-							if (maxxp < zonexpreqs[tier, 0])
-								f.monMin[p + o]++;
-							if (Large(f.id[p]))
-								largelimit--;
-							else
-								smalllimit--;
-						}
-						else
-							validIDs.Remove(p);
-					}
-					else
-					{
-						validIDs.Remove(p);
-					}
-					if (validIDs.Count == 0)
+					case 0x00:
+						availablemons = availablemons.Where(Small).ToList();
 						break;
-					if (smalllimit + largelimit == 0)
+					case 0x01:
+						availablemons = availablemons.Where(Large).ToList();
 						break;
 				}
-				if (f.monMin[o] * 3 < f.monMax[o])
-					f.monMin[o] = f.monMax[o] / 3 + 1;
-				if (f.monMin[o] > f.monMax[o])
-					f.monMin[o] = f.monMax[o];
-				if (f.monMin[o + 1] * 3 < f.monMax[o + 1])
-					f.monMin[o + 1] = f.monMax[o + 1] / 3 + 1;
-				if (f.monMin[o + 1] > f.monMax[o + 1])
-					f.monMin[o + 1] = f.monMax[o + 1];
-				return false;
+				f.id[1] = availablemons.PickRandom(rng);
+				f.pal2 = enemyPalettes[f.id[1]];
+				availablemons = enemiesInTileset[f.tileset].Where(mon => mon != f.Top && mon != f.id[1] && (enemyPalettes[mon] == f.pal1 || enemyPalettes[mon] == f.pal2)).ToList();
+				switch (f.shape)
+				{
+					case 0x00:
+						availablemons = availablemons.Where(Small).ToList();
+						break;
+					case 0x01:
+						availablemons = availablemons.Where(Large).ToList();
+						break;
+				}
+				if (availablemons.Count > 0)
+				{
+					availablemons.Shuffle(rng);
+					f.id[2] = availablemons[0];
+					if (availablemons.Count > 1)
+						f.id[3] = availablemons[1];
+				}
+				int zoneA = enemyZones[f.id[1]].PickRandom(rng);
+				zoneA = ENF_Picker_ASide(rng, f, zoneA, 1);
+				if (zoneA != -1)
+					zone[zoneA].Add(id); // if for some reason we didn't fill any valid zone from the A-side, we simply don't add it to any zones (and thus it will never be seen)
+				// if for some reason there were no available mons to draw, we don't draw an A-Side and it will never be added to a zone, thus it will never be used
+				ENF_AssignPicAndPaletteBytes(f);
+				LogAndCompressFormation(f, id);
 			}
 
-			public void ENF_Imps(MT19337 rng)
+			public byte ENF_PickAVamp(MT19337 rng)
 			{
-				Formation f = new Formation();
-				f.shape = 0x00;
-				f.tileset = 0x00;
-				f.pal1 = 0x00;
-				f.pal2 = 0x01;
-				f.id[0] = 0x00;
-				f.id[1] = 0x01;
-				f.id[2] = 0x02;
-				ENF_AssignPicAndPaletteBytes(f);
-				f.monMin[0] = 1;
-				f.monMax[0] = 2;
-				f.monMin[1] = 2;
-				f.monMax[1] = 4;
-				f.monMin[2] = 2;
-				f.monMax[2] = 3;
-				f.monMax[4] = rng.Between(4, 6);
-				f.monMin[4] = rng.Between(3, 4);
-				f.surprise = 4;
-				f.unrunnable = false;
-				LogAndCompressFormation(f, 0x00);
-				ENF_ApproveFormation(f, -1, -1);
-				zone[0].Add(0x00);
-			}
-
-			public void ENF_Wizards(MT19337 rng)
-			{
-				Formation f = new Formation();
-				f.shape = 0x00;
-				f.tileset = 0x0B;
-				f.pal1 = 0x32;
-				f.pal2 = 0x33;
-				f.id[0] = 0x67;
-				f.id[1] = 0x68;
-				ENF_AssignPicAndPaletteBytes(f);
-				f.monMin[0] = 2;
-				f.monMax[0] = 4;
-				f.monMax[5] = rng.Between(6, 9);
-				f.monMin[5] = rng.Between(3, 5);
-				f.surprise = 4;
-				f.unrunnable = true;
-				LogAndCompressFormation(f, 0x01);
-				ENF_ApproveFormation(f, -1, -1);
-				zone[3].Add(0x01);
-				zone[6].Add(0x81);
-			}
-
-			public void ENF_Phantom(MT19337 rng)
-			{
-				Formation f = new Formation();
-				f.shape = 0x02;
-				f.tileset = 0x04;
-				f.pal1 = 0x16;
-				f.pal2 = 0x07;
-				f.id[0] = 0x33;
-				f.id[1] = 0x2A;
-				ENF_AssignPicAndPaletteBytes(f);
-				f.monMin[0] = 1;
-				f.monMax[0] = 1;
-				f.monMax[5] = 5;
-				f.monMin[5] = 2;
-				f.surprise = 4;
-				f.unrunnable = true;
-				LogAndCompressFormation(f, 0x03);
-				ENF_ApproveFormation(f, -1, -1);
-				zone[8].Add(0x83);
-			}
-
-			public void ENF_Eye(MT19337 rng)
-			{
-				Formation f = new Formation();
-				f.shape = 0x01;
-				f.tileset = 0x04;
-				f.pal1 = 0x17;
-				f.pal2 = 0x17;
-				f.id[0] = 0x32;
-				ENF_AssignPicAndPaletteBytes(f);
-				f.monMin[0] = 1;
-				f.monMax[0] = 1;
-				f.monMin[4] = 2;
-				f.monMax[4] = 3;
-				f.surprise = 4;
-				f.unrunnable = true;
-				LogAndCompressFormation(f, 0x02);
-				ENF_ApproveFormation(f, -1, -1);
-				zone[8].Add(0x02);
-				zone[9].Add(0x82);
-			}
-
-			public void ENF_VampireZombieD(MT19337 rng)
-			{
-				Formation f = new Formation();
-				f.shape = 0x02;
-				f.tileset = 0x06;
-				f.pal1 = 0x1F;
-				f.pal2 = 0x16;
-				f.id[0] = 0x3C;
-				f.id[1] = 0x44;
-				ENF_AssignPicAndPaletteBytes(f);
-				f.monMin[0] = 1;
-				f.monMax[0] = 1;
-				f.monMin[5] = 1;
-				f.monMax[5] = 2;
-				f.surprise = 4;
-				f.unrunnable = true;
-				LogAndCompressFormation(f, 0x7C);
-				ENF_ApproveFormation(f, -1, -1);
-				zone[6].Add(0xFC);
-			}
-
-			public void ENF_Warmech(MT19337 rng)
-			{
-				Formation f = new Formation();
-				f.shape = 0x02;
-				f.tileset = 0x0C;
-				f.pal1 = 0x2F;
-				f.pal2 = 0x2E;
-				f.id[0] = 0x76;
-				f.id[1] = 0x73;
-				ENF_AssignPicAndPaletteBytes(f);
-				f.monMin[0] = 1;
-				f.monMax[0] = 1;
-				f.monMax[5] = 2;
-				f.monMin[5] = 1;
-				f.surprise = 75;
-				f.unrunnable = false;
-				LogAndCompressFormation(f, 0x56);
-				ENF_ApproveFormation(f, -1, -1);
-				zone[9].Add(0xD6);
-			}
-
-			public void ENF_Pirates(MT19337 rng)
-			{
-				Formation f = new Formation();
-				f.shape = 0x00;
-				f.tileset = 0x01;
-				f.pal1 = 0x08;
-				f.pal2 = 0x0B;
-				f.id[0] = 0x0D;
-				f.id[1] = 0x0E;
-				f.id[2] = 0x0F;
-				ENF_AssignPicAndPaletteBytes(f);
-				f.monMin[2] = 9;
-				f.monMax[2] = 9;
-				f.monMin[4] = 1;
-				f.monMax[4] = 2;
-				f.monMax[5] = 8;
-				f.monMin[5] = 8;
-				f.surprise = 4;
-				f.unrunnable = true;
-				LogAndCompressFormation(f, 0x7E);
-				ENF_ApproveFormation(f, -1, -1);
-				zone[8].Add(0xFE);
-			}
-
-			public void ENF_Garland(MT19337 rng)
-			{
-				Formation f = new Formation();
-				f.shape = 0x02;
-				f.tileset = 0x0B;
-				f.pal1 = 0x13;
-				f.pal2 = 0x2E;
-				f.id[0] = 0x69;
-				f.id[1] = 0x6E;
-				ENF_AssignPicAndPaletteBytes(f);
-				f.monMin[0] = 1;
-				f.monMax[0] = 1;
-				f.monMax[5] = 1;
-				f.monMin[5] = 2;
-				f.surprise = 4;
-				f.unrunnable = true;
-				LogAndCompressFormation(f, 0x7F);
-				ENF_ApproveFormation(f, -1, -1);
-				zone[10].Add(0xFF);
+				// picks a random vampire for the Earth Cave fight.  priority is given to vampires that give out less than 3000 experience points, then to any monster under 3000 experience points
+				List<byte> vamps = uniqueEnemyIDs.Where(mon => enemyImage[mon] == 24 && enemyStats[mon].exp <= 3000).ToList();
+				if (vamps.Count == 0)
+					vamps = uniqueEnemyIDs.Where(mon => enemyStats[mon].exp <= 3000).ToList();
+				return vamps.PickRandom(rng);
 			}
 
 			public void DoDomains(MT19337 rng)
@@ -1325,7 +3768,7 @@ namespace FF1Lib
 				traptile_formations[(int)TrapTiles.TRAP_MUMMIES] = zone[3][1];
 				traptile_formations[(int)TrapTiles.TRAP_MUDGOLS] = zone[6][0];
 				traptile_formations[(int)TrapTiles.TRAP_NITEMARES] = zone[6][1];
-				traptile_formations[(int)TrapTiles.TRAP_ZOMBIE_D] = 0xFC;
+				traptile_formations[(int)TrapTiles.TRAP_ZOMBIE_D] = zombieD_encounter;
 				traptile_formations[(int)TrapTiles.TRAP_GARGOYLES] = zone[2][0];
 				traptile_formations[(int)TrapTiles.TRAP_SEAFOOD_PARTY_MIX] = zone[8][0];
 				traptile_formations[(int)TrapTiles.TRAP_SHARKNADO] = zone[8][1];
@@ -1347,14 +3790,14 @@ namespace FF1Lib
 				traptile_formations[(int)TrapTiles.TRAP_FROSTGIANT] = zone[5][7];
 				traptile_formations[(int)TrapTiles.TRAP_MAGES] = zone[5][8];
 				traptile_formations[(int)TrapTiles.TRAP_FROST_D] = zone[5][9];
-				traptile_formations[(int)TrapTiles.TRAP_EYE] = 0x02;
+				traptile_formations[(int)TrapTiles.TRAP_EYE] = eye_encounter;
 				traptile_formations[(int)TrapTiles.TRAP_WATERFALL_MUMMIES] = zone[8][3];
-				traptile_formations[(int)TrapTiles.TRAP_WIZARDS] = 0x01;
-				traptile_formations[(int)TrapTiles.TRAP_WIZARDS2] = 0x01;
+				traptile_formations[(int)TrapTiles.TRAP_WIZARDS] = wizard_encounter;
+				traptile_formations[(int)TrapTiles.TRAP_WIZARDS2] = wizard_encounter;
 				traptile_formations[(int)TrapTiles.TRAP_COBRAS] = zone[3][2];
 				traptile_formations[(int)TrapTiles.TRAP_BLUE_D] = zone[9][0];
 				traptile_formations[(int)TrapTiles.TRAP_SLIMES] = zone[9][1];
-				traptile_formations[(int)TrapTiles.TRAP_PHANTOM] = 0x03;
+				traptile_formations[(int)TrapTiles.TRAP_PHANTOM] = phantom_encounter;
 				// proceed to place mons in all zones
 				zone[2].Shuffle(rng); // re-shuffling zone lists
 				zone[3].Shuffle(rng);
@@ -1432,7 +3875,7 @@ namespace FF1Lib
 					}
 				}
 				// special zone placement for overworld 4,4 and 4,5: replace the first four encounters with encounter 0x80 (imp group)
-				PutD(0x120, 0x80); PutD(0x121, 0x80); PutD(0x122, 0x80); PutD(0x123, 0x80); PutD(0x160, 0x80); PutD(0x161, 0x80); PutD(0x162, 0x80); PutD(0x163, 0x80);
+				PutD(0x120, 0x80); PutD(0x121, imp_encounter); PutD(0x122, imp_encounter); PutD(0x123, imp_encounter); PutD(0x160, imp_encounter); PutD(0x161, imp_encounter); PutD(0x162, imp_encounter); PutD(0x163, imp_encounter);
 				PutD(0x39E, 0x56); // replace 7th encounter on sky 5F with warmech
 			}
 		}
@@ -1443,16 +3886,32 @@ namespace FF1Lib
 			// load vanilla values from ROM into the enemizer
 			en.PutAllFormationData(Get(FormationDataOffset, FormationDataSize * FormationDataCount));
 			en.PutAllDomainData(Get(ZoneFormationsOffset, ZoneFormationsSize * ZoneCount));
+			for(int i = 0; i < MagicCount; ++i)
+			{
+				byte[] spellInfo = Get(MagicOffset + i * MagicSize, MagicSize);
+				en.ReadSpellDataFromMagicBytes(en.decompressSpellData(spellInfo), i);
+			}
 			for (int i = 0; i < EnemyCount; ++i)
 			{
-				var jumbledXP = Get(EnemyOffset + i * EnemySize, 2);
-				en.enemyXPLUT[i] = jumbledXP[1] * 256 + jumbledXP[0];
+				byte[] enemyInfo = Get(EnemyOffset + i * EnemySize, EnemySize);
+				en.ReadEnemyDataFromEnemies(en.decompressEnemyData(enemyInfo), i);
+			}
+			en.enemyNames = ReadText(EnemyTextPointerOffset, EnemyTextPointerBase, EnemyCount); // load all the enemy names into the array for use by enemizer
+			for(int i = 0; i < EnemyCount; ++i) // we want to know how many characters are in enemy names so we don't make random names that are too long for the ROM to hold
+			{
+				en.numEnemyNameCharacters += en.enemyNames[i].Length;
+			}
+			for (int i = 0; i < ScriptCount; ++i)
+			{
+				byte[] scriptInfo = Get(ScriptOffset + i * ScriptSize, ScriptSize);
+				en.ReadScriptDataFromScript(en.decompressEnemyScript(scriptInfo), i);
 			}
 			for (int i = 0; i < FormationCount; ++i)
 			{
-				byte[] formationData = Get(FormationDataOffset + FormationDataSize * i, 16).ToBytes();
-				en.ReadEnemyDataFromFormation(en.decompressFormation(formationData)); // read information about enemies from the ROM
+				byte[] formationData = Get(FormationDataOffset + FormationDataSize * i, FormationDataSize).ToBytes();
+				en.ReadEnemyDataFromFormation(en.decompressFormation(formationData), i); // read information about enemy formations from the ROM
 			}
+			en.PurgeIDFromEnemyTilesetList(Enemy.Imp);
 			en.PurgeIDFromEnemyTilesetList(Enemy.Pirate);
 			en.PurgeIDFromEnemyTilesetList(Enemy.Phantom);
 			en.PurgeIDFromEnemyTilesetList(Enemy.Astos);
@@ -1461,11 +3920,37 @@ namespace FF1Lib
 			if (enemies)
 			{
 				// do enemizer stuff
-				formations = true; // must use formation generator with enemizer
+				if(en.DoEnemies(rng))
+				{
+					formations = true; // must use formation generator with enemizer
+					for(int i = 0; i < EnemyCount; ++i)
+					{
+						Put(EnemyOffset + EnemySize * i, en.enemyStats[i].CompressData()); // move every entry from the enemizer to the ROM
+					}
+					for(int i = 0; i < ScriptCount; ++i)
+					{
+						Put(ScriptOffset + ScriptSize * i, en.enemyScripts[i].compressData()); // and move the modified scripts as well
+					}
+					var enemyTextPart1 = en.enemyNames.Take(2).ToArray();
+					var enemyTextPart2 = en.enemyNames.Skip(2).ToArray();
+					WriteText(enemyTextPart1, EnemyTextPointerOffset, EnemyTextPointerBase, 0x2CFEC);
+					WriteText(enemyTextPart2, EnemyTextPointerOffset + 4, EnemyTextPointerBase, EnemyTextOffset);
+					en.PurgeIDFromEnemyTilesetList(Enemy.Imp);
+					en.PurgeIDFromEnemyTilesetList(Enemy.Pirate);
+					en.PurgeIDFromEnemyTilesetList(Enemy.Phantom);
+					en.PurgeIDFromEnemyTilesetList(Enemy.Astos);
+					en.PurgeIDFromEnemyTilesetList(Enemy.Garland);
+					en.PurgeIDFromEnemyTilesetList(Enemy.WarMech); // making doubleplus sure these don't appear, probably not necessary
+				}
+				else
+				{
+					Console.WriteLine("Fission Mailed - Abort Enemy Shuffle");
+					throw new InsaneException("Something went wrong with Enemy Generation (Enemizer)!");
+				}
 			}
 			if(formations)
 			{
-				if(en.DoFormations(rng))
+				if(en.DoFormations(rng, enemies))
 				{
 					battledomains = true; // must use domain generator with formation shuffle
 					Put(FormationsOffset, en.GetFormationData());
@@ -1474,6 +3959,7 @@ namespace FF1Lib
 				else
 				{
 					Console.WriteLine("Fission Mailed - Abort Formation Shuffle");
+					throw new InsaneException("Something went wrong with Formation Generation (Enemizer)!");
 				}
 			}
 			if (battledomains)
@@ -1483,7 +3969,6 @@ namespace FF1Lib
 
 				bool IsBattleTile(Blob tuple) => tuple[0] == 0x0A;
 				bool IsRandomBattleTile(Blob tuple) => IsBattleTile(tuple) && (tuple[1] & 0x80) != 0x00;
-				// bool IsNonBossTrapTile(Blob tuple) => IsBattleTile(tuple) && tuple[1] > 0 && tuple[1] < FirstBossEncounterIndex;
 
 				var tilesets = Get(TilesetDataOffset, TilesetDataCount * TilesetDataSize * TilesetCount).Chunk(TilesetDataSize).ToList();
 				tilesets.ForEach(tile => { if (IsRandomBattleTile(tile)) tile[1] = 0x00; });

--- a/FF1Lib/Enemizer.cs
+++ b/FF1Lib/Enemizer.cs
@@ -3953,6 +3953,8 @@ namespace FF1Lib
 				if(en.DoFormations(rng, enemies))
 				{
 					Put(FormationsOffset, en.GetFormationData());
+					if(en.imp_encounter != 0x80)
+						throw new InsaneException(en.imp_encounter.ToString());
 					// we must also do the domains
 					// This code is partially lifted from ShuffleTrapTiles
 					Data[0x7CDC5] = 0xD0; // changes the game's programming

--- a/FF1Lib/Enemizer.cs
+++ b/FF1Lib/Enemizer.cs
@@ -3656,6 +3656,8 @@ namespace FF1Lib
 				}			
 				// if for some reason there were no available mons, then a B-Side is not drawn at all and no formation is added to the zones, so this slot will remain unused.  this shouldn't happen, though
 				ENF_AssignPicAndPaletteBytes(f);
+				f.unrunnable = true;
+				f.surprise = 4;
 				LogAndCompressFormation(f, id);
 			}
 

--- a/FF1Lib/Enemizer.cs
+++ b/FF1Lib/Enemizer.cs
@@ -11,320 +11,411 @@ namespace FF1Lib
 	{
 		public const int GenericTilesetsCount = 13;
 		public const int EnemySkillCount = 26;
-		public const int EnemySkillSize = 5;
+		public const int EnemySkillSize = 8; // even though the actual information is only five bytes, each entry in the game ROM uses three extra bytes that are all 00
 		public const int EnemySkillOffset = 0x303F0;
 
-		public class Enemizer
+		enum MonsterPerks
 		{
-			enum MonsterPerks
-			{
-				PERK_GAINSTAT10, // increases a minor stat by 10%, +2% XP
-				PERK_LOSESTAT10, // reduces a minor stat by 10%, -2% XP
-				PERK_LOWRESIST, // adds a low resist (fire/ice/lit/earth), +4% XP
-				PERK_HIGHRESIST, // adds a high resist (status/poison/time/death), +3% XP
-				PERK_LOWWEAKNESS, // adds a low weakness, -5% XP
-				PERK_HIGHWEAKNESS, // adds a high weakness, -3% XP 
-				PERK_PLUSONEHIT, // adds an extra hit, +5% XP for 2hitter, +3% for 3hitter, +2% for 4hitter and +1% for any hits beyond that
-				PERK_POISONTOUCH, // adds poisontouch if no status ailment already exists
-				PERK_STUNSLEEPTOUCH, // adds stun or sleep touch, +3% XP if stun touch is selected
-				PERK_MUTETOUCH, // adds mute touch, +2% XP
-				NUM_PERKS // total number of perks that are available for seletion
-			};
+			PERK_GAINSTAT10, // increases a minor stat by 10%, +2% XP
+			PERK_LOSESTAT10, // reduces a minor stat by 10%, -2% XP
+			PERK_LOWRESIST, // adds a low resist (fire/ice/lit/earth), +4% XP
+			PERK_HIGHRESIST, // adds a high resist (status/poison/time/death), +3% XP
+			PERK_LOWWEAKNESS, // adds a low weakness, -5% XP
+			PERK_HIGHWEAKNESS, // adds a high weakness, -3% XP 
+			PERK_PLUSONEHIT, // adds an extra hit, +5% XP for 2hitter, +3% for 3hitter, +2% for 4hitter and +1% for any hits beyond that
+			PERK_POISONTOUCH, // adds poisontouch if no status ailment already exists
+			PERK_STUNSLEEPTOUCH, // adds stun or sleep touch, +3% XP if stun touch is selected
+			PERK_MUTETOUCH, // adds mute touch, +2% XP
+			NUM_PERKS // total number of perks that are available for seletion
+		};
 
-			enum TrapTiles
+		enum TrapTiles
+		{
+			TRAP_IMAGES,
+			TRAP_MUMMIES,
+			TRAP_MUDGOLS,
+			TRAP_NITEMARES,
+			TRAP_ZOMBIE_D,
+			TRAP_GARGOYLES,
+			TRAP_SEAFOOD_PARTY_MIX,
+			TRAP_SHARKNADO,
+			TRAP_WATERS,
+			TRAP_SEASHRINE_MUMMIES,
+			TRAP_ZOMBIES,
+			TRAP_GARGOYLES2,
+			TRAP_GIANTS,
+			TRAP_GIANTS_IGUANAS,
+			TRAP_EARTH,
+			TRAP_OGRES_HYENAS,
+			TRAP_SPHINX,
+			TRAP_FIRE,
+			TRAP_GREYWORM,
+			TRAP_AGAMA,
+			TRAP_RED_D,
+			TRAP_UNDEAD_PARTYMIX,
+			TRAP_FROSTRURUS,
+			TRAP_FROSTGIANT,
+			TRAP_MAGES,
+			TRAP_FROST_D,
+			TRAP_EYE,
+			TRAP_WATERFALL_MUMMIES,
+			TRAP_WIZARDS,
+			TRAP_WIZARDS2,
+			TRAP_COBRAS,
+			TRAP_BLUE_D,
+			TRAP_SLIMES,
+			TRAP_PHANTOM,
+			TRAP_LICH2,
+			TRAP_KARY2,
+			TRAP_KRAKEN2,
+			TRAP_TIAMAT2,
+			NUM_TRAP_TILES
+		};
+
+		public class SpellInfo
+		{
+			public byte accuracy;
+			public byte effect;
+			public byte elem;
+			public byte targeting;
+			public byte routine;
+			public byte gfx;
+			public byte palette;
+			public int tier;
+
+			public byte[] compressData()
 			{
-				TRAP_IMAGES,
-				TRAP_MUMMIES,
-				TRAP_MUDGOLS,
-				TRAP_NITEMARES,
-				TRAP_ZOMBIE_D,
-				TRAP_GARGOYLES,
-				TRAP_SEAFOOD_PARTY_MIX,
-				TRAP_SHARKNADO,
-				TRAP_WATERS,
-				TRAP_SEASHRINE_MUMMIES,
-				TRAP_ZOMBIES,
-				TRAP_GARGOYLES2,
-				TRAP_GIANTS,
-				TRAP_GIANTS_IGUANAS,
-				TRAP_EARTH,
-				TRAP_OGRES_HYENAS,
-				TRAP_SPHINX,
-				TRAP_FIRE,
-				TRAP_GREYWORM,
-				TRAP_AGAMA,
-				TRAP_RED_D,
-				TRAP_UNDEAD_PARTYMIX,
-				TRAP_FROSTRURUS,
-				TRAP_FROSTGIANT,
-				TRAP_MAGES,
-				TRAP_FROST_D,
-				TRAP_EYE,
-				TRAP_WATERFALL_MUMMIES,
-				TRAP_WIZARDS,
-				TRAP_WIZARDS2,
-				TRAP_COBRAS,
-				TRAP_BLUE_D,
-				TRAP_SLIMES,
-				TRAP_PHANTOM,
-				TRAP_LICH2,
-				TRAP_KARY2,
-				TRAP_KRAKEN2,
-				TRAP_TIAMAT2,
-				NUM_TRAP_TILES
+				byte[] spellInfo = new byte[8];
+				spellInfo[0] = accuracy;
+				spellInfo[1] = effect;
+				spellInfo[2] = elem;
+				spellInfo[3] = targeting;
+				spellInfo[4] = routine;
+				spellInfo[5] = gfx;
+				spellInfo[6] = palette;
+				spellInfo[7] = 0x00; // last byte is always 00
+				return spellInfo;
 			}
 
-			public class SpellData
+			public void decompressData(byte[] data)
 			{
-				public byte accuracy;
-				public byte effect;
-				public byte elem;
-				public byte targeting;
-				public byte routine;
-				public byte gfx;
-				public byte palette;
-
-				public byte[] CompressData()
+				if (data.Length < MagicSize)
 				{
-					byte[] spellInfo = new byte[8];
-					spellInfo[0] = accuracy;
-					spellInfo[1] = effect;
-					spellInfo[2] = elem;
-					spellInfo[3] = targeting;
-					spellInfo[4] = routine;
-					spellInfo[5] = gfx;
-					spellInfo[6] = palette;
-					spellInfo[7] = 0x00; // last byte is always 00
-					return spellInfo;
+					accuracy = 0x00;
+					effect = 0x00;
+					elem = 0x00;
+					targeting = 0x00;
+					routine = 0x00;
+					gfx = 0x00;
+					palette = 0x00;
+				}
+				else
+				{
+					accuracy = data[0];
+					effect = data[1];
+					elem = data[2];
+					targeting = data[3];
+					routine = data[4];
+					gfx = data[5];
+					palette = data[6];
 				}
 			}
+		}
 
-			public class EnemySkillData
+		public class EnemySkillInfo
+		{
+			public byte accuracy;
+			public byte effect;
+			public byte elem;
+			public byte targeting;
+			public byte routine;
+			public int tier;
+
+			public byte[] compressData()
 			{
-				public byte accuracy;
-				public byte effect;
-				public byte elem;
-				public byte targeting;
-				public byte routine;
+				byte[] spellInfo = new byte[8];
+				spellInfo[0] = accuracy;
+				spellInfo[1] = effect;
+				spellInfo[2] = elem;
+				spellInfo[3] = targeting;
+				spellInfo[4] = routine;
+				spellInfo[5] = 0x00; // last three bytes are always 0x00
+				spellInfo[6] = 0x00;
+				spellInfo[7] = 0x00;
+				return spellInfo;
 			}
 
-			public class EnemyData
+			public void decompressData(byte[] data)
 			{
-				public int exp;
-				public int gp;
-				public int hp;
-				public int morale;
-				public byte AIscript;
-				public int agility;
-				public int absorb;
-				public int num_hits;
-				public int accuracy;
-				public int damage;
-				public int critrate;
-				public byte atk_elem;
-				public byte atk_ailment;
-				public byte monster_type;
-				public int mdef;
-				public byte elem_weakness;
-				public byte elem_resist;
-
-				public byte[] CompressData() // compresses the information of the enemy into an array of bytes to be placed in the game code
+				if (data.Length < EnemySkillSize)
 				{
-					byte[] enemyInfo = new byte[20];
-					if (exp < 0)
-						exp = 0; // make sure experience isn't a negative number
-					enemyInfo[0] = (byte)(exp & 0xFF); // experience bytes are inverted from the usual format
-					enemyInfo[1] = (byte)((exp >> 8) & 0xFF);
-					enemyInfo[2] = (byte)(gp & 0xFF); // as is gold
-					enemyInfo[3] = (byte)((gp >> 8) & 0xFF);
-					enemyInfo[4] = (byte)(hp & 0xFF); // and hp
-					enemyInfo[5] = (byte)((hp >> 8) & 0xFF);
-					enemyInfo[6] = (byte)morale; // morale is 0-255
-					enemyInfo[7] = AIscript;
-					enemyInfo[8] = (byte)agility;
-					enemyInfo[9] = (byte)absorb;
-					enemyInfo[10] = (byte)num_hits;
-					enemyInfo[11] = (byte)accuracy;
-					enemyInfo[12] = (byte)damage;
-					enemyInfo[13] = (byte)critrate;
-					enemyInfo[14] = atk_elem;
-					enemyInfo[15] = atk_ailment;
-					enemyInfo[16] = monster_type;
-					enemyInfo[17] = (byte)mdef;
-					enemyInfo[18] = elem_weakness;
-					enemyInfo[19] = elem_resist;
-					return enemyInfo;
+					accuracy = 0x00;
+					effect = 0x00;
+					elem = 0x00;
+					targeting = 0x00;
+					routine = 0x00;
+				}
+				else
+				{
+					accuracy = data[0];
+					effect = data[1];
+					elem = data[2];
+					targeting = data[3];
+					routine = data[4];
 				}
 			}
+		}
 
-			public class EnemyScript
+		public class EnemyInfo
+		{
+			public int exp;
+			public int gp;
+			public int hp;
+			public int morale;
+			public byte AIscript;
+			public int agility;
+			public int absorb;
+			public int num_hits;
+			public int accuracy;
+			public int damage;
+			public int critrate;
+			public byte atk_elem;
+			public byte atk_ailment;
+			public byte monster_type;
+			public int mdef;
+			public byte elem_weakness;
+			public byte elem_resist;
+			public int tier; // enemy's tier rating, used by Enemizer to determine stats and Formation Generator to enforce certain placement rules
+			public byte image; // the image used by this image, of the 52 unique monster images available to normal enemies (does not include fiends or chaos).
+			public byte pal; // the palette normally used by this enemy.  this and the enemy's image are not stored in game data directly, rather they are implied by data in the formations
+
+			public byte tileset
 			{
-				public byte spell_chance;
-				public byte skill_chance;
-				public byte[] spell_list = new byte[8];
-				public byte[] skill_list = new byte[4];
-
-				public byte[] compressData()
-				{
-					byte[] scriptData = new byte[16];
-					scriptData[0] = spell_chance;
-					scriptData[1] = skill_chance;
-					scriptData[2] = spell_list[0];
-					scriptData[3] = spell_list[1];
-					scriptData[4] = spell_list[2];
-					scriptData[5] = spell_list[3];
-					scriptData[6] = spell_list[4];
-					scriptData[7] = spell_list[5];
-					scriptData[8] = spell_list[6];
-					scriptData[9] = spell_list[7];
-					scriptData[10] = 0xFF;
-					scriptData[11] = skill_list[0];
-					scriptData[12] = skill_list[1];
-					scriptData[13] = skill_list[2];
-					scriptData[14] = skill_list[3];
-					scriptData[15] = 0xFF;
-					return scriptData;
-				}
+				get => (byte)((image >> 2) & 0b00001111);
 			}
 
-			public class Formation
+			public byte pic
 			{
-				public int shape;
-				public byte tileset;
-				public byte pics = 0x00000000;
-				public byte[] id = new byte[4] { 0xFF, 0xFF, 0xFF, 0xFF };
-				public int[] monMin = new int[6] { 0, 0, 0, 0, 0, 0 };
-				public int[] monMax = new int[6] { 0, 0, 0, 0, 0, 0 };
-				public byte pal1;
-				public byte pal2;
-				public byte surprise;
-				public byte paletteassignment = 0b00000000;
-				public bool unrunnable;
-
-				public byte Top
-				{
-					get => id[0];
-					set => id[0] = value;
-				}
-
-				public byte[] CompressData() // compresses the information in the formation into an array of bytes to be placed in the game code
-				{
-					for (int i = 0; i < 4; ++i)
-					{
-						if (id[i] == 0xFF)
-							id[i] = 0; // set empty slots to IMPs
-					}
-					byte[] formationData = new byte[16];
-					formationData[0] = unchecked((byte)(shape << 4));
-					formationData[0] |= tileset;
-					formationData[1] = pics;
-					formationData[2] = id[0];
-					formationData[3] = id[1];
-					formationData[4] = id[2];
-					formationData[5] = id[3];
-					formationData[6] = (byte)((monMin[0] << 4) | monMax[0]);
-					formationData[7] = (byte)((monMin[1] << 4) | monMax[1]);
-					formationData[8] = (byte)((monMin[2] << 4) | monMax[2]);
-					formationData[9] = (byte)((monMin[3] << 4) | monMax[3]);
-					formationData[10] = pal1;
-					formationData[11] = pal2;
-					formationData[12] = surprise;
-					formationData[13] = paletteassignment;
-					if (unrunnable)
-						formationData[13] |= 0x01;
-					formationData[14] = (byte)((monMin[4] << 4) | monMax[4]);
-					formationData[15] = (byte)((monMin[5] << 4) | monMax[5]);
-					return formationData;
-				}
+				get => (byte)(image & 0b00000011);
 			}
 
-			public class FormationMarker
+			public bool Large
 			{
-				public List<byte> mons = new List<byte> { };
-				public List<int> moncount = new List<int> { };
+				get => (image & 1) == 1;
 			}
 
-			public class EnemyPicPlusCount
+			public bool Small
 			{
-				char count;
-				byte picID;
-				EnemyPicPlusCount(char num, byte pict)
+				get => (image & 1) == 0;
+			}
+
+			public byte[] compressData() // compresses the information of the enemy into an array of bytes to be placed in the game code
+			{
+				byte[] enemyInfo = new byte[20];
+				enemyInfo[0] = (byte)(exp & 0xFF); // experience bytes are inverted from the usual format
+				enemyInfo[1] = (byte)((exp >> 8) & 0xFF);
+				enemyInfo[2] = (byte)(gp & 0xFF); // as is gold
+				enemyInfo[3] = (byte)((gp >> 8) & 0xFF);
+				enemyInfo[4] = (byte)(hp & 0xFF); // and hp
+				enemyInfo[5] = (byte)((hp >> 8) & 0xFF);
+				enemyInfo[6] = (byte)morale; // morale is 0-255
+				enemyInfo[7] = AIscript;
+				enemyInfo[8] = (byte)agility;
+				enemyInfo[9] = (byte)absorb;
+				enemyInfo[10] = (byte)num_hits;
+				enemyInfo[11] = (byte)accuracy;
+				enemyInfo[12] = (byte)damage;
+				enemyInfo[13] = (byte)critrate;
+				enemyInfo[14] = atk_elem;
+				enemyInfo[15] = atk_ailment;
+				enemyInfo[16] = monster_type;
+				enemyInfo[17] = (byte)mdef;
+				enemyInfo[18] = elem_weakness;
+				enemyInfo[19] = elem_resist;
+				return enemyInfo;
+			}
+
+			public void decompressData(byte[] data)
+			{
+				if (data.Length != EnemySize)
+					return; // don't bother decompressing data of invalid size
+				exp = data[0] + data[1] * 256;
+				gp = data[2] + data[3] * 256;
+				hp = data[4] + data[5] * 256;
+				morale = data[6];
+				AIscript = data[7];
+				agility = data[8];
+				absorb = data[9];
+				num_hits = data[10];
+				accuracy = data[11];
+				damage = data[12];
+				critrate = data[13];
+				atk_elem = data[14];
+				atk_ailment = data[15];
+				monster_type = data[16];
+				mdef = data[17];
+				elem_weakness = data[18];
+				elem_resist = data[19];
+			}
+		}
+
+		public class EnemyScriptInfo
+		{
+			public byte spell_chance;
+			public byte skill_chance;
+			public byte[] spell_list = new byte[8];
+			public byte[] skill_list = new byte[4];
+
+			public byte[] compressData()
+			{
+				byte[] scriptData = new byte[16];
+				scriptData[0] = spell_chance;
+				scriptData[1] = skill_chance;
+				scriptData[2] = spell_list[0];
+				scriptData[3] = spell_list[1];
+				scriptData[4] = spell_list[2];
+				scriptData[5] = spell_list[3];
+				scriptData[6] = spell_list[4];
+				scriptData[7] = spell_list[5];
+				scriptData[8] = spell_list[6];
+				scriptData[9] = spell_list[7];
+				scriptData[10] = 0xFF;
+				scriptData[11] = skill_list[0];
+				scriptData[12] = skill_list[1];
+				scriptData[13] = skill_list[2];
+				scriptData[14] = skill_list[3];
+				scriptData[15] = 0xFF;
+				return scriptData;
+			}
+
+			public void decompressData(byte[] data)
+			{
+				if (data.Length != ScriptSize)
+					return; // don't do anything if this is not a valid script
+				spell_chance = data[0];
+				skill_chance = data[1];
+				spell_list[0] = data[2];
+				spell_list[1] = data[3];
+				spell_list[2] = data[4];
+				spell_list[3] = data[5];
+				spell_list[4] = data[6];
+				spell_list[5] = data[7];
+				spell_list[6] = data[8];
+				spell_list[7] = data[9];
+				skill_list[0] = data[11];
+				skill_list[1] = data[12];
+				skill_list[2] = data[13];
+				skill_list[3] = data[14];
+			}
+		}
+
+		public class FormationInfo
+		{
+			public int shape;
+			public byte tileset;
+			public byte pics = 0x00000000;
+			public byte[] id = new byte[4] { 0xFF, 0xFF, 0xFF, 0xFF };
+			public int[] monMin = new int[6] { 0, 0, 0, 0, 0, 0 };
+			public int[] monMax = new int[6] { 0, 0, 0, 0, 0, 0 };
+			public byte pal1;
+			public byte pal2;
+			public byte surprise;
+			public byte paletteassignment = 0b00000000;
+			public bool unrunnable;
+
+			public byte Top
+			{
+				get => id[0];
+				set => id[0] = value;
+			}
+
+			public byte[] compressData() // compresses the information in the formation into an array of bytes to be placed in the game code
+			{
+				for (int i = 0; i < 4; ++i)
 				{
-					count = num;
-					picID = pict;
+					if (id[i] == 0xFF)
+						id[i] = 0; // set empty slots to IMPs
 				}
+				byte[] formationData = new byte[16];
+				formationData[0] = unchecked((byte)(shape << 4));
+				formationData[0] |= tileset;
+				formationData[1] = pics;
+				formationData[2] = id[0];
+				formationData[3] = id[1];
+				formationData[4] = id[2];
+				formationData[5] = id[3];
+				formationData[6] = (byte)((monMin[0] << 4) | monMax[0]);
+				formationData[7] = (byte)((monMin[1] << 4) | monMax[1]);
+				formationData[8] = (byte)((monMin[2] << 4) | monMax[2]);
+				formationData[9] = (byte)((monMin[3] << 4) | monMax[3]);
+				formationData[10] = pal1;
+				formationData[11] = pal2;
+				formationData[12] = surprise;
+				formationData[13] = paletteassignment;
+				if (unrunnable)
+					formationData[13] |= 0x01;
+				formationData[14] = (byte)((monMin[4] << 4) | monMax[4]);
+				formationData[15] = (byte)((monMin[5] << 4) | monMax[5]);
+				return formationData;
 			}
 
-			public byte[] spellDataFile = new byte[MagicSize * MagicCount];
-			public SpellData[] spells = new SpellData[MagicCount];
-			public byte[] spelltiers_human = new byte[]
+			public void decompressData(byte[] data)
 			{
-				0, 0, 0, 0, 0, 0, 0, 0,
-				0, 0, 0, 0, 0, 0, 0, 0,
-				0, 0, 0, 0, 0, 0, 0, 0,
-				0, 0, 0, 0, 0, 0, 0, 0,
-				0, 0, 0, 0, 0, 0, 0, 0,
-				0, 0, 0, 0, 0, 0, 0, 0,
-				0, 0, 0, 0, 0, 0, 0, 0,
-				0, 0, 0, 0, 0, 0, 0, 0
-			};
-			public byte[] spelltiers_enemy = new byte[]
+				if (data.Length != FormationDataSize)
+					return; // do nothing if this data isn't the right size
+				shape = (data[0] & 0xF0) >> 4;
+				tileset = (byte)(data[0] & 0x0F);
+				pics = data[1];
+				id[0] = data[2];
+				id[1] = data[3];
+				id[2] = data[4];
+				id[3] = data[5];
+				monMin[0] = (data[6] & 0xF0) >> 4;
+				monMax[0] = data[6] & 0x0F;
+				monMin[1] = (data[7] & 0xF0) >> 4;
+				monMax[1] = data[7] & 0x0F;
+				monMin[2] = (data[8] & 0xF0) >> 4;
+				monMax[2] = data[8] & 0x0F;
+				monMin[3] = (data[9] & 0xF0) >> 4;
+				monMax[3] = data[9] & 0x0F;
+				pal1 = data[10];
+				pal2 = data[11];
+				surprise = data[12];
+				paletteassignment = (byte)(data[13] & 0xF0);
+				unrunnable = (data[13] & 0x01) == 0x01 ? true : false;
+				monMin[4] = (data[14] & 0xF0) >> 4;
+				monMax[4] = data[14] & 0x0F;
+				monMin[5] = (data[15] & 0xF0) >> 4;
+				monMax[5] = data[15] & 0x0F;
+			}
+		}
+
+		public class Enemizer_Zone
+		{
+			public int min; // minimum count for this zone 
+			public int max; // maximum count for this zone
+			public List<byte> forms; // list of which formations belong to this zone
+			public int minXP; // minimum XP yield for this zone
+			public int midXP; // "minimum maximum" XP yield for this zone
+			public int maxXP; // maximum XP yield for this zone
+			public List<byte> zonemons; // monsters that are compatible with this zone
+			public int[] addr; // list of addresses this zone writes to
+			public Enemizer_Zone(int mincount, int maxcount, int zminXP, int zmidXP, int zmaxXP)
 			{
-				1, 0, 1, 3, 1, 2, 1, 1,
-				0, 2, 2, 1, 2, 1, 2, 2,
-				2, 0, 2, 2, 3, 3, 3, 2,
-				0, 0, 2, 1, 2, 3, 0, 3,
-				3, 0, 0, 3, 4, 4, 0, 3,
-				0, 0, 3, 3, 4, 3, 4, 3,
-				4, 0, 3, 4, 4, 4, 2, 1,
-				0, 5, 4, 4, 5, 4, 4, 4
-			};
-			public byte[] skillDataFile = new byte[EnemySkillCount * EnemySkillSize];
-			public EnemySkillData[] skills = new EnemySkillData[EnemySkillCount];
-			public byte[] skilltiers_human = new byte[]
-			{
-				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-			};
-			public byte[] skilltiers_enemy = new byte[]
-			{
-				3, 2, 3, 1, 2, 1, 4, 3, 3, 4, 4, 4, 5, 3, 4, 3, 4, 4, 4, 1, 5, 2, 2, 1, 5, 5
-			};
-			public byte[] enemyDataFile = new byte[EnemySize * EnemyCount];
-			public EnemyData[] enemyStats = new EnemyData[EnemyCount];
-			public string[] enemyNames = new string[EnemyCount];
-			public int numEnemyNameCharacters = 0;
-			public byte[] enemyScriptDataFile = new byte[ScriptSize * ScriptCount];
-			public EnemyScript[] enemyScripts = new EnemyScript[ScriptCount];
-			public byte[] formationData = new byte[FormationDataSize * FormationDataCount];
-			public Formation[] formationInfo = new Formation[FormationDataCount];
+				min = mincount; max = maxcount; minXP = zminXP; midXP = zmidXP; maxXP = zmaxXP;
+				forms = new List<byte> { };
+				zonemons = new List<byte> { };
+			}
+		}
+
+		public class EnemizerTrackingInfo
+		{		
 			public List<byte>[] enemiesInTileset = new List<byte>[GenericTilesetsCount];
 			public List<byte>[] palettesInTileset = new List<byte>[GenericTilesetsCount];
-			public List<byte> enemyTilesets;
-			public List<byte> enemyPalettes;
-			public List<bool> enemySmallOrBig;
-			public List<int> enemyPics;
-			public List<int> enemyImage; // this combines tileset and pic
-			public List<byte> uniqueEnemyIDs = new List<byte> { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19,
-														0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F, 0x30, 0x31, 0x32, 0x34,
-														0x35, 0x36, 0x37, 0x38, 0x39, 0x3A, 0x3B, 0x3C, 0x3D, 0x3E, 0x3F, 0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D,
-														0x4E, 0x4F, 0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5A, 0x5B, 0x5C, 0x5D, 0x5E, 0x5F, 0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67,
-														0x68, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F, 0x70, 0x72, 0x73, 0x74, 0x75 };
-
-			public byte[] traptile_formations = new byte[(int)TrapTiles.NUM_TRAP_TILES]; // formation pointers for each trap tile
-			public int[] traptile_addresses = new int[(int)TrapTiles.NUM_TRAP_TILES]; // ROM addresses of trap tiles
-
 			public List<int>[] enemyZones = new List<int>[EnemyCount];
-
 			public bool[] featured = new bool[EnemyCount];
-			public int[] zonecountmin; // counter to tell the enemizer how many enemies we want to roll for each zone
-			public int[] zonecountmax;
-			public List<byte>[] zone; // array of lists which contain the formation indices we have assigned to each zone
-			public int[,] zonexpreqs;
-			public List<byte>[] zonemons; // array of which monsters are compatible with which zones
-			public List<int>[] zoneaddr; // list of addresses to place zone data
+			public List<Enemizer_Zone> zone = new List<Enemizer_Zone> { };
 			public int[][] zoneclone; // list of addresses which are clones of other domain addresses - the first entry in the array is the base to read from, the other entries will copy that
-
-			public byte[] domainData = new byte[ZoneFormationsSize * ZoneCount];
 			public byte imp_encounter = 0x00; // note the location of the imp encounter
 			public byte wizard_encounter = 0x1C; // note the location of the wizard encounter
 			public byte phantom_encounter = 0x46; // note the location of the phantom encounter, which will not be placed as a random (but can move around)
@@ -335,27 +426,29 @@ namespace FF1Lib
 			public byte vamp_encounter = 0x7C; // vamp encounter
 			public byte astos_encounter = 0x7D; // astos encounter
 			public byte pirate_encounter = 0x7E; // pirate encounter
-			public byte garland_encounter = 0x7F;
-			public Enemizer()
+			public byte garland_encounter = 0x7F; // garland encounter
+
+			public EnemizerTrackingInfo()
 			{
-				enemyTilesets = Enumerable.Repeat((byte)0x00, EnemyCount).ToList();
-				enemyPalettes = Enumerable.Repeat((byte)0x00, EnemyCount).ToList();
-				enemyPics = Enumerable.Repeat(0x00, EnemyCount).ToList();
-				enemySmallOrBig = Enumerable.Repeat(false, EnemyCount).ToList();
-				enemyImage = Enumerable.Repeat(0x00, EnemyCount).ToList();
+				// constructor for EnemizerTrackingInfo contains much of the information for zones we have hardcoded
 				for (int i = 0; i < GenericTilesetsCount; ++i)
 				{
 					enemiesInTileset[i] = new List<byte> { };
 					palettesInTileset[i] = new List<byte> { };
 				}
-				zonecountmin = new int[] { 8, 36, 16, 10, 14, 12, 12, 22, 14, 10, 14 };
-				zonecountmax = new int[] { 12, 48, 24, 15, 21, 18, 18, 33, 21, 15, 21 };
-				zonexpreqs = new int[11, 3]
+				for(int i = 0; i < EnemyCount; ++i)
 				{
-					{18, 40, 300}, // early game
-					{150, 400, 800}, // ocean/pravoka/elfland/marsh
-					{600, 800, 1200}, // melmond and other overworld area
-					{600, 800, 2400}, // earth cave
+					enemyZones[i] = new List<int> { };
+					featured[i] = false;
+				}
+				int[] zonecountmin = new int[11] { 12, 36, 18, 12, 14, 12, 12, 22, 14, 10, 14 };
+				int[] zonecountmax = new int[11] { 18, 48, 27, 18, 21, 18, 18, 33, 21, 15, 21 };
+				int[,] zonexpreqs = new int[11, 3]
+				{
+					{18, 24, 300}, // early game
+					{150, 300, 700}, // ocean/pravoka/elfland/marsh
+					{500, 800, 1400}, // melmond and other overworld area
+					{600, 1200, 2400}, // earth cave
 					{800, 2000, 4000}, // crescent/onrac/cardia/power peninsula overworld
 					{1200, 1500, 3600}, // gurgu/river south
 					{1350, 2800, 4800}, // ordeals ice waterfall
@@ -363,28 +456,23 @@ namespace FF1Lib
 					{2400, 3600, 7200}, // mirage tower and sea shrine
 					{2400, 4800, 10000}, // sky castle
 					{6000, 6001, 32000}, // tofr
-					
 				};
-				zone = new List<byte>[zonecountmin.Length];
-				for (int i = 0; i < zone.Length; ++i)
-					zone[i] = new List<byte> { };
-				for (int i = 0; i < EnemyCount; ++i)
-					enemyZones[i] = new List<int> { };
-				zonemons = new List<byte>[zonecountmin.Length];
-				for (int i = 0; i < zone.Length; ++i)
-					zonemons[i] = new List<byte> { };
-				zoneaddr = new List<int>[zonecountmin.Length];
-				zoneaddr[0] = new List<int> { 0x0D8, 0x120, 0x260 };
-				zoneaddr[1] = new List<int> { 0x128, 0x130, 0x0E8, 0x1E0, 0x118, 0x128, 0x158, 0x168, 0x170, 0x190, 0x198, 0x1A0, 0x1D0, 0x1D8, 0x210, 0x2B0, 0x2D8, 0x2E0 };
-				zoneaddr[2] = new List<int> { 0x108, 0x110, 0x138, 0x140, 0x148, 0x150, 0x178, 0x3E0 };
-				zoneaddr[3] = new List<int> { 0x268, 0x2E8, 0x2F0, 0x2F8, 0x300 };
-				zoneaddr[4] = new List<int> { 0x0F8, 0x1A8, 0x1B0, 0x1B8, 0x1E8, 0x1F0, 0x1F8 };
-				zoneaddr[5] = new List<int> { 0x208, 0x270, 0x308, 0x310, 0x318, 0x320 };
-				zoneaddr[6] = new List<int> { 0x278, 0x290, 0x2C8, 0x2D0, 0x328, 0x330 };
-				zoneaddr[7] = new List<int> { 0x000, 0x010, 0x018, 0x028, 0x030, 0x040, 0x048, 0x050, 0x068, 0x078, 0x200 };
-				zoneaddr[8] = new List<int> { 0x2B8, 0x340, 0x348, 0x350, 0x358, 0x360, 0x368 };
-				zoneaddr[9] = new List<int> { 0x378, 0x380, 0x388, 0x390, 0x398 };
-				zoneaddr[10] = new List<int> { 0x3A0, 0x3A8, 0x3B0, 0x3B8, 0x3C0, 0x3C8, 0x3D0 };
+				for (int i = 0; i < 11; ++i)
+				{
+					zone.Add(new Enemizer_Zone(zonecountmin[i], zonecountmax[i], zonexpreqs[i, 0], zonexpreqs[i, 1], zonexpreqs[i, 2]));
+				}
+				zone[0].addr = new int[] { 0x0D8, 0x120, 0x128, 0x130, 0x260 };
+				zone[1].addr = new int[] { 0x0E8, 0x1E0, 0x118, 0x158, 0x168, 0x170, 0x190, 0x198, 0x1A0, 0x1D0, 0x1D8, 0x210, 0x2B0, 0x2D8, 0x2E0 };
+				zone[2].addr = new int[] { 0x108, 0x110, 0x138, 0x140, 0x148, 0x150, 0x178, 0x218, 0x3E0 };
+				zone[3].addr = new int[] { 0x268, 0x2E8, 0x2F0, 0x2F8, 0x300 };
+				zone[4].addr = new int[] { 0x0F8, 0x1A8, 0x1B0, 0x1B8, 0x1E8, 0x1F0, 0x1F8 };
+				zone[5].addr = new int[] { 0x208, 0x270, 0x308, 0x310, 0x318, 0x320 };
+				zone[6].addr = new int[] { 0x278, 0x290, 0x2C8, 0x2D0, 0x328, 0x330 };
+				zone[7].addr = new int[] { 0x000, 0x010, 0x018, 0x028, 0x030, 0x040, 0x048, 0x050, 0x068, 0x078, 0x200 };
+				zone[8].addr = new int[] { 0x2B8, 0x340, 0x348, 0x350, 0x358, 0x360, 0x368 };
+				zone[9].addr = new int[] { 0x378, 0x380, 0x388, 0x390, 0x398 };
+				zone[10].addr = new int[] { 0x3A0, 0x3A8, 0x3B0, 0x3B8, 0x3C0, 0x3C8, 0x3D0 };
+
 				zoneclone = new int[8][];
 				zoneclone[0] = new int[] { 0x000, 0x008 };
 				zoneclone[1] = new int[] { 0x040, 0x080, 0x088 };
@@ -396,290 +484,14 @@ namespace FF1Lib
 				zoneclone[7] = new int[] { 0x0D8, 0x0E0 };
 			}
 
-			public void SetVanillaInfo()
+			public void ReadEnemyDataFromFormation(FormationInfo f, EnemyInfo[] enemystats)
 			{
-				
-			}
-
-
-			public void PutF(int offset, byte[] data)
-			{
-				if (offset > formationData.Length || offset < 0)
-					return;
-				for (int i = 0; i < data.Length; ++i)
-				{
-					formationData[offset + i] = data[i];
-				}
-			}
-
-			public byte[] GetF(uint offset, int length)
-			{
-				byte[] return_value;
-				if (length < 0)
-				{
-					if (-length + 1 < 0)
-					{
-						return null;
-					}
-					return_value = new byte[-length];
-					for (int i = 0; i < -length; ++i)
-					{
-						return_value[i] = formationData[i + length + 1];
-					}
-					return return_value;
-				}
-				return_value = new byte[length];
-				for (int i = 0; i < length; ++i)
-				{
-					return_value[i] = formationData[i];
-				}
-				return return_value;
-			}
-
-			public void PutAllFormationData(byte[] ROMinfo)
-			{
-				formationData = ROMinfo;
-			}
-
-			public byte[] GetFormationData()
-			{
-				return formationData;
-			}
-
-			public void PutD(int offset, int entry)
-			{
-				domainData[offset] = (byte)entry;
-			}
-
-			public byte GetD(int offset)
-			{
-				return domainData[offset];
-			}
-
-			public void PutAllDomainData(byte[] ROMinfo)
-			{
-				domainData = ROMinfo;
-			}
-
-			public byte[] GetDomainData()
-			{
-				return domainData;
-			}
-
-			public byte GetTileset(byte mon)
-			{
-				return enemyTilesets[mon];
-			}
-
-			public byte GetPalette(byte mon)
-			{
-				return enemyPalettes[mon];
-			}
-
-			public int GetMonLimit(byte mon, int shape)
-			{
-				switch (shape)
-				{
-					case 0x00:
-						if (Small(mon))
-							return 9;
-						return 0;
-					case 0x01:
-						if (Large(mon))
-							return 4;
-						return 0;
-					case 0x02:
-						if (Large(mon))
-							return 2;
-						return 6;
-					default:
-						return 0;
-				}
-			}
-
-			public bool Small(byte mon)
-			{
-				return !enemySmallOrBig[mon];
-			}
-
-			public bool Large(byte mon)
-			{
-				return enemySmallOrBig[mon];
-			}
-
-			public bool Featured(byte id)
-			{
-				return featured[id];
-			}
-
-			public bool NotFeatured(byte id)
-			{
-				return !featured[id];
-			}
-
-			public void ClearFeaturedList()
-			{
-				foreach (byte mon in uniqueEnemyIDs)
-					featured[mon] = false;
-			}
-
-			public SpellData decompressSpellData(byte[] rawData)
-			{
-				SpellData sp = new SpellData();
-				if (rawData.Length != MagicSize)
-					return sp;
-				sp.accuracy = rawData[0];
-				sp.effect = rawData[1];
-				sp.elem = rawData[2];
-				sp.targeting = rawData[3];
-				sp.routine = rawData[4];
-				sp.gfx = rawData[5];
-				sp.palette = rawData[6];
-				return sp;
-			}
-
-			public EnemyData decompressEnemyData(byte[] rawData)
-			{
-				EnemyData e = new EnemyData();
-				if (rawData.Length != EnemySize)
-					return e; // return a blank enemy if rawdata is not the right size
-				e.exp = rawData[0] + rawData[1] * 256;
-				e.gp = rawData[2] + rawData[3] * 256;
-				e.hp = rawData[4] + rawData[5] * 256;
-				e.morale = rawData[6];
-				e.AIscript = rawData[7];
-				e.agility = rawData[8];
-				e.absorb = rawData[9];
-				e.num_hits = rawData[10];
-				e.accuracy = rawData[11];
-				e.damage = rawData[12];
-				e.critrate = rawData[13];
-				e.atk_elem = rawData[14];
-				e.atk_ailment = rawData[15];
-				e.monster_type = rawData[16];
-				e.mdef = rawData[17];
-				e.elem_weakness = rawData[18];
-				e.elem_resist = rawData[19];
-				return e;
-			}
-
-			public EnemyScript decompressEnemyScript(byte[] rawData)
-			{
-				EnemyScript s = new EnemyScript();
-				if (rawData.Length != ScriptSize)
-				{
-					s.spell_chance = 0;
-					s.skill_chance = 0;
-					s.spell_list[0] = 0xFF;
-					s.spell_list[1] = 0xFF;
-					s.spell_list[2] = 0xFF;
-					s.spell_list[3] = 0xFF;
-					s.spell_list[4] = 0xFF;
-					s.spell_list[5] = 0xFF;
-					s.spell_list[6] = 0xFF;
-					s.spell_list[7] = 0xFF;
-					s.skill_list[0] = 0xFF;
-					s.skill_list[1] = 0xFF;
-					s.skill_list[2] = 0xFF;
-					s.skill_list[3] = 0xFF;
-				}
-				s.spell_chance = rawData[0];
-				s.skill_chance = rawData[1];
-				s.spell_list[0] = rawData[2];
-				s.spell_list[1] = rawData[3];
-				s.spell_list[2] = rawData[4];
-				s.spell_list[3] = rawData[5];
-				s.spell_list[4] = rawData[6];
-				s.spell_list[5] = rawData[7];
-				s.spell_list[6] = rawData[8];
-				s.spell_list[7] = rawData[9];
-				s.skill_list[0] = rawData[11];
-				s.skill_list[1] = rawData[12];
-				s.skill_list[2] = rawData[13];
-				s.skill_list[3] = rawData[14];
-				return s;
-			}
-
-			public Formation decompressFormation(byte[] rawData)
-			{
-				Formation f = new Formation();
-				if (rawData.Length != FormationDataSize)
-					return f; // return a blank formation if rawdata is not the right size
-				f.shape = (rawData[0] & 0xF0) >> 4;
-				f.tileset = (byte)(rawData[0] & 0x0F);
-				f.pics = rawData[1];
-				f.id[0] = rawData[2];
-				f.id[1] = rawData[3];
-				f.id[2] = rawData[4];
-				f.id[3] = rawData[5];
-				f.monMin[0] = (rawData[6] & 0xF0) >> 4;
-				f.monMax[0] = rawData[6] & 0x0F;
-				f.monMin[1] = (rawData[7] & 0xF0) >> 4;
-				f.monMax[1] = rawData[7] & 0x0F;
-				f.monMin[2] = (rawData[8] & 0xF0) >> 4;
-				f.monMax[2] = rawData[8] & 0x0F;
-				f.monMin[3] = (rawData[9] & 0xF0) >> 4;
-				f.monMax[3] = rawData[9] & 0x0F;
-				f.pal1 = rawData[10];
-				f.pal2 = rawData[11];
-				f.surprise = rawData[12];
-				f.paletteassignment = (byte)(rawData[13] & 0xF0);
-				f.unrunnable = (rawData[13] & 0x01) == 0x01 ? true : false;
-				f.monMin[4] = (rawData[14] & 0xF0) >> 4;
-				f.monMax[4] = rawData[14] & 0x0F;
-				f.monMin[5] = (rawData[15] & 0xF0) >> 4;
-				f.monMax[5] = rawData[15] & 0x0F;
-				return f;
-			}
-
-			public void LogAndCompressFormation(Formation f, int slot)
-			{
-				for (int i = 0; i < 4; ++i)
-				{
-					if (f.id[i] == 0xFF)
-						continue;
-					if (f.monMin[i] > 0)
-						featured[f.id[i]] = true;
-				}
-				for (int i = 0; i < 2; ++i)
-				{
-					if (f.id[i] == 0xFF)
-						continue;
-					if (f.monMin[i + 4] > 0)
-						featured[f.id[i]] = true;
-				}
-				PutF(slot * FormationDataSize, f.CompressData());
-			}
-
-			public void ReadSpellDataFromMagicBytes(SpellData sp, int index)
-			{
-				spells[index] = sp;
-			}
-
-			public void ReadEnemyDataFromEnemies(EnemyData e, int index)
-			{
-				enemyStats[index] = e;
-			}
-
-			public void ReadScriptDataFromScript(EnemyScript s, int index)
-			{
-				enemyScripts[index] = s;
-			}
-
-			public void ReadEnemyDataFromFormation(Formation f, int index)
-			{
-				// enter the formation into the formations array
-				formationInfo[index] = f;
 				// pull information about the enemy's graphical data and other things that are held in formation data rather than the enemy data proper
-				if (f.tileset < 0x00 || f.tileset > GenericTilesetsCount - 1)
-				{
-					enemyTilesets[f.id[0]] = f.tileset;
-					enemyPalettes[f.id[0]] = 0xFF;
-					return; // don't enter data for enemies that use fiend tilesets or invalid tilesets, except for their tileset ID and a placeholder for palette
-				}
+				if (f.tileset < 0x00 || f.tileset >= GenericTilesetsCount)
+					return; // we don't care about extracting formation information from fiends or chaos
 				for (int i = 0; i < 4; ++i)
 				{
-					if(i < 2)
+					if (i < 2)
 					{
 						if (f.monMax[i] == 0 && f.monMax[i + 4] == 0)
 							continue; // do not bother reading info for enemies that don't have a maxcount
@@ -691,23 +503,18 @@ namespace FF1Lib
 					}
 					if (f.id[i] >= EnemyCount)
 						continue; // don't use IDs that exceed the maximum number of enemies
-					if (!enemiesInTileset[f.tileset].Contains(f.id[i])) {
+					if (!enemiesInTileset[f.tileset].Contains(f.id[i]))
+					{
 						// place enemy in appropriate tileset
 						enemiesInTileset[f.tileset].Add(f.id[i]);
-						enemyTilesets[f.id[i]] = f.tileset;
 						// determine which pic is being used
 						int pict = (f.pics >> (i * 2)) & 0b00000011;
-						enemyPics[f.id[i]] = pict;
-						if ((pict & 0b00000001) == 1)
-							enemySmallOrBig[f.id[i]] = true;
-						else
-							enemySmallOrBig[f.id[i]] = false;
-						enemyImage[f.id[i]] = (int)enemyTilesets[f.id[i]] << 2 | pict;
+						enemystats[f.id[i]].image = (byte)(f.tileset << 2 | pict);
 						bool paletteassigned = (f.paletteassignment & (0b10000000 >> i)) != 0;
 						if (paletteassigned)
-							enemyPalettes[f.id[i]] = f.pal2;
+							enemystats[f.id[i]].pal = f.pal2;
 						else
-							enemyPalettes[f.id[i]] = f.pal1;
+							enemystats[f.id[i]].pal = f.pal1;
 						if (!palettesInTileset[f.tileset].Contains(f.pal1))
 							palettesInTileset[f.tileset].Add(f.pal1);
 						if (!palettesInTileset[f.tileset].Contains(f.pal2))
@@ -716,9 +523,23 @@ namespace FF1Lib
 				}
 			}
 
+			public void LogFeatured(FormationInfo f)
+			{
+				for(int i = 0; i < 3; i++)
+				{
+					if (f.monMin[i] > 0)
+						featured[f.id[i]] = true;
+					if(i < 2)
+					{
+						if (f.monMin[i + 4] > 0)
+							featured[f.id[i]] = true;
+					}
+				}
+			}
+
 			public void PurgeIDFromEnemyTilesetList(byte mon)
 			{
-				for(int i = 0; i < GenericTilesetsCount; ++i)
+				for (int i = 0; i < GenericTilesetsCount; ++i)
 				{
 					enemiesInTileset[i].RemoveAll(id => id == mon);
 				}
@@ -726,1775 +547,784 @@ namespace FF1Lib
 
 			public void PrintFormationInfo()
 			{
-				for (int i = 0; i < zonecountmin.Length; ++i)
+				foreach (Enemizer_Zone domain in zone)
 				{
-					Console.WriteLine("Zone " + i + " " + zone[i].Count + "/" + zonecountmin[i]);
+					Console.WriteLine("Zone " + domain.forms.Count() + "/" + domain.min);
 				}
 			}
 
-			public bool DoEnemies(MT19337 rng)
+			public int GetMonLimit(bool size, int shape)
 			{
-				int num_enemy_name_chars = 0;
-				for(int i = 0; i < EnemyCount; ++i)
+				switch (shape)
 				{
-					num_enemy_name_chars += enemyNames[i].Length;
+					case 0x00:
+						if (!size)
+							return 9;
+						return 0;
+					case 0x01:
+						if (size)
+							return 4;
+						return 0;
+					case 0x02:
+						if (size)
+							return 2;
+						return 6;
+					default:
+						return 0;
 				}
-				Console.WriteLine(num_enemy_name_chars);
-				// set enemy default tier list.  these listings are based on a combination of where the enemy is placed in the game, its xp yield, its rough difficulty, whether it has a script or not, and gut feels
-				// -1 indicates a monster with special rules for enemy generation
-				int[] enemyTierList = new int[] { -1, 0, 0, 1, 1, 3, 1, 6, 5, 4, 6, 6, 0, 1, 4, -1,
-												  1, 2, 5, 0, 7, 0, 3, 1, 2, 2, 4, 2, 2, 5, 1, 2,
-												  5, 2, 5, 3, 4, 4, 5, 1, 2, 3, 5, 0, 1, 1, 2, 8,
-												  5, 5, 7, -1, 4, 5, 4, 4, 4, 5, 3, 4, 5, 7, 1, 3,
-												  4, 5, 5, 6, 6, 1, 2, 2, 7, 0, 1, 5, 4, 6, 7, 3,
-												  5, 2, 3, 5, 5, 7, 9, 2, 4, 4, 5, 4, 7, 4, 5, 6,
-												  8, 6, 6, 6, 7, 6, 8, 2, 4, -1, 8, 8, 5, 6, 9, 6,
-												  7, -1, 4, 7, 1, 5, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
-				List<int> enemyImageLUT = new List<int>   { 0b00000000, 0b00000010, 0b00000001, 0b00000011, 0b00000100, 0b00000110, 0b00000101, 0b00000111,
-															0b00001000, 0b00001010, 0b00001001, 0b00001011, 0b00001100, 0b00001110, 0b00001101, 0b00001111,
-															0b00010000, 0b00010010, 0b00010001, 0b00010011, 0b00010100, 0b00010110, 0b00010101, 0b00010111,
-															0b00011000, 0b00011010, 0b00011001, 0b00011011, 0b00011100, 0b00011110, 0b00011101, 0b00011111,
-															0b00100000, 0b00100010, 0b00100001, 0b00100011, 0b00100100, 0b00100110, 0b00100101, 0b00100111,
-															0b00101000, 0b00101010, 0b00101001, 0b00101011, 0b00101100, 0b00101110, 0b00101101, 0b00101111,
-															0b00110000, 0b00110010, 0b00110001, 0b00110011 }; // these are the default tilesets + pics of the enemies we wish to shuffle
-				List<string>[] monsterClassVariants = new List<string>[52]; // monster class modifiers that have effects on stats
-				monsterClassVariants[0] = new List<string> { "Fr", "R.", "Z.", "Wr", "Wz", "Sea" }; // imp variants with special perks
-				monsterClassVariants[1] = new List<string> { "Fr", "R.", "Z.", "Wz", "Sea" }; // iguana variants with special perks
-				monsterClassVariants[2] = new List<string> { "Fr", "R.", "Z.", "Wr", "Wz" }; // wolf variants with special perks
-				monsterClassVariants[3] = new List<string> { "Fr", "R.", "Z.", "Wz", "Sea" }; // giant variants with special perks
-				monsterClassVariants[4] = new List<string> { "Fr", "Z.", "Wr", "Wz" }; // sahag variants with special perks
-				monsterClassVariants[5] = new List<string> { "Fr", "Z." }; // shark variants with special perks
-				monsterClassVariants[6] = new List<string> { "Fr", "R.", "Z.", "Wz" }; // pirate variants with special perks
-				monsterClassVariants[7] = new List<string> { "Fr", "Z." }; // oddeye variants with special perks
-				monsterClassVariants[8] = new List<string> { "Wz" }; // bone variants with special perks
-				monsterClassVariants[9] = new List<string> { "Fr", "R.", "Z.", "Wz", "Sea" }; // ogre variants with special perks
-				monsterClassVariants[10] = new List<string> { "Fr", "R.", "Z.", "Wr", "Wz", "Sea" }; // creep variants with special perks
-				monsterClassVariants[11] = new List<string> { "Fr", "R.", "Z.", "Wr" }; // hyena variants with special perks
-				monsterClassVariants[12] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // asp variants with special perks
-				monsterClassVariants[13] = new List<string> { "Fr", "R.", "Z.", "Wr", "Wz", "Sea" }; // bull variants with special perks
-				monsterClassVariants[14] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // crab variants with special perks
-				monsterClassVariants[15] = new List<string> { "Fr", "R.", "Z.", "Wz", "Sea" }; // troll variants with special perks
-				monsterClassVariants[16] = new List<string> { "Wz" }; // ghost variants with special perks
-				monsterClassVariants[17] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // worm variants with special perks
-				monsterClassVariants[18] = new List<string> { "Sea" }; // wight variants with special perks
-				monsterClassVariants[19] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // eye variants with special perks
-				monsterClassVariants[20] = new List<string> { "Fr", "R.", "Z.", "Wz", "Sea" }; // medusa variants with special perks
-				monsterClassVariants[21] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // pede variants with special perks
-				monsterClassVariants[22] = new List<string> { "Fr", "R.", "Z.", "Wz" }; // catman variants with special perks
-				monsterClassVariants[23] = new List<string> { "Fr", "R.", "Z.", "Wr" }; // tiger variants with special perks
-				monsterClassVariants[24] = new List<string> { "Wz" }; // vamp variants with special perks
-				monsterClassVariants[25] = new List<string> { }; // large elem variants with special perks
-				monsterClassVariants[26] = new List<string> { "Fr", "R.", "Z.", "Wz", "Sea" }; // goyle variants with special perks
-				monsterClassVariants[27] = new List<string> { }; // drake 1 variants with special perks
-				monsterClassVariants[28] = new List<string> { "Wz" }; // flan variants with special perks
-				monsterClassVariants[29] = new List<string> { "Fr", "R.", "Z.", "Wz", "Sea" }; // manticore variants with special perks
-				monsterClassVariants[30] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // spider variants with special perks
-				monsterClassVariants[31] = new List<string> { "Fr", "R.", "Z." }; // ankylo variants with special perks
-				monsterClassVariants[32] = new List<string> { "Wz" }; // mummy variants with special perks
-				monsterClassVariants[33] = new List<string> { "Fr", "R.", "Z.", "Wr", "Wz" }; // wyvern variants with special perks
-				monsterClassVariants[34] = new List<string> { "Fr", "R.", "Z." }; // bird variants with special perks
-				monsterClassVariants[35] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // tyro variants with special perks
-				monsterClassVariants[36] = new List<string> { "Fr", "Z." }; // caribe variants with special perks
-				monsterClassVariants[37] = new List<string> { "Fr", "Z.", "Wz" }; // ocho variants with special perks
-				monsterClassVariants[38] = new List<string> { "Fr", "Z.", "Wr" }; // gator variants with special perks
-				monsterClassVariants[39] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // hydra variants with special perks
-				monsterClassVariants[40] = new List<string> {  }; // bot variants with special perks
-				monsterClassVariants[41] = new List<string> { "Fr", "Z.", "Sea" }; // naga variants with special perks
-				monsterClassVariants[42] = new List<string> { }; // small elem variants with special perks
-				monsterClassVariants[43] = new List<string> { "Z.", "Wr", "Wz" }; // chimera variants with special perks
-				monsterClassVariants[44] = new List<string> { "Z.", "Wz" }; // piscodemon variants with special perks
-				monsterClassVariants[45] = new List<string> {  }; // dragon 2 variants with special perks
-				monsterClassVariants[46] = new List<string> { "Fr", "R.", "Z.", "Wz" }; // knight variants with special perks
-				monsterClassVariants[47] = new List<string> {  }; // golem variants with special perks
-				monsterClassVariants[48] = new List<string> { "Fr", "R.", "Z.", "Wz" }; // badman variants with special perks
-				monsterClassVariants[49] = new List<string> { "Fr", "R.", "Z.", "Wr", "Sea" }; // pony variants with special perks
-				monsterClassVariants[50] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // elf variants with special perks
-				monsterClassVariants[51] = new List<string> { }; // mech variants with special perks
-				List<string>[] monsterNameVariants = new List<string>[52]; // name variants for monsters to prevent duplicates
-				bool[] monsterBaseNameUsed = new bool[52]; // true if the base name has been used, false if not
-				for(int i = 0; i < 52; ++i)
+			}
+		}
+
+		public void ENF_AssignPicAndPaletteBytes(EnemyInfo[] enemy, FormationInfo f)
+		{
+			for (int i = 0; i < 4; ++i)
+			{
+				if (f.id[i] == 0xFF)
+					continue;
+				if (enemy[f.id[i]].pal == f.pal2)
+					f.paletteassignment |= (byte)(0b00010000 << (3 - i));
+				f.pics |= (byte)(enemy[f.id[i]].pic << (i * 2));
+			}
+		}
+
+		private bool DoEnemizer_Formations(MT19337 rng, EnemyInfo[] enemy, EnemizerTrackingInfo en)
+		{
+			Console.WriteLine("Formations Start");
+			bool NotFeatured(byte mon) => !en.featured[mon];
+			bool Small(byte mon) => enemy[mon].Small;
+			bool Large(byte mon) => enemy[mon].Large;
+			bool SmallAndNotFeatured(byte mon, byte id) => Small(mon) && NotFeatured(mon) && mon != id;
+			bool LargeAndNotFeatured(byte mon, byte id) => Large(mon) && NotFeatured(mon) && mon != id;
+
+			var formationData = Get(FormationDataOffset, FormationDataSize * FormationDataCount).Chunk(FormationDataSize); // load base information from the ROM into chunks we can manipulate
+			var dom = Get(ZoneFormationsOffset, ZoneFormationsSize * ZoneCount); // however, we are going to adjust the domain data directly
+			List<byte> uniqueEnemyIDs = new List<byte> { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19,
+			  0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F, 0x30, 0x31, 0x32, 0x34,
+			  0x35, 0x36, 0x37, 0x38, 0x39, 0x3A, 0x3B, 0x3C, 0x3D, 0x3E, 0x3F, 0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D,
+			  0x4E, 0x4F, 0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5A, 0x5B, 0x5C, 0x5D, 0x5E, 0x5F, 0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67,
+			  0x68, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F, 0x70, 0x72, 0x73, 0x74, 0x75 };
+			byte[] traptile_formations = new byte[(int)TrapTiles.NUM_TRAP_TILES]; // formation pointers for each trap tile
+			int[] traptile_addresses = new int[(int)TrapTiles.TRAP_LICH2]; // ROM addresses of trap tiles (excluding Lich2 and after
+			foreach (byte mon in uniqueEnemyIDs) // sort an enemy into its zone
+			{
+				int limit = enemy[mon].Large ? 4 : 9;
+				for (int i = 0; i < en.zone.Count; ++i)
 				{
-					monsterBaseNameUsed[i] = false; // if enemy is not part of a variant class, by default it uses the base name for the monster
-					monsterNameVariants[i] = new List<string> { "A.", "B.", "C.", "D.", "E.", "F.", "G.", "H.", "I.", "K.", "L.", "M.", "N.", "P.", "S.", "T.", "V.", "W.", "X." };
-				}
-				monsterBaseNameUsed[25] = true; // large elemental
-				monsterBaseNameUsed[27] = true; // dragon 1
-				monsterBaseNameUsed[42] = true; // small elemental
-				monsterBaseNameUsed[45] = true; // dragon 2
-				enemyImageLUT.Shuffle(rng); // shuffle the LUT - whatever image was there in vanilla will be replaced with what is at its position in the LUT
-				enemyImage.RemoveRange(Enemy.Lich, Enemy.Chaos - Enemy.Lich); // remove Lich 1 thru Chaos from the enemyImage array so they're not shuffled to a generic enemy
-				enemyImage.Shuffle(rng); // and shuffle the enemy images themselves
-				int whatIsPirate = enemyImageLUT[enemyImage[Enemy.Pirate]]; // find out what monster was assigned to the pirate
-				for (int i = 0; i < enemyImageLUT.Count(); ++i)
-				{
-					if (enemyImageLUT[i] == 0b00000110)
+					if (enemy[mon].exp <= (en.zone[i].maxXP * 2) / 3 && enemy[mon].exp * limit >= en.zone[i].midXP)
 					{
-						enemyImageLUT[i] = whatIsPirate; // assign whatever what given the pirate image the image that was assigned to the pirate monster's slot
+						en.zone[i].zonemons.Add(mon);
+						en.enemyZones[mon].Add(i);
+					}
+				}
+			}
+			// roll special encounters for: imp, phantom, warmech, vampire, astos, pirates, garland (and ignore fiend encounters
+			en.wizard_encounter = 0x81;
+			en.eye_encounter = 0x82;
+			en.zombieD_encounter = 0x83;
+			en.phantom_encounter = 0x04;
+			formationData[en.imp_encounter] = ENF_DrawBossEncounter(en, rng, enemy, Enemy.Imp, 4, enemy[Enemy.Imp].Large ? 0x01 : 0x00, false, 4, en.imp_encounter);
+			formationData[0x01] = ENF_DrawForcedSingleFight(en, rng, enemy, 2, 0x01);
+			formationData[0x02] = ENF_DrawForcedSingleFight(en, rng, enemy, 6, 0x02);
+			formationData[0x03] = ENF_DrawForcedSingleFight(en, rng, enemy, 6, 0x03);
+			formationData[0x04] = ENF_DrawBossEncounter(en, rng, enemy, Enemy.Phantom, 1, 0x02, true, 4, 0x04);
+			formationData[en.vamp_encounter] = ENF_DrawBossEncounter(en, rng, enemy, ENF_PickAVamp(enemy, uniqueEnemyIDs, rng), 1, 0x02, true, 4, 0x7C);
+			formationData[en.astos_encounter] = ENF_DrawBossEncounter(en, rng, enemy, Enemy.Astos, 1, 0x02, true, 4, 0x7D);
+			formationData[en.pirate_encounter] = ENF_DrawBossEncounter(en, rng, enemy, Enemy.Pirate, 9, 0x00, true, 4, 0x7E);
+			formationData[en.garland_encounter] = ENF_DrawBossEncounter(en, rng, enemy, Enemy.Garland, 1, 0x02, true, 4, 0x7F);
+			formationData[en.warmech_encounter] = ENF_DrawBossEncounter(en, rng, enemy, Enemy.WarMech, 1, 0x02, false, 4, en.warmech_encounter);
+			// reserve so many slots for different surprise rates and unrunnables
+			int[,] surprisetiers = { { 10, 19 }, { 24, 36 }, { 48, 62 }, { 70, 100 } };
+			const int surp1 = 9;
+			const int surp2 = 12;
+			const int surp3 = 4;
+			const int surp4 = 2;
+			int[] surpcount = { surp1, surp2, surp3, surp4 };
+			const int regularformations = 0x05; // we start rolling formations from where we stopped rolling special-case formations
+			const int bossformations = 0x73; // we stop rolling formations once we reach boss formations
+			for (byte i = regularformations; i < bossformations; ++i) // general loop for formation generation
+			{
+				if (i == en.imp_encounter || i == en.phantom_encounter || i == en.warmech_encounter)
+					continue; // don't do these encounters (we will roll them as special exceptions)
+				FormationInfo f = new FormationInfo(); // this is the formation we are hoping to write
+				// we will start narrowing down the list of monsters we can feature
+				List<byte> availablemons = new List<byte> { };
+				// first, we check if all monsters have been featured yet
+				if (uniqueEnemyIDs.Where(NotFeatured).Count() == 0)
+				{
+					// if we have featured all monsters, reset the featured array
+					foreach (byte mon in uniqueEnemyIDs)
+					{
+						en.featured[mon] = false;
+					}
+				}
+				// first, we determine which zones we have yet to reach the minimum for.  if they have yet to reach the minimum, they can join the union if the mon hasn't been featured yet
+				for (int j = 0; j < en.zone.Count; ++j)			{
+					if (en.zone[j].forms.Count < en.zone[j].min)
+					{
+						availablemons = availablemons.Union(en.zone[j].zonemons.Where(NotFeatured)).ToList();
+					}
+				}
+				// if we have already met the minimums for each zone, then any zone which has not reached its maximum can be chosen, if they have not been featured yet in this cycle
+				if (availablemons.Count == 0)
+				{
+					for (int j = 0; j < en.zone.Count; ++j)
+					{
+						if (en.zone[j].forms.Count < en.zone[j].max)
+						{
+							availablemons = availablemons.Union(en.zone[j].zonemons.Where(NotFeatured)).ToList();
+						}
+					}
+				}
+				// if we still don't have any mons available, then we can freely pick from all mon IDs that have yet to be featured
+				if (availablemons.Count == 0)
+				{
+					availablemons = uniqueEnemyIDs.Where(NotFeatured).ToList();
+					// and if we simply don't have mons available because they've all been featured, all mons are considered available (this should never execute)
+					if (availablemons.Count == 0)
+					{
+						availablemons = uniqueEnemyIDs.ToList();
+					}
+				}
+				// now we pick one of the availablemons at random as our first mon
+				f.Top = availablemons.PickRandom(rng);
+				f.tileset = enemy[f.Top].tileset; // and we pick the corresponding tileset
+				// we need to select which zone we are aiming to fill on the B-Side (and if we require a Large-only or Small-only formation to do that, we set the shape of the formation accordingly)
+				List<int> availablezones = en.enemyZones[f.Top].Where(index => en.zone[index].forms.Count < en.zone[index].min).ToList();
+				if (availablezones.Count == 0) // if there are no zones available that haven't reached their mincount, check for maxcount instead
+					availablezones = en.enemyZones[f.Top].Where(index => en.zone[index].forms.Count < en.zone[index].max).ToList();
+				if (availablezones.Count == 0) // and if we've filled mincount and maxcount, just list all available zones
+					availablezones = en.enemyZones[f.Top].ToList();
+				if (availablezones.Count == 0) // and if by some freak chance the enemy has not been assigned any zones, write an error report to Console and abort Formation shuffle
+				{
+					Console.WriteLine(f.Top);
+					Console.WriteLine(enemy[f.Top].exp);
+					Console.WriteLine("This Enemy Has No Zones");
+					return false;
+				}
+				int zoneB = availablezones.PickRandom(rng); // the B-Side zone we are trying to fill
+				int limit = Large(f.Top) ? 2 : 6;
+				if (enemy[f.Top].exp * limit < en.zone[zoneB].midXP)
+					f.shape = Large(f.Top) ? 0x01 : 0x00;
+				else
+				{
+					if (rng.Between(0, 2) == 0)
+						f.shape = Large(f.Top) ? 0x01 : 0x00;
+					else
+						f.shape = 0x02;
+				}
+				// now we look for what we can pick for the second mon
+				if (f.shape == 0x00)
+				{
+					availablemons = en.enemiesInTileset[f.tileset].Where(mon => SmallAndNotFeatured(mon, f.Top)).ToList();
+					if (availablemons.Count == 0)
+						availablemons = en.enemiesInTileset[f.tileset].Where(mon => Small(mon) && mon != f.Top).ToList();
+				}
+				else if (f.shape == 0x01)
+				{
+					availablemons = en.enemiesInTileset[f.tileset].Where(mon=> LargeAndNotFeatured(mon, f.Top)).ToList();
+					if (availablemons.Count == 0)
+						availablemons = en.enemiesInTileset[f.tileset].Where(mon => Large(mon) && mon != f.Top).ToList();
+				}
+				else
+				{
+					availablemons = en.enemiesInTileset[f.tileset].Where(mon => NotFeatured(mon) && mon != f.Top).ToList();
+					if (availablemons.Count == 0)
+						availablemons = en.enemiesInTileset[f.tileset].Where(mon => mon != f.Top).ToList(); // if all other mons in this tileset have been featured, all mons in this tileset are eligible as a second mon
+				}
+				f.id[1] = availablemons.PickRandom(rng); // and pick a random mon from the available IDs to be mon 2 (and the primary monster of the A-side)
+				// we will attempt to hit a zone with the A-Side but if we can't we'll just try to make an encounter as close as possible to the goal
+				availablezones = en.enemyZones[f.id[1]].Where(index => en.zone[index].forms.Count < en.zone[index].min).ToList();
+				if (availablezones.Count == 0) // if there are no zones available that haven't reached their mincount, check for maxcount instead
+					availablezones = en.enemyZones[f.id[1]].Where(index => en.zone[index].forms.Count < en.zone[index].max).ToList();
+				if (availablezones.Count == 0) // and if we've filled mincount and maxcount, just list all available zones
+					availablezones = en.enemyZones[f.id[1]].ToList();
+				if (availablezones.Count == 0) // and if by some freak chance the enemy has not been assigned any zones, write an error report to Console and abort Formation shuffle
+				{
+					Console.WriteLine(f.id[1]);
+					Console.WriteLine(enemy[f.id[1]].exp);
+					Console.WriteLine("This Enemy Has No Zones");
+					return false;
+				}
+				int zoneA = availablezones.PickRandom(rng);
+				// now we set the palettes
+				f.pal1 = enemy[f.Top].pal;
+				if (enemy[f.Top].pal != enemy[f.id[1]].pal)
+					f.pal2 = enemy[f.id[1]].pal;
+				else // if first and second enemies in the formation have the same palette, draw a second palette at random
+				{
+					List<byte> availablepalettes = en.palettesInTileset[f.tileset].Where(pal => pal != f.pal1).ToList();
+					if (availablepalettes.Count == 0)
+						f.pal2 = f.pal1; // if there is only one palette in the tileset, just set the second palette to the same value as the first
+					else
+						f.pal2 = availablepalettes.PickRandom(rng);
+				}
+				// and we draw any monsters that conform to both the tileset and palette choices as the third and fourth monsters (if there are more than two, they are dropped after a shuffle of the list)
+				availablemons = en.enemiesInTileset[f.tileset].Where(mon => mon != f.Top && mon != f.id[1] && (enemy[mon].pal == f.pal1 || enemy[mon].pal == f.pal2)).ToList();
+				switch (f.shape)
+				{
+					case 0x00:
+						availablemons = availablemons.Where(Small).ToList();
 						break;
-					}
+					case 0x01:
+						availablemons = availablemons.Where(Large).ToList();
+						break;
 				}
-				enemyImageLUT[enemyImage[Enemy.Pirate]] = 0b00000110; // and now assign the pirate himself his proper slot
-
-				// generate the palettes for each tileset
-				for (int i = 0; i < GenericTilesetsCount; ++i)
+				if (availablemons.Count > 0)
 				{
-					palettesInTileset[i].Clear();
-					while (palettesInTileset[i].Count < 4)
-					{
-						int newPal = rng.Between(0, 0x3F);
-						if (palettesInTileset[i].Contains((byte)newPal))
-							continue;
-						palettesInTileset[i].Add((byte)newPal);
-					}
+					availablemons.Shuffle(rng);
+					f.id[2] = availablemons[0];
+					if (availablemons.Count > 1)
+						f.id[3] = availablemons[1];
 				}
-
-				// clear the list of enemies in each tileset
-				enemiesInTileset[0].Clear();
-				enemiesInTileset[1].Clear();
-				enemiesInTileset[2].Clear();
-				enemiesInTileset[3].Clear();
-				enemiesInTileset[4].Clear();
-				enemiesInTileset[5].Clear();
-				enemiesInTileset[6].Clear();
-				enemiesInTileset[7].Clear();
-				enemiesInTileset[8].Clear();
-				enemiesInTileset[9].Clear();
-				enemiesInTileset[10].Clear();
-				enemiesInTileset[11].Clear();
-				enemiesInTileset[12].Clear();
-
-				// List of elementals already selected
-				List<int> elementalsSelected = new List<int> { 0, 1, 2, 3, 4, 5, 6, 7, 8 };
-				List<int> dragonsSelected = new List<int> { 0, 1, 2, 3, 4, 5, 6, 7, 8 };
-
-				// create lists of palettes used for each enemy image
-				List<byte>[] enemyImagePalettes = new List<byte>[52];
-				for(int i = 0; i < 52; ++i)
+				// now we can decide how many monsters to aim for in the formation.  we call two functions, one to draw the B-side, and another to draw the A-side
+				zoneB = ENF_Picker_Generic(en, enemy, rng, f, zoneB, 0, true);
+				if (zoneB != -1)
+					zoneA = ENF_Picker_Generic(en, enemy, rng, f, zoneA, 1, false);
+				if (zoneA == -1 || zoneB == -1)
 				{
-					enemyImagePalettes[i] = new List<byte> { };
+					en.featured[f.Top] = true;
+					en.featured[f.id[1]] = true;
+					--i;
+					continue; // loop again after setting the problematic monsters to featured status so they are de-prioritized and won't cause an infinite loop problem
 				}
-
-				// now start generating the enemies themselves.  we stop before Lich and make special exceptions for various monsters
-				for (byte i = 0; i < Enemy.Lich; ++i)
+				// assign the pic and palette bytes to each monster slot
+				ENF_AssignPicAndPaletteBytes(enemy, f);
+				// set surprise rate and unrunnability flags
+				f.unrunnable = rng.Between(0, 29) + (zoneA > zoneB ? zoneA : zoneB) >= 32 ? true : false; // unrunnable chance is higher for later zones
+				if (f.unrunnable)
+					f.surprise = (byte)rng.Between(3, 30);
+				else
 				{
-					// set up variables we want to work with
-					List<MonsterPerks> perks = new List<MonsterPerks> { MonsterPerks.PERK_GAINSTAT10, MonsterPerks.PERK_LOSESTAT10 }; // list of perks this monster is eligible to receive
-
-					// assign the monster's pic
-					enemyImage[i] = enemyImageLUT[enemyImage[i]];
-					int enemyTileset = (enemyImage[i] & 0b00111100) >> 2;
-					if(enemyTileset < 0 || enemyTileset > 12)
+					if (bossformations - surpcount.Sum() <= i)
 					{
-						// enemy not in a valid tileset - abort enemizer
-						return false;
-					}
-					enemyPics[i] = enemyImage[i] & 0b00000011;
-					enemyTilesets[i] = (byte)enemyTileset;
-					bool wasSmallOrBig = enemySmallOrBig[i]; // remember whether the base enemy was a small or big
-					if ((enemyImage[i] & 1) == 1) // and determine whether the new image is a small or a big
-						enemySmallOrBig[i] = true;
-					else
-						enemySmallOrBig[i] = false;
-					// assign the monster's palette.  do not allow the same palette to be used for the same pic
-					byte thisEnemyPalette = palettesInTileset[enemyTileset].PickRandom(rng);
-					while (enemyImagePalettes[enemyImage[i]].Contains(thisEnemyPalette))
-					{
-						thisEnemyPalette = palettesInTileset[enemyTileset].PickRandom(rng);
-					}
-					enemyImagePalettes[enemyImage[i]].Add(thisEnemyPalette);
-					enemyPalettes[i] = thisEnemyPalette;
-					// generate the stats for each monster
-					if(enemyTierList[i] == -1)
-					{
-						// generate special monsters
-						switch(i)
+						// automatically roll a surprise chance
+						int s_roll = rng.Between(1, surpcount.Sum());
+						int s_tier = -1;
+						if (s_roll <= surpcount[0])
+							s_tier = 0;
+						else if (s_roll <= surpcount[0] + surpcount[1] && s_roll > surpcount[0])
+							s_tier = 1;
+						else if (s_roll <= surpcount[0] + surpcount[1] + surpcount[2] && s_roll > surpcount[0] + surpcount[1])
+							s_tier = 2;
+						else if (s_roll <= surpcount[0] + surpcount[1] + surpcount[2] + surpcount[3] && s_roll > surpcount[0] + surpcount[1] + surpcount[2])
+							s_tier = 3;
+						if (s_tier == -1)
 						{
-							case Enemy.Imp:
-								enemyNames[i] = "BUM";
-								break;
-							case Enemy.Pirate:
-								break;
-							case Enemy.Phantom:
-								break;
-							case Enemy.Garland:
-								break;
-							case Enemy.Astos:
-								break;
-							case Enemy.WarMech:
-								break;
-						}
-					}
-					else
-					{
-						enemiesInTileset[enemyTileset].Add(i); // add enemy to enemiesInTileset unless it is a boss
-						// adjust HP, EXP, and GP if enemy changes size
-						if (wasSmallOrBig && !enemySmallOrBig[i]) // large became small
-						{
-							enemyStats[i].hp *= 4;
-							enemyStats[i].hp /= 5;
-							enemyStats[i].exp *= 9;
-							enemyStats[i].exp /= 10;
-							enemyStats[i].gp *= 9;
-							enemyStats[i].gp /= 10;
-						}
-						else if (!wasSmallOrBig && enemySmallOrBig[i]) // small became large
-						{
-							enemyStats[i].hp *= 5;
-							enemyStats[i].hp /= 4;
-							enemyStats[i].exp *= 10;
-							enemyStats[i].exp /= 9;
-							enemyStats[i].gp *= 10;
-							enemyStats[i].gp /= 9;
-						}
-						int elemental = 9; // track elemental affinity for certain classes of monsters (elementals and dragons)
-						// generate BASE stats for generic monsters and their base name
-						switch (enemyImage[i])
-						{
-							case 0: // Imp
-								enemyNames[i] = "IMP";
-								enemyStats[i].num_hits = rng.Between(1, 3);
-								enemyStats[i].critrate = rng.Between(1, 5);
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 5);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 3);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000100;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 1: // Iguana
-								enemyNames[i] = "SAUR";
-								enemyStats[i].num_hits = rng.Between(1, 3);
-								enemyStats[i].critrate = rng.Between(1, 5);
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 5);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 5);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 2);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000010;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 2: // Wolf
-								enemyNames[i] = "WOLF";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = rng.Between(1, 5);
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 5);
-								enemyStats[i].absorb = 0;
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 6);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000000;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								break;
-							case 3: // Giant
-								enemyNames[i] = "GIANT";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = rng.Between(1, 5);
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 6);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i],6);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 3);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000100;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								break;
-							case 4: // Sahag
-								enemyNames[i] = "SAHAG";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 2);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 3);
-								enemyStats[i].agility = 72 + enemyStats[i].exp / 40;
-								if (enemyStats[i].agility > 100)
-									enemyStats[i].agility = 100;
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00100000;
-								enemyStats[i].elem_resist = 0b10010000;
-								enemyStats[i].elem_weakness = 0b01000000;
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 5: // Shark
-								enemyNames[i] = "SHARK";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 6);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 5);
-								enemyStats[i].absorb = rng.Between(0, 8);
-								enemyStats[i].agility = 72 + enemyStats[i].exp / 40;
-								if (enemyStats[i].agility > 100)
-									enemyStats[i].agility = 100;
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00100000;
-								enemyStats[i].elem_resist = 0b10010000;
-								enemyStats[i].elem_weakness = 0b01000000;
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								break;
-							case 6: // Pirate
-								enemyNames[i] = "BRUTE";
-								enemyStats[i].num_hits = rng.Between(1, 2);
-								enemyStats[i].critrate = rng.Between(1, 5);
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000000;
-								enemyStats[i].elem_resist = 0b10000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 7: // Oddeye
-								enemyNames[i] = "EYE";
-								enemyStats[i].num_hits = rng.Between(1, 4);
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 2);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 5);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 2);
-								enemyStats[i].agility = enemyStats[i].exp > 400 ? rollEnemyEvade(enemyTierList[i], 4) : rollEnemyEvade(enemyTierList[i], 7);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00100000;
-								enemyStats[i].elem_resist = 0b10010000;
-								enemyStats[i].elem_weakness = 0b01000000;
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 8: // Skeleton
-								enemyNames[i] = "BONE";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = rng.Between(1, 2);
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 5);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 2);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00001000;
-								enemyStats[i].elem_resist = 0b00101011;
-								enemyStats[i].elem_weakness = 0b00010000;
-								break;
-							case 9: // Hyena
-								enemyNames[i] = "DOG";
-								enemyStats[i].num_hits = rng.Between(1, 2);
-								enemyStats[i].critrate = rng.Between(1, 3);
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
-								enemyStats[i].absorb = rng.Between(0, 12);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 5);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000000;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 10: // Creep
-								enemyNames[i] = "CRAWL";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 6);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000000;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00010000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 11: // Ogre
-								enemyNames[i] = "OGRE";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = rng.Between(1, 5);
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 5);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000100;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								break;
-							case 12: // Asp
-								enemyNames[i] = "ASP";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = rng.Between(1, 31);
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 3);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 5);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000010;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 13: // Bull
-								enemyNames[i] = "BULL";
-								enemyStats[i].num_hits = 2;
-								enemyStats[i].critrate = rng.Between(1, 3);
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 5);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 5);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000000;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 14: // Crab
-								enemyNames[i] = "CRAB";
-								enemyStats[i].num_hits = rng.Between(2, 4);
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 5);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 3);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 6);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000000;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								break;
-							case 15: // Troll
-								enemyNames[i] = "TROLL";
-								enemyStats[i].num_hits = 3;
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b10000000;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 16: // Spectral Undead
-								enemyNames[i] = "GHOST";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 6);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 3);
-								enemyStats[i].absorb = rng.Between(0, 4) == 4 ? rollEnemyAbsorb(enemyTierList[i], 4) : rng.Between(0, 8);
-								enemyStats[i].agility = rng.Between(0, 2) == 2 ? rollEnemyEvade(enemyTierList[i], 4) : rollEnemyEvade(enemyTierList[i], 7);
-								enemyStats[i].atk_elem = 0b00000001;
-								enemyStats[i].atk_ailment = enemyStats[i].exp < 150 ? (byte)0b00001000 : (byte)0b00010000; // darkness for low xp enemies, stun for high xp enemies
-								enemyStats[i].monster_type = 0b00001001;
-								enemyStats[i].elem_resist = 0b10101011;
-								enemyStats[i].elem_weakness = 0b00010000;
-								break;
-							case 17: // Worm
-								enemyNames[i] = "WORM";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 5);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 7);
-								enemyStats[i].absorb = enemyStats[i].exp < 100 ? rng.Between(0, 10) : (enemyStats[i].exp > 1200 ? rng.Between(10, 40) : rng.Between(10, 20));
-								enemyStats[i].agility = rng.Between(0, 60);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000000;
-								enemyStats[i].elem_resist = 0b10000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 18: // Zombie Undead
-								enemyNames[i] = "WIGHT";
-								enemyStats[i].num_hits = rng.Between(0, 4) == 4 || enemyStats[i].exp < 100 ? 1 : 3;
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = enemyStats[i].num_hits == 3 ? rollEnemyStrength(enemyTierList[i], 2) : rollEnemyStrength(enemyTierList[i], 4);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 2);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 2);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 5);
-								enemyStats[i].atk_elem = 0b00000001;
-								enemyStats[i].atk_ailment = enemyStats[i].exp > 80 ? (byte)0b00010000 : (byte)0b00000000;
-								enemyStats[i].monster_type = 0b00001000;
-								enemyStats[i].elem_resist = 0b00101011;
-								enemyStats[i].elem_weakness = 0b00010000;
-								break;
-							case 19: // Eyes that are totally not Beholders plz no sue
-								enemyNames[i] = "DRUJ";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 6);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 2);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b01000000;
-								enemyStats[i].elem_resist = 0b10000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								if (enemyStats[i].AIscript == 0xFF)
-									enemyStats[i].AIscript = ENE_PickForcedAIScript(enemyTierList[i]);
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 20: // Medusa
-								enemyNames[i] = "LAMIA";
-								enemyStats[i].num_hits = rng.Between(0, 1) == 1 ? 1 : rng.Between(6, 10);
-								enemyStats[i].critrate = rng.Between(1, 5);
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 2);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 2);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 5);
-								enemyStats[i].atk_elem = 0b00000001;
-								enemyStats[i].atk_ailment = enemyStats[i].exp > 200 ? (byte)0b00010000 : (byte)0b00000000;
-								enemyStats[i].monster_type = 0b00000000;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								break;
-							case 21: // Pede
-								enemyNames[i] = "PEDE";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 7);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 5);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 5);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000000;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								break;
-							case 22: // Were
-								enemyNames[i] = "CAT";
-								enemyStats[i].num_hits = rng.Between(2, 3);
-								enemyStats[i].critrate = rng.Between(1, 2);
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 5);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 5);
-								enemyStats[i].atk_elem = 0b00000010;
-								enemyStats[i].atk_ailment = 0b00000100;
-								enemyStats[i].monster_type = 0b00010000;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								break;
-							case 23: // Tiger
-								enemyNames[i] = "TIGER";
-								enemyStats[i].num_hits = 2;
-								enemyStats[i].critrate = rng.Between(20, 100);
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
-								enemyStats[i].absorb = 8;
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 5);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000000;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 24: // Blah, it's a Vampire!
-								enemyNames[i] = "VAMP";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = rng.Between(1, 5);
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 6);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 5);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 6);
-								enemyStats[i].atk_elem = 0b00000001;
-								enemyStats[i].atk_ailment = 0b00010000;
-								enemyStats[i].monster_type = 0b10001001;
-								enemyStats[i].elem_resist = 0b10101011;
-								enemyStats[i].elem_weakness = 0b00010000;
-								break;
-							case 25: // Large Elemental
-								if (elementalsSelected.Count > 0)
-									elemental = elementalsSelected.PickRandom(rng);
-								rollLargeElemental(rng, ref enemyStats[i], enemyTierList[i], elemental);
-								switch (elemental)
-								{
-									case 1:
-										enemyNames[i] = "EARTH";
-										break;
-									case 2:
-										enemyNames[i] = "STORM";
-										break;
-									case 3:
-										enemyNames[i] = "ICE";
-										break;
-									case 4:
-										enemyNames[i] = "FIRE";
-										break;
-									case 5:
-										enemyNames[i] = "DEATH";
-										break;
-									case 6:
-										enemyNames[i] = "CRONO";
-										break;
-									case 7:
-										enemyNames[i] = "VENOM";
-										break;
-									case 8:
-										enemyNames[i] = "DJINN";
-										break;
-									default:
-										enemyNames[i] = "FORCE";
-										break;
-								}
-								if (elemental != 9)
-									elementalsSelected.Remove(elemental);
-								break;
-							case 26: // Gargoyle
-								enemyNames[i] = "GOYLE";
-								enemyStats[i].num_hits = 4;
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 3);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 5);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000001;
-								enemyStats[i].elem_resist = 0b10000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 27: // Dragon Type 1
-								if (dragonsSelected.Count > 0)
-									elemental = dragonsSelected.PickRandom(rng);
-								rollDragon(rng, ref enemyStats[i], enemyTierList[i], elemental);
-								switch(elemental)
-								{
-									case 1:
-										enemyNames[i] = "Earth D";
-										break;
-									case 2:
-										enemyNames[i] = "Elec D";
-										break;
-									case 3:
-										enemyNames[i] = "Ice D";
-										break;
-									case 4:
-										enemyNames[i] = "Fire D";
-										break;
-									case 5:
-										enemyNames[i] = "Death D";
-										break;
-									case 6:
-										enemyNames[i] = "Time D";
-										break;
-									case 7:
-										enemyNames[i] = "Gas D";
-										break;
-									case 8:
-										enemyNames[i] = "Magic D";
-										break;
-									default:
-										enemyNames[i] = "DRAKE";
-										break;
-								}
-								if (elemental != 9)
-									dragonsSelected.Remove(elemental);
-								break;
-							case 28: // Slime
-								enemyNames[i] = "FLAN";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 6);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 2);
-								enemyStats[i].absorb = rng.Between(0, 2) == 2 ? rng.Between(0, 12) : 255;
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 1);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000001;
-								enemyStats[i].elem_weakness = (byte)(rng.Between(1, 6) << 4); // can be fire, ice, fire+ice, lit, fire+lit, or ice+lit weak
-								enemyStats[i].elem_resist = (byte)((0b11111111 ^ enemyStats[i].elem_weakness) & 0b11111011); // resist all other elements except time
-								break;
-							case 29: // Manticore
-								enemyNames[i] = "MANT";
-								enemyStats[i].num_hits = rng.Between(2, 3);
-								enemyStats[i].critrate = rng.Between(1, 3);
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 5);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 2);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 7);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000000;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 30: // Spider
-								enemyNames[i] = "BUG";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 3);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000000;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 31: // Ankylo
-								enemyNames[i] = "ANK";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = rng.Between(1, 3);
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 7);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 6);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 7);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000000;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								break;
-							case 32: // Mummy
-								enemyNames[i] = "MUMMY";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = rng.Between(1, 3);
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 3);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 5);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 3);
-								enemyStats[i].atk_elem = 0b00000001;
-								enemyStats[i].atk_ailment = 0b00100000;
-								enemyStats[i].monster_type = 0b00001000;
-								enemyStats[i].elem_resist = 0b00101011;
-								enemyStats[i].elem_weakness = 0b00010000;
-								break;
-							case 33: // Wyvern
-								enemyNames[i] = "WYRM";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 5);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 6);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
-								enemyStats[i].agility = 72 + enemyStats[i].exp / 40;
-								if (enemyStats[i].agility > 100)
-									enemyStats[i].agility = 100;
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000010;
-								enemyStats[i].elem_resist = 0b10000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								break;
-							case 34: // Jerk Bird
-								enemyNames[i] = "BIRD";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 3);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 3);
-								enemyStats[i].absorb = rng.Between(0, 8);
-								enemyStats[i].agility = 72;
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000000;
-								enemyStats[i].elem_resist = 0b10000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 35: // Steak
-								enemyNames[i] = "TYRO";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = rng.Between(20, 40);
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 7);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 7);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 2);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 6);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000010;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								break;
-							case 36: // Pirahna
-								enemyNames[i] = "FISH";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 2);
-								enemyStats[i].agility = 72;
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00100000;
-								enemyStats[i].elem_resist = 0b10010000;
-								enemyStats[i].elem_weakness = 0b01000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								break;
-							case 37: // Ocho
-								enemyNames[i] = "OCHO";
-								enemyStats[i].num_hits = 3;
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 6);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 5);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
-								enemyStats[i].atk_elem = 0b00000010;
-								enemyStats[i].atk_ailment = 0b00000100;
-								enemyStats[i].monster_type = 0b00100000;
-								enemyStats[i].elem_resist = 0b10010000;
-								enemyStats[i].elem_weakness = 0b01000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 38: // Gator
-								enemyNames[i] = "GATOR";
-								enemyStats[i].num_hits = rng.Between(2, 3);
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 6);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 5);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
-								enemyStats[i].agility = 48;
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00100010;
-								enemyStats[i].elem_resist = 0b10010000;
-								enemyStats[i].elem_weakness = 0b01000000;
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 39: // Hydra
-								enemyNames[i] = "HYDRA";
-								enemyStats[i].num_hits = 4;
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 5);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 5);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000010;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 40: // Robot
-								enemyNames[i] = "BOT";
-								enemyStats[i].num_hits = rng.Between(1, 2);
-								enemyStats[i].critrate = rng.Between(1, 5);
-								enemyStats[i].damage = enemyStats[i].num_hits == 1 ? rollEnemyStrength(enemyTierList[i], 7) : rollEnemyStrength(enemyTierList[i], 5);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 6);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 7);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 6);
-								enemyStats[i].atk_elem = 0b00000001;
-								enemyStats[i].atk_ailment = enemyStats[i].num_hits == 1 ? (byte)0b00000000 : (byte)0b00010000;
-								enemyStats[i].monster_type = 0b00000000;
-								enemyStats[i].elem_resist = 0b00001011;
-								enemyStats[i].elem_weakness = 0b01000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 41: // Naga
-								enemyNames[i] = "NAGA";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 1);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 7);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 2);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 6);
-								enemyStats[i].atk_elem = 0b00000010;
-								enemyStats[i].atk_ailment = 0b00000100;
-								enemyStats[i].monster_type = 0b01000000;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								if (enemyStats[i].AIscript == 0xFF)
-									enemyStats[i].AIscript = ENE_PickForcedAIScript(enemyTierList[i]);
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								break;
-							case 42: // Small Elemental
-								enemyNames[i] = "AIR";
-								if (elementalsSelected.Count > 0)
-									elemental = elementalsSelected.PickRandom(rng);
-								rollSmallElemental(rng, ref enemyStats[i], enemyTierList[i], elemental);
-								switch (elemental)
-								{
-									case 1:
-										enemyNames[i] = "SHARD";
-										break;
-									case 2:
-										enemyNames[i] = "WIND";
-										break;
-									case 3:
-										enemyNames[i] = "WATER";
-										break;
-									case 4:
-										enemyNames[i] = "FLARE";
-										break;
-									case 5:
-										enemyNames[i] = "DOOM";
-										break;
-									case 6:
-										enemyNames[i] = "TIME";
-										break;
-									case 7:
-										enemyNames[i] = "BANE";
-										break;
-									case 8:
-										enemyNames[i] = "MAGIC";
-										break;
-									default:
-										enemyNames[i] = "AIR";
-										break;
-								}
-								if (elemental != 9)
-									elementalsSelected.Remove(elemental);
-								break;
-							case 43: // Chimera
-								enemyNames[i] = "BEAST";
-								enemyStats[i].num_hits = 4;
-								enemyStats[i].critrate = rng.Between(1, 3);
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 6);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 6);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 6);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000010;
-								enemyStats[i].elem_resist = 0b10010000;
-								enemyStats[i].elem_weakness = 0b00100000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 44: // Piscodemon
-								enemyNames[i] = "SQUID";
-								enemyStats[i].num_hits = rng.Between(2, 3);
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 5);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 5);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 6);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000000;
-								enemyStats[i].elem_resist = 0b00110011;
-								enemyStats[i].elem_weakness = 0b00000000;
-								break;
-							case 45: // Dragon Type 2
-								if (dragonsSelected.Count > 0)
-									elemental = dragonsSelected.PickRandom(rng);
-								rollDragon(rng, ref enemyStats[i], enemyTierList[i], elemental);
-								switch (elemental)
-								{
-									case 1:
-										enemyNames[i] = "Earth D";
-										break;
-									case 2:
-										enemyNames[i] = "Elec D";
-										break;
-									case 3:
-										enemyNames[i] = "Ice D";
-										break;
-									case 4:
-										enemyNames[i] = "Fire D";
-										break;
-									case 5:
-										enemyNames[i] = "Death D";
-										break;
-									case 6:
-										enemyNames[i] = "Time D";
-										break;
-									case 7:
-										enemyNames[i] = "Gas D";
-										break;
-									case 8:
-										enemyNames[i] = "Magic D";
-										break;
-									default:
-										enemyNames[i] = "DRAGON";
-										break;
-								}
-								if (elemental != 9)
-									dragonsSelected.Remove(elemental);
-								break;
-							case 46: // Knight Type 1
-								enemyNames[i] = "KNIGHT";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = rng.Between(1, 10);
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 5);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 5);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 5);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 5);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000000;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 47: // Golem
-								enemyNames[i] = "GOLEM";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 6);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
-								enemyStats[i].absorb = rng.Between(7, 60);
-								if (enemyStats[i].exp > 4000)
-									enemyStats[i].absorb = (enemyStats[i].absorb * 2) + 30;
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000000;
-								enemyStats[i].elem_resist = 0b11111011;
-								if(enemyStats[i].absorb > 60)
-								{
-									switch(rng.Between(0, 2))
-									{
-										case 0:
-											enemyStats[i].elem_resist &= 0b10111111;
-											break;
-										case 1:
-											enemyStats[i].elem_resist &= 0b11011111;
-											break;
-										case 2:
-											enemyStats[i].elem_resist &= 0b11101111;
-											break;
-									}
-								}
-								enemyStats[i].elem_weakness = 0b00000000;
-								break;
-							case 48: // Knight Type 2
-								enemyNames[i] = "RANGER";
-								enemyStats[i].num_hits = rng.Between(1, 2);
-								enemyStats[i].critrate = rng.Between(1, 5);
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 6);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 6);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 6);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000000;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 49: // Pony
-								enemyNames[i] = "PONY";
-								enemyStats[i].num_hits = rng.Between(2, 4);
-								enemyStats[i].critrate = rng.Between(1, 3);
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 5);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 5);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 4);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 6);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b00000000;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								break;
-							case 50: // Elf
-								enemyNames[i] = "ELF";
-								enemyStats[i].num_hits = 1;
-								enemyStats[i].critrate = rng.Between(1, 5);
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 4);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 4);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 6);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 7);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b01000000;
-								enemyStats[i].elem_resist = 0b00000000;
-								enemyStats[i].elem_weakness = 0b00000000;
-								if (enemyStats[i].AIscript == 0xFF)
-									enemyStats[i].AIscript = ENE_PickForcedAIScript(enemyTierList[i]);
-								perks.Add(MonsterPerks.PERK_LOWRESIST);
-								perks.Add(MonsterPerks.PERK_HIGHRESIST);
-								perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
-								perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
-								perks.Add(MonsterPerks.PERK_PLUSONEHIT);
-								perks.Add(MonsterPerks.PERK_POISONTOUCH);
-								perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
-								perks.Add(MonsterPerks.PERK_MUTETOUCH);
-								break;
-							case 51: // War Machine
-								enemyNames[i] = "MECH";
-								enemyStats[i].num_hits = 2;
-								enemyStats[i].critrate = 1;
-								enemyStats[i].damage = rollEnemyStrength(enemyTierList[i], 7);
-								enemyStats[i].accuracy = rollEnemyAccuracy(enemyTierList[i], 7);
-								enemyStats[i].absorb = rollEnemyAbsorb(enemyTierList[i], 7);
-								enemyStats[i].agility = rollEnemyEvade(enemyTierList[i], 4);
-								enemyStats[i].atk_elem = 0b00000000;
-								enemyStats[i].atk_ailment = 0b00000000;
-								enemyStats[i].monster_type = 0b10000000;
-								enemyStats[i].elem_resist = 0b00111011;
-								enemyStats[i].elem_weakness = 0b01000000;
-								enemyStats[i].exp *= 9;
-								enemyStats[i].exp /= 8;
-								break;
-						}
-						bool hasGlobalPerk = false;
-						bool didntChooseVariantClass = true; // false if this monster rolled a variant class and thus doesn't need a name modifier
-						// if enemy has a global perk, apply it now and skip all other perks
-						if (i == Enemy.Crawl)
-						{
-							// Global Perk - multi-hitter with weak attacks but stun touch guaranteed (overrides existing atk ailment)
-							enemyStats[i].atk_elem = 0b00000001;
-							enemyStats[i].atk_ailment = 0b00010000;
-							enemyStats[i].num_hits = 8;
-							enemyStats[i].damage = 1;
-							hasGlobalPerk = true;
-						}
-						else if(i == Enemy.Coctrice)
-						{
-							// Global Perk - stonetouch (overrides other atk_elem and ailment), -1 hit if num_hits > 1
-							enemyStats[i].atk_elem = 0b00000010;
-							enemyStats[i].atk_ailment = 0b00000010;
-							if (enemyStats[i].num_hits > 1)
-								enemyStats[i].num_hits--;
-							hasGlobalPerk = true;
-						}
-						else if(i == Enemy.Mancat)
-						{
-							// Global Perk - Mancat (resistance to all elements except time and no weaknesses)
-							enemyStats[i].elem_resist = 0b11111011;
-							enemyStats[i].elem_weakness = 0b00000000;
-							hasGlobalPerk = true;
-						}
-						else if(i == Enemy.Sorceror)
-						{
-							// Global Perk - deathtouch
-							enemyStats[i].atk_elem = 0b00000000;
-							enemyStats[i].atk_ailment = 0b00000001;
-							hasGlobalPerk = true;
-						}
-						else if(i == Enemy.Nitemare)
-						{
-							// Global Perk - resist all except one low element and time, weak to selected element
-							switch(rng.Between(0,2))
-							{
-								case 0:
-									enemyStats[i].elem_resist = 0b10111011;
-									enemyStats[i].elem_weakness = 0b01000000;
-									break;
-								case 1:
-									enemyStats[i].elem_resist = 0b11011011;
-									enemyStats[i].elem_weakness = 0b00100000;
-									break;
-								case 2:
-									enemyStats[i].elem_resist = 0b11101011;
-									enemyStats[i].elem_weakness = 0b00010000;
-									break;
-							}
+							f.surprise = (byte)rng.Between(3, 9);
 						}
 						else
 						{
-							// else, roll the chance for an enemy to get a class modifier.  Each class of monster can have Frost, Red, Zombie, Were, and Wizard variants, though some monster classes can't use some of these
-							// this perk restricts the monster from rolling any other perks
-							if (rng.Between(0, 11) < monsterClassVariants[enemyImage[i]].Count())
+							f.surprise = (byte)rng.Between(surprisetiers[s_tier, 0], surprisetiers[s_tier, 1]);
+							surpcount[s_tier]--;
+						}
+					}
+					else
+					{
+						// random chance to roll additional surprise rate
+						int s_tier = -1;
+						int s_roll = rng.Between(regularformations, bossformations);
+						if (s_roll > bossformations - surp4)
+							s_tier = 3;
+						else if (s_roll > bossformations - surp4 - surp3)
+							s_tier = 2;
+						else if (s_roll > bossformations - surp4 - surp3 - surp2)
+							s_tier = 1;
+						else if (s_roll > bossformations - surp4 - surp3 - surp2 - surp1)
+							s_tier = 0;
+						if (s_tier == -1)
+						{
+							f.surprise = (byte)rng.Between(3, 9);
+						}
+						else
+						{
+							if (surpcount[s_tier] > 0)
 							{
-								didntChooseVariantClass = false;
-								string classModifier = monsterClassVariants[enemyImage[i]].PickRandom(rng);
-								switch (classModifier) // apply the traits of this enemy class
-								{
-									case "Wz":
-										if(enemyStats[i].AIscript == 0xFF)
-										{
-											enemyStats[i].AIscript = ENE_PickForcedAIScript(enemyTierList[i]);
-										}
-										break;
-									case "Fr":
-										enemyStats[i].elem_resist |= 0b00100000;
-										enemyStats[i].elem_resist &= 0b11101111;
-										enemyStats[i].elem_weakness |= 0b00010000;
-										enemyStats[i].elem_weakness &= 0b11011111;
-										enemyStats[i].atk_elem = 0b00100000;
-										break;
-									case "R.":
-										enemyStats[i].elem_resist |= 0b00010000;
-										enemyStats[i].elem_resist &= 0b11011111;
-										enemyStats[i].elem_weakness |= 0b00100000;
-										enemyStats[i].elem_weakness &= 0b11101111;
-										enemyStats[i].atk_elem = 0b00010000;
-										break;
-									case "Z.":
-										enemyStats[i].elem_resist |= 0b00101011;
-										enemyStats[i].elem_resist &= 0b11101111;
-										enemyStats[i].elem_weakness |= 0b00010000;
-										enemyStats[i].elem_weakness &= 0b11010100;
-										enemyStats[i].monster_type |= 0b00001000;
-										if(enemyStats[i].atk_ailment == 0)
-										{
-											enemyStats[i].atk_ailment = 0b00010000;
-											enemyStats[i].atk_elem = 0b00000001;
-										}
-										break;
-									case "Sea":
-										enemyStats[i].elem_resist |= 0b10010000;
-										enemyStats[i].elem_resist &= 0b10111111;
-										enemyStats[i].elem_weakness |= 0b01000000;
-										enemyStats[i].elem_weakness &= 0b01101111;
-										enemyStats[i].monster_type |= 0b00100000;
-										break;
-									case "Wr":
-										enemyStats[i].atk_ailment = 0b00000100;
-										enemyStats[i].atk_elem = 0b00000010;
-										enemyStats[i].monster_type |= 0b00010000;
-										break;
-								}
-								enemyNames[i] = classModifier + enemyNames[i]; // change the enemy's name
-								monsterClassVariants[enemyImage[i]].Remove(classModifier); // remove this variant from the list of variants available for this enemy image
+								f.surprise = (byte)rng.Between(surprisetiers[s_tier, 0], surprisetiers[s_tier, 1]);
+								surpcount[s_tier]--;
+							}
+							else
+							{
+								f.surprise = (byte)rng.Between(3, 9);
 							}
 						}
-						if(didntChooseVariantClass)
-						{
-							// else, roll minor perks.  there is a 75% chance to gain a perk, then 62.5%, 50%, and so on.  monsters cannot gain more than 4 perks
-							int num_perks = 0;
-							if(!hasGlobalPerk)
-							{
-								while (rng.Between(0, 7) > 1 + num_perks && num_perks < 4)
-								{
-									// select from the list of available perks
-									MonsterPerks this_perk = perks.PickRandom(rng);
-									bool didPerkRoll = true;
-									switch (this_perk)
-									{
-										case MonsterPerks.PERK_GAINSTAT10: // pick a random stat to increase by 10%, +3% XP
-											switch (rng.Between(0, 2))
-											{
-												case 0:
-													enemyStats[i].hp *= 11;
-													enemyStats[i].hp /= 10;
-													break;
-												case 1:
-													enemyStats[i].damage *= 11;
-													enemyStats[i].damage /= 10;
-													break;
-												case 2:
-													enemyStats[i].absorb *= 11;
-													enemyStats[i].absorb /= 10;
-													break;
-											}
-											enemyStats[i].exp *= 103;
-											enemyStats[i].exp /= 100;
-											break;
-										case MonsterPerks.PERK_LOSESTAT10: // pick a random stat to decrease by 10%, -3% XP
-											switch (rng.Between(0, 2))
-											{
-												case 0:
-													enemyStats[i].hp *= 9;
-													enemyStats[i].hp /= 10;
-													break;
-												case 1:
-													enemyStats[i].damage *= 9;
-													enemyStats[i].damage /= 10;
-													break;
-												case 2:
-													enemyStats[i].absorb *= 9;
-													enemyStats[i].absorb /= 10;
-													break;
-											}
-											enemyStats[i].exp *= 97;
-											enemyStats[i].exp /= 100;
-											break;
-										case MonsterPerks.PERK_LOWRESIST: // pick a low resist or remove the corresponding weakness, +4% XP
-											switch (rng.Between(0, 3))
-											{
-												case 0:
-													if ((enemyStats[i].elem_weakness & 0b10000000) == 0b10000000)
-														enemyStats[i].elem_weakness &= 0b01111111;
-													else
-														enemyStats[i].elem_resist |= 0b10000000;
-													break;
-												case 1:
-													if ((enemyStats[i].elem_weakness & 0b01000000) == 0b01000000)
-														enemyStats[i].elem_weakness &= 0b10111111;
-													else
-														enemyStats[i].elem_resist |= 0b01000000;
-													break;
-												case 2:
-													if ((enemyStats[i].elem_weakness & 0b00100000) == 0b00100000)
-														enemyStats[i].elem_weakness &= 0b11011111;
-													else
-														enemyStats[i].elem_resist |= 0b00100000;
-													break;
-												case 3:
-													if ((enemyStats[i].elem_weakness & 0b00010000) == 0b00001000)
-														enemyStats[i].elem_weakness &= 0b11101111;
-													else
-														enemyStats[i].elem_resist |= 0b00010000;
-													break;
-											}
-											enemyStats[i].exp *= 104;
-											enemyStats[i].exp /= 100;
-											break;
-										case MonsterPerks.PERK_LOWWEAKNESS: // pick a low weakness (or cancel a resist, or ignore for earth resist), -5% XP
-											switch (rng.Between(0, 3))
-											{
-												case 0:
-													if ((enemyStats[i].elem_resist & 0b10000000) == 0b10000000)
-														didPerkRoll = false;
-													else
-														enemyStats[i].elem_weakness |= 0b10000000;
-													break;
-												case 1:
-													if ((enemyStats[i].elem_resist & 0b01000000) == 0b01000000)
-														enemyStats[i].elem_resist &= 0b10111111;
-													else
-														enemyStats[i].elem_weakness |= 0b01000000;
-													break;
-												case 2:
-													if ((enemyStats[i].elem_resist & 0b00100000) == 0b00100000)
-														enemyStats[i].elem_resist &= 0b11011111;
-													else
-														enemyStats[i].elem_weakness |= 0b00100000;
-													break;
-												case 3:
-													if ((enemyStats[i].elem_resist & 0b00010000) == 0b00010000)
-														enemyStats[i].elem_resist &= 0b11101111;
-													else
-														enemyStats[i].elem_weakness |= 0b00010000;
-													break;
-											}
-											if (didPerkRoll)
-											{
-												enemyStats[i].exp *= 95;
-												enemyStats[i].exp /= 100;
-											}
-											break;
-										case MonsterPerks.PERK_HIGHRESIST:  // pick a high resist and remove the corresponding weakness, +3% XP
-											switch (rng.Between(0, 3))
-											{
-												case 0:
-													enemyStats[i].elem_resist |= 0b00001000;
-													enemyStats[i].elem_weakness &= 0b11110111;
-													break;
-												case 1:
-													enemyStats[i].elem_resist |= 0b00000100;
-													enemyStats[i].elem_weakness &= 0b11111011;
-													break;
-												case 2:
-													enemyStats[i].elem_resist |= 0b00000010;
-													enemyStats[i].elem_weakness &= 0b11111101;
-													break;
-												case 3:
-													enemyStats[i].elem_resist |= 0b00000001;
-													enemyStats[i].elem_weakness &= 0b11111110;
-													break;
-											}
-											enemyStats[i].exp *= 103;
-											enemyStats[i].exp /= 100;
-											break;
-										case MonsterPerks.PERK_HIGHWEAKNESS:
-											switch (rng.Between(0, 3))
-											{
-												case 0:
-													if ((enemyStats[i].elem_resist & 0b00001000) == 0b00001000)
-														enemyStats[i].elem_resist &= 0b11110111;
-													else
-														enemyStats[i].elem_weakness |= 0b00001000;
-													break;
-												case 1:
-													if ((enemyStats[i].elem_resist & 0b00000100) == 0b00000100)
-														enemyStats[i].elem_resist &= 0b11111011;
-													else
-														enemyStats[i].elem_weakness |= 0b00000100;
-													break;
-												case 2:
-													if ((enemyStats[i].elem_resist & 0b00000010) == 0b00000010)
-														enemyStats[i].elem_resist &= 0b11111101;
-													else
-														enemyStats[i].elem_weakness |= 0b00000010;
-													break;
-												case 3:
-													if ((enemyStats[i].elem_resist & 0b00000001) == 0b00000001)
-														enemyStats[i].elem_resist &= 0b11111110;
-													else
-														enemyStats[i].elem_weakness |= 0b00000001;
-													break;
-											}
-											if (didPerkRoll)
-											{
-												enemyStats[i].exp *= 97;
-												enemyStats[i].exp /= 100;
-											}
-											break;
-										case MonsterPerks.PERK_PLUSONEHIT: // +1 hit, +5/3/2/1... XP for an addition hit
-											enemyStats[i].num_hits++;
-											switch (enemyStats[i].num_hits)
-											{
-												case 2:
-													enemyStats[i].exp *= 21;
-													enemyStats[i].exp /= 20;
-													break;
-												case 3:
-													enemyStats[i].exp *= 103;
-													enemyStats[i].exp /= 100;
-													break;
-												case 4:
-													enemyStats[i].exp *= 51;
-													enemyStats[i].exp /= 50;
-													break;
-												default:
-													enemyStats[i].exp *= 101;
-													enemyStats[i].exp /= 100;
-													break;
-											}
-											break;
-										case MonsterPerks.PERK_POISONTOUCH: // adds poisontouch if enemy has no atk_ailment already, no XP increase
-											if (enemyStats[i].atk_ailment == 0)
-											{
-												enemyStats[i].atk_ailment = 0b00000100;
-												enemyStats[i].atk_elem = 0b00000010;
-											}
-											break;
-										case MonsterPerks.PERK_STUNSLEEPTOUCH: // adds stun or sleep touch if enemy has no atk_ailment already
-											if (enemyStats[i].atk_ailment == 0)
-											{
-												enemyStats[i].atk_ailment = rng.Between(0, 1) == 0 ? (byte)0b00100000 : (byte)0b00010000;
-												enemyStats[i].atk_elem = 0b00000001;
-												enemyStats[i].exp *= 103;
-												enemyStats[i].exp /= 100;
-											}
-											break;
-										case MonsterPerks.PERK_MUTETOUCH: // adds mute touch if enemy has no atk_ailment already
-											if (enemyStats[i].atk_ailment == 0)
-											{
-												enemyStats[i].atk_ailment = 0b01000000;
-												enemyStats[i].atk_elem = 0b00000001;
-												enemyStats[i].exp *= 51;
-												enemyStats[i].exp /= 50;
-											}
-											break;
-									}
-									num_perks++;
-								}
-							}
-							// if enemy's vanilla name has already been used, add a name modifier
-							if(elemental == 9) // don't make alternate names for elementals
-							{
-								if (monsterBaseNameUsed[enemyImage[i]])
-								{
-									string nameModifier = monsterNameVariants[enemyImage[i]].PickRandom(rng);
-									enemyNames[i] = nameModifier + enemyNames[i];
-								}
-								else
-									monsterBaseNameUsed[enemyImage[i]] = true;
-							}
-						}
-						if (enemyStats[i].AIscript != 0xFF) // set monster type to Mage if it has a script
-							enemyStats[i].monster_type |= 0b01000000;
-						for(int j = 1; j < enemyStats[i].num_hits; ++j) // for each hit past the first, reduce the base damage by one for every 15 points of damage rating
-						{
-							enemyStats[i].damage = enemyStats[i].damage - enemyStats[i].damage / 15;
-						}
-						enemyStats[i].damage = rng.Between(enemyStats[i].damage - enemyStats[i].damage / 25, enemyStats[i].damage + enemyStats[i].damage / 25); // variance for damage rating
-						enemyStats[i].hp = rng.Between(enemyStats[i].hp - enemyStats[i].hp / 30, enemyStats[i].hp + enemyStats[i].hp / 30); // variance for hp rating
-						enemyStats[i].gp = rng.Between(enemyStats[i].gp - enemyStats[i].gp / 20, enemyStats[i].gp + enemyStats[i].gp / 20); // variance for gp reward
-						enemyStats[i].exp = rng.Between(enemyStats[i].exp - enemyStats[i].exp / 40, enemyStats[i].exp + enemyStats[i].exp / 40); // variance for exp reward
 					}
 				}
-				// remove palettes from tilesets where there are no mons using those palettes
-				for(int i = 0; i < GenericTilesetsCount; ++i)
-				{
-					List<byte> palRemoveList = new List<byte> { };
-					foreach(byte pal in palettesInTileset[i])
-					{
-						bool nopalettematch = true;
-						foreach(byte mon in enemiesInTileset[i])
-						{
-							if(enemyPalettes[mon] == pal)
-							{
-								nopalettematch = false;
-								break;
-							}
-						}
-						if(nopalettematch)
-						{
-							palRemoveList.Add(pal);
-						}
-					}
-					foreach(byte pal in palRemoveList)
-					{
-						palettesInTileset[i].Remove(pal);
-					}
-				}
-				// modify scripts - all scripts that are skills-only gain a magic list full of spells in the same tier (with 24/128 chance of activating)
-				// each spell is then selected from a list of spells available for that tier.  it is not possible to promote to a higher tier
-				// skills will remain the same
-				for(int i = 0; i < ScriptCount - 10; ++i) // exclude the last 10 scripts
-				{
-					if(enemyScripts[i].spell_chance == 0)
-					{
-						byte whichSpell = 0; // index for CURE, a tier 1 enemy spell
-						switch (ENE_GetEnemySkillTier(enemyScripts[i].skill_list[0]))
-						{
-							case 2:
-								whichSpell = 5; // these are just spell indices of spells that correspond to the tier, we will replace them later
-								break;
-							case 3:
-								whichSpell = 21;
-								break;
-							case 4:
-								whichSpell = 37;
-								break;
-							case 5:
-								whichSpell = 0xFF; // if a tier 5 is encountered, we don't fill the spell list (the skill is nasty enough!) - by default this only applies to warmech
-								break;
-						}
-						for(byte j = 0; j < 8; ++j)
-						{
-							enemyScripts[i].spell_list[j] = whichSpell;
-						}
-						if(whichSpell != 0xFF)
-							enemyScripts[i].spell_chance = 24;
-					}
-					// start replacing each spell with another spell from the same tier
-					for(byte j = 0; j < 8; ++j)
-					{
-						if (enemyScripts[i].spell_list[j] == 0xFF)
-							continue; // skip blank spells
-						int whichTier = ENE_GetEnemySpellTier(enemyScripts[i].spell_list[j]);
-						List<byte> eligibleSpellIDs = new List<byte> { };
-						for(byte k = 0; k < 64; ++k)
-						{
-							if (ENE_GetEnemySpellTier(k) == whichTier)
-								eligibleSpellIDs.Add(k);
-						}
-						enemyScripts[i].spell_list[j] = eligibleSpellIDs.PickRandom(rng);
-					}
-				}
-
-				num_enemy_name_chars = 0;
-				for (int i = 0; i < EnemyCount; ++i)
-				{
-					num_enemy_name_chars += enemyNames[i].Length;
-				}
-				Console.WriteLine(num_enemy_name_chars);
-				return true;
+				// add the A-Side and B-Side to their respective zones
+				en.zone[zoneA].forms.Add(i);
+				en.zone[zoneB].forms.Add((byte)(i | 0x80));
+				// log and compress this formation
+				en.LogFeatured(f);
+				formationData[i] = f.compressData();
 			}
+			en.PrintFormationInfo();
+			// now we will place enemies in their proper domains
+			// load the addresses of all known trap tiles (these addresses are hardcoded for now - i'm not going to consider altered maps)
+			traptile_addresses[(int)TrapTiles.TRAP_IMAGES] = 0x1B3;
+			traptile_addresses[(int)TrapTiles.TRAP_MUMMIES] = 0x1B5;
+			traptile_addresses[(int)TrapTiles.TRAP_MUDGOLS] = 0x1B7;
+			traptile_addresses[(int)TrapTiles.TRAP_NITEMARES] = 0x1B9;
+			traptile_addresses[(int)TrapTiles.TRAP_ZOMBIE_D] = 0x1BB;
+			traptile_addresses[(int)TrapTiles.TRAP_GARGOYLES] = 0x541;
+			traptile_addresses[(int)TrapTiles.TRAP_SEAFOOD_PARTY_MIX] = 0x543;
+			traptile_addresses[(int)TrapTiles.TRAP_SHARKNADO] = 0x545;
+			traptile_addresses[(int)TrapTiles.TRAP_WATERS] = 0x547;
+			traptile_addresses[(int)TrapTiles.TRAP_SEASHRINE_MUMMIES] = 0x549;
+			traptile_addresses[(int)TrapTiles.TRAP_ZOMBIES] = 0x5A5;
+			traptile_addresses[(int)TrapTiles.TRAP_GARGOYLES2] = 0x5A9;
+			traptile_addresses[(int)TrapTiles.TRAP_GIANTS] = 0x237;
+			traptile_addresses[(int)TrapTiles.TRAP_GIANTS_IGUANAS] = 0x239;
+			traptile_addresses[(int)TrapTiles.TRAP_EARTH] = 0x23B;
+			traptile_addresses[(int)TrapTiles.TRAP_OGRES_HYENAS] = 0x23D;
+			traptile_addresses[(int)TrapTiles.TRAP_SPHINX] = 0x243;
+			traptile_addresses[(int)TrapTiles.TRAP_FIRE] = 0x245;
+			traptile_addresses[(int)TrapTiles.TRAP_GREYWORM] = 0x247;
+			traptile_addresses[(int)TrapTiles.TRAP_AGAMA] = 0x25F;
+			traptile_addresses[(int)TrapTiles.TRAP_RED_D] = 0x281;
+			traptile_addresses[(int)TrapTiles.TRAP_UNDEAD_PARTYMIX] = 0x381;
+			traptile_addresses[(int)TrapTiles.TRAP_FROSTRURUS] = 0x383;
+			traptile_addresses[(int)TrapTiles.TRAP_FROSTGIANT] = 0x385;
+			traptile_addresses[(int)TrapTiles.TRAP_MAGES] = 0x387;
+			traptile_addresses[(int)TrapTiles.TRAP_FROST_D] = 0x389;
+			traptile_addresses[(int)TrapTiles.TRAP_EYE] = 0x38B;
+			traptile_addresses[(int)TrapTiles.TRAP_WATERFALL_MUMMIES] = 0x391;
+			traptile_addresses[(int)TrapTiles.TRAP_WIZARDS] = 0x433;
+			traptile_addresses[(int)TrapTiles.TRAP_WIZARDS2] = 0x435;
+			traptile_addresses[(int)TrapTiles.TRAP_COBRAS] = 0x437;
+			traptile_addresses[(int)TrapTiles.TRAP_BLUE_D] = 0x439;
+			traptile_addresses[(int)TrapTiles.TRAP_SLIMES] = 0x43B;
+			traptile_addresses[(int)TrapTiles.TRAP_PHANTOM] = 0x7AD;
 
-			public int rollEnemyStrength(int tier, int level)
+			// assign monsters to trap tiles
+			traptile_formations[(int)TrapTiles.TRAP_IMAGES] = en.zone[3].forms[0];
+			traptile_formations[(int)TrapTiles.TRAP_MUMMIES] = en.zone[3].forms[1];
+			traptile_formations[(int)TrapTiles.TRAP_MUDGOLS] = en.zone[6].forms[0];
+			traptile_formations[(int)TrapTiles.TRAP_NITEMARES] = en.zone[6].forms[1];
+			traptile_formations[(int)TrapTiles.TRAP_ZOMBIE_D] = en.zombieD_encounter;
+			traptile_formations[(int)TrapTiles.TRAP_GARGOYLES] = en.zone[2].forms[0];
+			traptile_formations[(int)TrapTiles.TRAP_SEAFOOD_PARTY_MIX] = en.zone[8].forms[0];
+			traptile_formations[(int)TrapTiles.TRAP_SHARKNADO] = en.zone[8].forms[1];
+			traptile_formations[(int)TrapTiles.TRAP_WATERS] = en.zone[8].forms[2];
+			traptile_formations[(int)TrapTiles.TRAP_SEASHRINE_MUMMIES] = en.zone[8].forms[3];
+			traptile_formations[(int)TrapTiles.TRAP_ZOMBIES] = en.zone[0].forms[0];
+			traptile_formations[(int)TrapTiles.TRAP_GARGOYLES2] = en.zone[2].forms[1];
+			traptile_formations[(int)TrapTiles.TRAP_GIANTS] = en.zone[4].forms[0];
+			traptile_formations[(int)TrapTiles.TRAP_GIANTS_IGUANAS] = en.zone[4].forms[1];
+			traptile_formations[(int)TrapTiles.TRAP_EARTH] = en.zone[4].forms[2];
+			traptile_formations[(int)TrapTiles.TRAP_OGRES_HYENAS] = en.zone[4].forms[3];
+			traptile_formations[(int)TrapTiles.TRAP_SPHINX] = en.zone[5].forms[0];
+			traptile_formations[(int)TrapTiles.TRAP_FIRE] = en.zone[5].forms[1];
+			traptile_formations[(int)TrapTiles.TRAP_GREYWORM] = en.zone[5].forms[2];
+			traptile_formations[(int)TrapTiles.TRAP_AGAMA] = en.zone[5].forms[3];
+			traptile_formations[(int)TrapTiles.TRAP_RED_D] = en.zone[5].forms[4];
+			traptile_formations[(int)TrapTiles.TRAP_UNDEAD_PARTYMIX] = en.zone[5].forms[5];
+			traptile_formations[(int)TrapTiles.TRAP_FROSTRURUS] = en.zone[5].forms[6];
+			traptile_formations[(int)TrapTiles.TRAP_FROSTGIANT] = en.zone[5].forms[7];
+			traptile_formations[(int)TrapTiles.TRAP_MAGES] = en.zone[5].forms[8];
+			traptile_formations[(int)TrapTiles.TRAP_FROST_D] = en.zone[5].forms[9];
+			traptile_formations[(int)TrapTiles.TRAP_EYE] = en.eye_encounter;
+			traptile_formations[(int)TrapTiles.TRAP_WATERFALL_MUMMIES] = en.zone[8].forms[3];
+			traptile_formations[(int)TrapTiles.TRAP_WIZARDS] = en.wizard_encounter;
+			traptile_formations[(int)TrapTiles.TRAP_WIZARDS2] = en.wizard_encounter;
+			traptile_formations[(int)TrapTiles.TRAP_COBRAS] = en.zone[3].forms[2];
+			traptile_formations[(int)TrapTiles.TRAP_BLUE_D] = en.zone[9].forms[0];
+			traptile_formations[(int)TrapTiles.TRAP_SLIMES] = en.zone[9].forms[1];
+			traptile_formations[(int)TrapTiles.TRAP_PHANTOM] = en.phantom_encounter;
+			// proceed to place mons in all zones
+			foreach(Enemizer_Zone zone in en.zone)
 			{
-				int[,] returnValue = new int[,] {
+				zone.forms.Shuffle(rng);
+				int loop = 0;
+				int f = 0;
+				int a = 0;
+				while(f < zone.forms.Count)
+				{
+					if (loop == 0)
+					{
+						for (int j = 0; j < 8; ++j)
+						{
+							dom[zone.addr[a] + j] = zone.forms[f]; // first loop: fill the domain with the encounter
+						}
+					}
+					if (loop == 1)
+					{
+						for (int j = 0; j < 8; j += 2)
+						{
+							dom[zone.addr[a] + j] = zone.forms[f]; // second loop: 1, 3, 5, and 7 are filled with the second formation
+						}
+					}
+					if (loop == 2)
+					{
+						dom[zone.addr[a] + 2] = zone.forms[f]; // third loop: 3, 6, and 8 are filled with the third encounter
+						dom[zone.addr[a] + 5] = zone.forms[f];
+						dom[zone.addr[a] + 7] = zone.forms[f];
+					}
+					if (loop == 3)
+					{
+						dom[zone.addr[a] + 3] = zone.forms[f]; // fourth loop: 4 and 7 are filled with the 4th encounter
+						dom[zone.addr[a] + 6] = zone.forms[f];
+					}
+					if (loop == 4)
+					{
+						dom[zone.addr[a] + 4] = zone.forms[f]; // fifth loop: 5 and 6 are filled with the 5th encounter
+						dom[zone.addr[a] + 5] = zone.forms[f];
+					}
+					if (loop > 4)
+					{
+						dom[zone.addr[a] + loop] = zone.forms[f]; // sixth-eigth loop: slot 6, 7, or 8 is filled depending on which loop we are at
+					}
+					f++;
+					a++;
+					if (a == zone.addr.Length)
+					{
+						a = 0;
+						loop++;
+						if (loop == 8)
+							break; // place no more than 8 encounters per domain even if formations are left to be placed (this should basically never happen)
+					}
+				}
+			}
+			// duplicate entries in the overworld that clone other areas
+			foreach (int[] array in en.zoneclone)
+			{
+				byte[] dataToCopy = new byte[8];
+				for (int i = 0; i < 8; ++i)
+				{
+					dataToCopy[i] = dom[array[0] + i];
+				}
+				for (int i = 1; i < array.Length; ++i)
+				{
+					for (int j = 0; j < 8; ++j)
+					{
+						dom[array[i] + j] = dataToCopy[j];
+					}
+				}
+			}
+			// special zone placement for overworld 4,4 and 4,5: replace the first four encounters with imp encounter
+			dom[0x120] = en.imp_encounter; dom[0x121] = en.imp_encounter; dom[0x122] = en.imp_encounter; dom[0x123] = en.imp_encounter;
+			dom[0x160] = en.imp_encounter; dom[0x161] = en.imp_encounter; dom[0x162] = en.imp_encounter; dom[0x123] = en.imp_encounter;
+			dom[0x39E] = en.warmech_encounter; // replace 7th encounter on sky 5F with warmech
+			for (int i = 0; i < FormationDataCount; ++i) // write formation info to ROM
+				Put(FormationDataOffset + i * FormationDataSize, formationData[i]);
+			Put(ZoneFormationsOffset, dom); // write the domain data as one big chunk
+			// write trap tile information
+			for (int i = 0; i < traptile_addresses.Length; ++i)
+			{
+				Data[TilesetDataOffset + traptile_addresses[i]] = traptile_formations[i];
+			}
+			return true;
+		}
+
+		public int ENF_Picker_Generic(EnemizerTrackingInfo en, EnemyInfo[] enemy, MT19337 rng, FormationInfo f, int zone, int p, bool sideB)
+		{
+			bool Small(byte mon) => enemy[mon].Small;
+			bool Large(byte mon) => enemy[mon].Large;
+			// draw A-Side formation, prioritizing the priority monster (defaults to f.id[0] if given an invalid priority)
+			if (p < 0 || p > 3)
+				p = 0;
+			if (f.id[p] == 0xFF)
+				p = 0;
+			if (f.id[p] == 0xFF)
+				return -1; // do not draw mons if there is no valid mon as priority
+			int o = sideB ? 4 : 0; // increase offset by 4 when placing a side B encounter
+			int s = sideB ? 1 : 3; // indicates where we stop looping through ids (stop at 1 for sideB since ids 2 and 3 cannot be placed in side B encounters, stop at 3 otherwise)
+			f.monMin[p + o] = 1; // there will always be at least one mon of the priority
+			f.monMax[p + o] = 1;
+			int minXP = enemy[f.id[p]].exp;
+			int maxXP = enemy[f.id[p]].exp;
+			int smallLimit = 0, largeLimit = 0;
+			switch (f.shape)
+			{
+				case 0x00:
+					smallLimit = 9;
+					largeLimit = 0;
+					break;
+				case 0x01:
+					smallLimit = 0;
+					largeLimit = 4;
+					break;
+				case 0x02:
+					smallLimit = 6;
+					largeLimit = 2;
+					break;
+			}
+			if (Large(f.id[p]))
+				largeLimit--;
+			else
+				smallLimit--;
+			List<int> validindices = new List<int> { }; // no weighting selection towards priority in A-Side
+			List<int> trashindices = new List<int> { }; // list of "trash mons" that may be optionally added in after general mon selection
+			for (int i = 0; i < s; ++i)
+			{
+				if (f.id[i] == 0xFF)
+					continue; // don't include mons with an invalid index
+				int sizeFactor = Large(f.id[i]) ? 6 : 12;
+				if (enemy[f.id[i]].exp > en.zone[zone].maxXP / sizeFactor)
+					validindices.Add(i); // valid monsters must contribute significant experience for their size
+				else if (Small(f.id[i]))
+					trashindices.Add(i);
+			}
+			if (validindices.Count == 0) // if we have no valid indices (possible if some zones), we use the minimum-maximum instead of total max
+			{
+				trashindices.Clear();
+				for (int i = 0; i < s; ++i)
+				{
+					if (f.id[i] == 0xFF)
+						continue; // don't include mons with an invalid index
+					int sizeFactor = Large(f.id[i]) ? 6 : 12;
+					if (enemy[f.id[i]].exp > en.zone[zone].midXP / sizeFactor)
+						validindices.Add(i); // valid monsters must contribute experience equal to 1/12th of the xp cap for this zone
+					else if (Small(f.id[i]))
+						trashindices.Add(i);
+				}
+			}
+			while ((smallLimit > 0 || largeLimit > 0) && validindices.Count > 0)
+			{
+				if (rng.Between(0, 14) == 0 && maxXP > en.zone[zone].midXP)
+					break; // 6.66% chance of ending the while loop if we have already met the minimum-maximum
+				int index = validindices.PickRandom(rng);
+				if (maxXP + enemy[f.id[index]].exp <= en.zone[zone].maxXP && ((Large(f.id[index]) && largeLimit > 0) || (Small(f.id[index]) && smallLimit > 0)))
+				{
+					f.monMax[index + o]++;
+					maxXP += enemy[f.id[index]].exp;
+					if (Large(f.id[index]))
+						largeLimit--;
+					else
+						smallLimit--;
+				}
+				else
+				{
+					validindices.Remove(index);
+				}
+			}
+			// now, hopefully, we got the minimum-maximums we wanted from that.  time to raise minimums
+			validindices = new List<int> { };
+			for (int i = 0; i < s; ++i)
+			{
+				if (f.id[i] == 0xFF)
+					continue;
+				if (f.monMax[i + o] > 0)
+					validindices.Add(i); // add any monster that has a maxcount
+			}
+			while (minXP < en.zone[zone].minXP && validindices.Count > 0)
+			{
+				int index = validindices.PickRandom(rng);
+				if (f.monMin[index + o] < f.monMax[index + o])
+				{
+					f.monMin[index + o]++;
+					minXP += enemy[f.id[index]].exp;
+				}
+				else
+					validindices.Remove(index);
+			}
+			// set the minimums to a random number between the current minimum and the maximum
+			for (int i = 0; i < s; ++i)
+			{
+				f.monMin[i + o] = rng.Between(f.monMin[i + o], f.monMax[i + o]);
+			}
+			// if there is space, we can add 1-2 of each trash index (so long as they do not exceed the zone's maximum).  only smalls can be trash mons.
+			if (trashindices.Count > 0 && smallLimit > 0)
+			{
+				for (int i = 0; i < trashindices.Count; ++i)
+				{
+					if (rng.Between(0, 2) == 0) // 33% chance of rejecting a trash index
+					{
+						if (Small(f.id[trashindices[i]]))
+						{
+							if (maxXP + enemy[f.id[trashindices[i]]].exp < en.zone[zone].maxXP)
+							{
+								smallLimit--;
+								f.monMax[trashindices[i]]++;
+								maxXP += enemy[f.id[trashindices[i]]].exp;
+							}
+							if (rng.Between(0, 1) == 0) // 50% chance of adding a second trash mon of the same type
+							{
+								if (maxXP + enemy[f.id[trashindices[i]]].exp < en.zone[zone].maxXP)
+								{
+									smallLimit--;
+									f.monMax[trashindices[i]]++;
+									maxXP += enemy[f.id[trashindices[i]]].exp;
+								}
+							}
+						}
+					}
+				}
+			}
+			// if we were able to conform to all requirements of the zone, return false, but if we couldn't conform to the zone requirements return true so we know to calc the new zone
+			return ENF_Calc_Zone(en, enemy, f, sideB);
+		}
+
+		public int ENF_Calc_Zone(EnemizerTrackingInfo en, EnemyInfo[] enemy, FormationInfo f, bool sideB)
+		{
+			// calculates a zone for the encounter to fit if we couldn't reach our goal zone (return -1 if the zone is completely invalid)
+			int return_value = -1;
+			List<int> acceptableValues = new List<int> { };
+			int minXP = 0, maxXP = 0;
+			int o = sideB ? 4 : 0;
+			int s = sideB ? 1 : 3;
+			for (int i = 0; i < s; ++i)
+			{
+				if (f.id[i] == 0xFF)
+					continue;
+				if (f.monMax[i + o] > 0)
+				{
+					minXP += f.monMin[i + o] * enemy[f.id[i]].exp;
+					maxXP += f.monMax[i + o] * enemy[f.id[i]].exp;
+				}
+			}
+			for (int i = 0; i < en.zone.Count; ++i)
+			{
+				if (minXP >= en.zone[i].minXP && maxXP >= en.zone[i].midXP && maxXP <= en.zone[i].maxXP)
+					acceptableValues.Add(i);
+			}
+			List<int> mincountValues = acceptableValues.Where(id => en.zone[id].forms.Count < en.zone[id].min).ToList();
+			if (mincountValues.Count == 0)
+				mincountValues = acceptableValues.Where(id => en.zone[id].forms.Count < en.zone[id].max).ToList();
+			if (mincountValues.Count > 0)
+				return_value = mincountValues.Max();
+			else
+			{
+				if (acceptableValues.Count > 0)
+					return_value = acceptableValues.Max();
+			}
+			return ENF_ApproveFormation(f, return_value);
+		}
+
+		public int ENF_ApproveFormation(FormationInfo f, int zone)
+		{
+			// approves a formation based on the zone it has been assigned.  this will be used to rule out formations that might be problematic
+			// for now this function does nothing but it will be used in future to reject certain formations
+			if (zone == -1)
+				return zone; // formations which have already been calculated as failed will be rejected
+			return zone;
+		}
+
+		private byte[] ENF_DrawBossEncounter(EnemizerTrackingInfo en, MT19337 rng, EnemyInfo[] enemy, byte id, int count, int shape, bool unrunnable, byte surprise, byte formid)
+		{
+			bool Small(byte mon) => enemy[mon].Small;
+			bool Large(byte mon) => enemy[mon].Large;
+
+			FormationInfo f = new FormationInfo();
+			f.id[2] = id; // we place the boss monster in the third slot
+			f.tileset = enemy[id].tileset;
+			f.pal1 = enemy[id].pal;
+			f.shape = shape;
+			f.monMin[2] = count;
+			f.monMax[2] = count; // always produce the necessary number of enemies
+			// draw mons for B-Side
+			List<byte> availablemons = en.enemiesInTileset[f.tileset].ToList();
+			switch (f.shape)
+			{
+				case 0x00:
+					availablemons = availablemons.Where(Small).ToList();
+					break;
+				case 0x01:
+					availablemons = availablemons.Where(Large).ToList();
+					break;
+			}
+			if (availablemons.Count > 0)
+			{
+				f.Top = availablemons.PickRandom(rng);
+				f.pal2 = enemy[f.Top].pal;
+				availablemons = availablemons.Where(mon => mon != f.Top && mon != f.id[2] && (enemy[mon].pal == f.pal1 || enemy[mon].pal == f.pal2)).ToList();
+				if (availablemons.Count > 0)
+				{
+					f.id[1] = availablemons.PickRandom(rng);
+				}
+				int zoneB = en.enemyZones[f.Top].PickRandom(rng);
+				zoneB = ENF_Picker_Generic(en, enemy, rng, f, zoneB, 0, true);
+				if (zoneB != -1)
+					en.zone[zoneB].forms.Add((byte)(formid | 0x80)); // if for some reason we didn't fill any valid zone from the B-side, we simply don't add it to any zones (and thus it will never be seen)
+			}
+			// if for some reason there were no available mons, then a B-Side is not drawn at all and no formation is added to the zones, so this slot will remain unused.  this shouldn't happen, though
+			ENF_AssignPicAndPaletteBytes(enemy, f);
+			f.unrunnable = unrunnable;
+			f.surprise = surprise;
+			en.LogFeatured(f);
+			return f.compressData();
+		}
+
+		public byte[] ENF_DrawForcedSingleFight(EnemizerTrackingInfo en, MT19337 rng, EnemyInfo[] enemy, int zoneB, byte formid)
+		{
+			bool Small(byte mon) => enemy[mon].Small;
+			bool Large(byte mon) => enemy[mon].Large;
+
+			FormationInfo f = new FormationInfo();
+			f.Top = en.zone[zoneB].zonemons.PickRandom(rng);
+			f.tileset = enemy[f.Top].tileset;
+			int limit = Large(f.Top) ? 2 : 6;
+			if (enemy[f.Top].exp * limit < en.zone[zoneB].maxXP)
+				f.shape = Large(f.Top) ? 0x01 : 0x00;
+			else
+				f.shape = 0x02;
+			f.monMax[4] = en.zone[zoneB].maxXP / enemy[f.Top].exp;
+			if (f.monMax[4] > en.GetMonLimit(Large(f.Top), f.shape))
+				f.monMax[4] = en.GetMonLimit(Large(f.Top), f.shape);
+			f.monMin[4] = en.zone[zoneB].midXP / enemy[f.Top].exp;
+			if (f.monMin[4] > f.monMax[4])
+				f.monMin[4] = f.monMax[4];
+			if (f.monMax[4] == 0) // this should never execute but just in case
+			{
+				f.monMin[4] = 1;
+				f.monMax[4] = 1;
+			}
+			if (f.monMin[4] == 0)
+				f.monMin[4] = 1;
+			// draw all potential mons for A-Side
+			List<byte> availablemons = en.enemiesInTileset[f.tileset].Where(mon => mon != f.Top).ToList();
+			switch (f.shape)
+			{
+				case 0x00:
+					availablemons = availablemons.Where(Small).ToList();
+					break;
+				case 0x01:
+					availablemons = availablemons.Where(Large).ToList();
+					break;
+			}
+			f.id[1] = availablemons.PickRandom(rng);
+			f.pal1 = enemy[f.Top].pal;
+			f.pal2 = enemy[f.id[1]].pal; // if these are both the same, i don't really care
+			availablemons = en.enemiesInTileset[f.tileset].Where(mon => mon != f.Top && mon != f.id[1] && (enemy[mon].pal == f.pal1 || enemy[mon].pal == f.pal2)).ToList();
+			switch (f.shape)
+			{
+				case 0x00:
+					availablemons = availablemons.Where(Small).ToList();
+					break;
+				case 0x01:
+					availablemons = availablemons.Where(Large).ToList();
+					break;
+			}
+			if (availablemons.Count > 0)
+			{
+				availablemons.Shuffle(rng);
+				f.id[2] = availablemons[0];
+				if (availablemons.Count > 1)
+					f.id[3] = availablemons[1];
+			}
+			int zoneA = en.enemyZones[f.id[1]].PickRandom(rng); // pick a random zone to aim for from the second mon
+			zoneA = ENF_Picker_Generic(en, enemy, rng, f, zoneA, 1, false); // now we actually run the generic picker
+			en.zone[zoneB].forms.Add((byte)(formid | 0x80));
+			if (zoneA != -1)
+				en.zone[zoneA].forms.Add(formid); // if for some reason we didn't fill any valid zone from the A-side, we simply don't add it to any zones (and thus it will never be seen)
+			f.surprise = 4;
+			f.unrunnable = true; // these fights are always unrunnable
+			// put on the finishing touches and log and compress this formation
+			ENF_AssignPicAndPaletteBytes(enemy, f);
+			en.LogFeatured(f);
+			return f.compressData();
+		}
+
+		public byte ENF_PickAVamp(EnemyInfo[] enemy, List<byte> uniqueEnemyIDs, MT19337 rng)
+		{
+			// picks a random vampire for the Earth Cave fight.  priority is given to vampires that give out less than 3000 experience points, then to any monster under 3000 experience points
+			List<byte> vamps = uniqueEnemyIDs.Where(mon => enemy[mon].image == 24 && enemy[mon].exp <= 3000).ToList();
+			if (vamps.Count == 0)
+				vamps = uniqueEnemyIDs.Where(mon => enemy[mon].exp <= 3000).ToList();
+			return vamps.PickRandom(rng);
+		}
+
+		public int ENE_rollEnemyStrength(int tier, int level)
+		{
+			int[,] returnValue = new int[,] {
 					{ 3, 6, 11, 16, 19, 25, 33, 40, 50, 61},
 					{ 4, 9, 15, 19, 22, 29, 38, 45, 55, 68},
 					{ 6, 12, 17, 22, 26, 32, 43, 50, 60, 75},
@@ -2502,14 +1332,14 @@ namespace FF1Lib
 					{ 9, 16, 22, 28, 34, 42, 54, 61, 75, 92},
 					{ 10, 18, 25, 31, 38, 47, 60, 70, 82, 100},
 					{ 12, 20, 28, 35, 42, 53, 70, 85, 95, 110} };
-				if (tier < 0 || level < 1 || tier > 9 || level > 7)
-					return 0; // return 0 if the tier/level are out of bounds
-				return returnValue[level - 1, tier];
-			}
+			if (tier < 0 || level < 1 || tier > 9 || level > 7)
+				return 0; // return 0 if the tier/level are out of bounds
+			return returnValue[level - 1, tier];
+		}
 
-			public int rollEnemyAccuracy(int tier, int level)
-			{
-				int[,] returnValue = new int[,] {
+		public int ENE_rollEnemyAccuracy(int tier, int level)
+		{
+			int[,] returnValue = new int[,] {
 					{ 1, 6, 11, 16, 19, 25, 33, 40, 50, 61},
 					{ 2, 9, 15, 19, 22, 29, 38, 45, 55, 68},
 					{ 4, 12, 17, 22, 26, 32, 43, 50, 60, 75},
@@ -2517,14 +1347,14 @@ namespace FF1Lib
 					{ 8, 16, 22, 28, 34, 42, 54, 61, 75, 92},
 					{ 10, 18, 25, 31, 38, 47, 60, 70, 82, 100},
 					{ 12, 20, 30, 40, 50, 60, 70, 85, 95, 110} };
-				if (tier < 0 || level < 1 || tier > 9 || level > 7)
-					return 0; // return 0 if the tier/level are out of bounds
-				return returnValue[level - 1, tier];
-			}
+			if (tier < 0 || level < 1 || tier > 9 || level > 7)
+				return 0; // return 0 if the tier/level are out of bounds
+			return returnValue[level - 1, tier];
+		}
 
-			public int rollEnemyAbsorb(int tier, int level)
-			{
-				int[,] returnValue = new int[,] {
+		public int ENE_rollEnemyAbsorb(int tier, int level)
+		{
+			int[,] returnValue = new int[,] {
 					{ 1, 2, 3, 4, 5, 6, 7, 8, 10, 12},
 					{ 2, 3, 5, 7, 9, 12, 14, 17, 20, 24},
 					{ 3, 5, 7, 9, 12, 14, 17, 20, 24, 30},
@@ -2532,14 +1362,14 @@ namespace FF1Lib
 					{ 5, 8, 11, 14, 18, 22, 26, 30, 34, 46},
 					{ 8, 12, 16, 20, 25, 30, 35, 40, 45, 53},
 					{ 10, 14, 19, 25, 30, 36, 42, 49, 56, 68 } };
-				if (tier < 0 || level < 1 || tier > 9 || level > 7)
-					return 0; // return 0 if the tier/level are out of bounds
-				return returnValue[level - 1, tier];
-			}
+			if (tier < 0 || level < 1 || tier > 9 || level > 7)
+				return 0; // return 0 if the tier/level are out of bounds
+			return returnValue[level - 1, tier];
+		}
 
-			public int rollEnemyEvade(int tier, int level)
-			{
-				int[,] returnValue = new int[,] {
+		public int ENE_rollEnemyEvade(int tier, int level)
+		{
+			int[,] returnValue = new int[,] {
 					{ 1, 3, 6, 8, 10, 12, 15, 18, 21, 24},
 					{ 3, 6, 9, 12, 15, 18, 21, 24, 27, 30},
 					{ 6, 9, 12, 16, 21, 26, 30, 35, 40, 45},
@@ -2547,1371 +1377,2186 @@ namespace FF1Lib
 					{ 20, 24, 30, 36, 42, 48, 54, 60, 70, 80},
 					{ 36, 42, 48, 54, 60, 66, 72, 78, 90, 102},
 					{ 48, 54, 64, 72, 80, 90, 100, 115, 125, 140} };
-				if (tier < 0 || level < 1 || tier > 9 || level > 7)
-					return 0; // return 0 if the tier/level are out of bounds
-				return returnValue[level - 1, tier];
-			}
+			if (tier < 0 || level < 1 || tier > 9 || level > 7)
+				return 0; // return 0 if the tier/level are out of bounds
+			return returnValue[level - 1, tier];
+		}
 
-			public void rollLargeElemental(MT19337 rng, ref EnemyData thisEnemy, int tier, int element)
+		public void ENE_rollLargeElemental(MT19337 rng, ref EnemyInfo thisEnemy, int element)
+		{
+			int tier = thisEnemy.tier;
+			switch (element)
 			{
-				switch(element)
-				{
-					case 1: // Earth Elemental
-						thisEnemy.num_hits = 1;
-						thisEnemy.critrate = 1;
-						thisEnemy.damage = rollEnemyStrength(tier, 7);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 7);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 5);
-						thisEnemy.agility = rollEnemyEvade(tier, 2);
-						thisEnemy.atk_elem = 0b10000000;
-						thisEnemy.atk_ailment = 0b00000000;
-						thisEnemy.monster_type = 0b00000001;
-						thisEnemy.elem_resist = 0b11101011;
-						thisEnemy.elem_weakness = 0b00010000;
-						break;
-					case 2: // Lightning Elemental
-						thisEnemy.num_hits = 1;
-						thisEnemy.critrate = 20;
-						thisEnemy.damage = rollEnemyStrength(tier, 5);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 5);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 2);
-						thisEnemy.agility = rollEnemyEvade(tier, 6);
-						thisEnemy.atk_elem = 0b01000000;
-						thisEnemy.atk_ailment = 0b00100000;
-						thisEnemy.monster_type = 0b00000001;
-						thisEnemy.elem_resist = 0b11011001;
-						thisEnemy.elem_weakness = 0b00000110;
-						break;
-					case 3: // Ice Elemental
-						thisEnemy.num_hits = 1;
-						thisEnemy.critrate = 1;
-						thisEnemy.damage = rollEnemyStrength(tier, 5);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 7);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 6);
-						thisEnemy.agility = rollEnemyEvade(tier, 2);
-						thisEnemy.atk_elem = 0b00100000;
-						thisEnemy.atk_ailment = 0b00010000;
-						thisEnemy.monster_type = 0b00000001;
-						thisEnemy.elem_resist = 0b11101011;
-						thisEnemy.elem_weakness = 0b00010000;
-						break;
-					case 4: // Fire Elemental
-						thisEnemy.num_hits = 1;
-						thisEnemy.critrate = 1;
-						thisEnemy.damage = rollEnemyStrength(tier, 6);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 7);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 5);
-						thisEnemy.agility = rollEnemyEvade(tier, 2);
-						thisEnemy.atk_elem = 0b00010000;
-						thisEnemy.atk_ailment = 0b00000000;
-						thisEnemy.monster_type = 0b00000001;
-						thisEnemy.elem_resist = 0b11011011;
-						thisEnemy.elem_weakness = 0b00100000;
-						break;
-					case 5: // Death Elemental
-						thisEnemy.num_hits = 2;
-						thisEnemy.critrate = 1;
-						thisEnemy.damage = rollEnemyStrength(tier, 7);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 4);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 4);
-						thisEnemy.agility = rollEnemyEvade(tier, 4);
-						thisEnemy.atk_elem = 0b00001000;
-						thisEnemy.atk_ailment = 0b00001000;
-						thisEnemy.monster_type = 0b00001001;
-						thisEnemy.elem_resist = 0b10101011;
-						thisEnemy.elem_weakness = 0b00010000;
-						break;
-					case 6: // Time Elemental
-						thisEnemy.num_hits = rng.Between(4, 6);
-						thisEnemy.critrate = 1;
-						thisEnemy.damage = rollEnemyStrength(tier, 4);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 4);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 4);
-						thisEnemy.agility = rollEnemyEvade(tier, 5);
-						thisEnemy.atk_elem = 0b00000100;
-						thisEnemy.atk_ailment = 0b00010000;
-						thisEnemy.monster_type = 0b00000001;
-						thisEnemy.elem_resist = 0b10001111;
-						thisEnemy.elem_weakness = 0b01110000;
-						break;
-					case 7: // Poison Elemental
-						thisEnemy.num_hits = 1;
-						thisEnemy.critrate = 1;
-						thisEnemy.damage = rollEnemyStrength(tier, 6);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 7);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 2);
-						thisEnemy.agility = rollEnemyEvade(tier, 6);
-						thisEnemy.atk_elem = 0b00000010;
-						thisEnemy.atk_ailment = 0b00000100;
-						thisEnemy.monster_type = 0b10000001;
-						thisEnemy.elem_resist = 0b10001011;
-						thisEnemy.elem_weakness = 0b00000000;
-						break;
-					case 8: // Status Elemental
-						thisEnemy.num_hits = 1;
-						thisEnemy.critrate = 3;
-						thisEnemy.damage = rollEnemyStrength(tier, 4);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 7);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 5);
-						thisEnemy.agility = rollEnemyEvade(tier, 5);
-						thisEnemy.atk_elem = 0b00000001;
-						thisEnemy.atk_ailment = 0b01000000;
-						thisEnemy.monster_type = 0b00000001;
-						thisEnemy.elem_resist = 0b11111011;
-						thisEnemy.elem_weakness = 0b00000000;
-						if (thisEnemy.AIscript == 0xFF)
-						{
-							thisEnemy.AIscript = ENE_PickForcedAIScript(tier);
-						}
-						break;
-					default: // Raw Mana Elemental
-						thisEnemy.num_hits = 1;
-						thisEnemy.critrate = 1;
-						thisEnemy.damage = rollEnemyStrength(tier, 5);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 5);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 5);
-						thisEnemy.agility = rollEnemyEvade(tier, 2);
-						thisEnemy.atk_elem = 0b00000000;
-						thisEnemy.atk_ailment = 0b00000000;
-						thisEnemy.monster_type = 0b00000001;
-						thisEnemy.elem_resist = 0b11111011;
-						thisEnemy.elem_weakness = 0b00000000;
-						break;
-				}
-			}
-
-			public void rollSmallElemental(MT19337 rng, ref EnemyData thisEnemy, int tier, int element)
-			{
-				switch (element)
-				{
-					case 1: // Earth Elemental
-						thisEnemy.num_hits = 1;
-						thisEnemy.critrate = 1;
-						thisEnemy.damage = rollEnemyStrength(tier, 6);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 7);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 5);
-						thisEnemy.agility = rollEnemyEvade(tier, 2);
-						thisEnemy.atk_elem = 0b10000000;
-						thisEnemy.atk_ailment = 0b00000000;
-						thisEnemy.monster_type = 0b00000001;
-						thisEnemy.elem_resist = 0b10101011;
-						thisEnemy.elem_weakness = 0b01010000;
-						break;
-					case 2: // Lightning Elemental
-						thisEnemy.num_hits = 1;
-						thisEnemy.critrate = 10;
-						thisEnemy.damage = rollEnemyStrength(tier, 5);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 5);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 2);
-						thisEnemy.agility = rollEnemyEvade(tier, 6);
-						thisEnemy.atk_elem = 0b01000000;
-						thisEnemy.atk_ailment = 0b00100000;
-						thisEnemy.monster_type = 0b00000001;
-						thisEnemy.elem_resist = 0b11011001;
-						thisEnemy.elem_weakness = 0b00000110;
-						break;
-					case 3: // Water Elemental
-						thisEnemy.num_hits = 1;
-						thisEnemy.critrate = 1;
-						thisEnemy.damage = rollEnemyStrength(tier, 6);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 6);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 4);
-						thisEnemy.agility = rollEnemyEvade(tier, 5);
-						thisEnemy.atk_elem = 0b00100000;
-						thisEnemy.atk_ailment = 0b00000000;
-						thisEnemy.monster_type = 0b00000001;
-						thisEnemy.elem_resist = 0b10011011;
-						thisEnemy.elem_weakness = 0b00100000;
-						break;
-					case 4: // Fire Elemental
-						thisEnemy.num_hits = 1;
-						thisEnemy.critrate = 1;
-						thisEnemy.damage = rollEnemyStrength(tier, 5);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 6);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 3);
-						thisEnemy.agility = rollEnemyEvade(tier, 6);
-						thisEnemy.atk_elem = 0b00010000;
-						thisEnemy.atk_ailment = 0b00000000;
-						thisEnemy.monster_type = 0b00000001;
-						thisEnemy.elem_resist = 0b10011001;
-						thisEnemy.elem_weakness = 0b00100000;
-						break;
-					case 5: // Death Elemental
-						thisEnemy.num_hits = 2;
-						thisEnemy.critrate = 1;
-						thisEnemy.damage = rollEnemyStrength(tier, 7);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 4);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 4);
-						thisEnemy.agility = rollEnemyEvade(tier, 4);
-						thisEnemy.atk_elem = 0b00001000;
-						thisEnemy.atk_ailment = 0b00001000;
-						thisEnemy.monster_type = 0b00001001;
-						thisEnemy.elem_resist = 0b10101011;
-						thisEnemy.elem_weakness = 0b00010000;
-						break;
-					case 6: // Time Elemental
-						thisEnemy.num_hits = rng.Between(2, 5);
-						thisEnemy.critrate = 1;
-						thisEnemy.damage = rollEnemyStrength(tier, 4);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 4);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 4);
-						thisEnemy.agility = rollEnemyEvade(tier, 5);
-						thisEnemy.atk_elem = 0b00000100;
-						thisEnemy.atk_ailment = 0b00010000;
-						thisEnemy.monster_type = 0b00000001;
-						thisEnemy.elem_resist = 0b10001111;
-						thisEnemy.elem_weakness = 0b01110000;
-						break;
-					case 7: // Poison Elemental
-						thisEnemy.num_hits = 1;
-						thisEnemy.critrate = 1;
-						thisEnemy.damage = rollEnemyStrength(tier, 6);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 7);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 2);
-						thisEnemy.agility = rollEnemyEvade(tier, 6);
-						thisEnemy.atk_elem = 0b00000010;
-						thisEnemy.atk_ailment = 0b00100000;
-						thisEnemy.monster_type = 0b10000001;
-						thisEnemy.elem_resist = 0b10001011;
-						thisEnemy.elem_weakness = 0b00000100;
-						break;
-					case 8: // Status Elemental
-						thisEnemy.num_hits = 2;
-						thisEnemy.critrate = 3;
-						thisEnemy.damage = rollEnemyStrength(tier, 4);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 4);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 4);
-						thisEnemy.agility = rollEnemyEvade(tier, 4);
-						thisEnemy.atk_elem = 0b00000001;
-						thisEnemy.atk_ailment = 0b01000000;
-						thisEnemy.monster_type = 0b00000001;
-						thisEnemy.elem_resist = 0b11111011;
-						thisEnemy.elem_weakness = 0b00000000;
-						if(thisEnemy.AIscript == 0xFF)
-						{
-							thisEnemy.AIscript = ENE_PickForcedAIScript(tier);
-						}
-						break;
-					default: // Air Elemental
-						thisEnemy.num_hits = 1;
-						thisEnemy.critrate = 1;
-						thisEnemy.damage = rollEnemyStrength(tier, 5);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 6);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 2);
-						thisEnemy.agility = rollEnemyEvade(tier, 7);
-						thisEnemy.atk_elem = 0b00000000;
-						thisEnemy.atk_ailment = 0b00000000;
-						thisEnemy.monster_type = 0b00000001;
-						thisEnemy.elem_resist = 0b10001011;
-						thisEnemy.elem_weakness = 0b00000000;
-						break;
-				}
-			}
-
-			public void rollDragon(MT19337 rng, ref EnemyData thisEnemy, int tier, int element)
-			{
-				switch (element)
-				{
-					case 1: // Earth Elemental
-						thisEnemy.num_hits = 1;
-						thisEnemy.critrate = 1;
-						thisEnemy.damage = rollEnemyStrength(tier, 6);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 4);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 7);
-						thisEnemy.agility = rollEnemyEvade(tier, 1);
-						thisEnemy.atk_elem = 0b10000000;
-						thisEnemy.atk_ailment = 0b00000000;
-						thisEnemy.monster_type = 0b00000010;
-						thisEnemy.elem_resist = 0b11100000;
-						thisEnemy.elem_weakness = 0b00000010;
-						break;
-					case 2: // Lightning Elemental
-						thisEnemy.num_hits = 1;
-						thisEnemy.critrate = 5;
-						thisEnemy.damage = rollEnemyStrength(tier, 7);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 6);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 3);
-						thisEnemy.agility = rollEnemyEvade(tier, 6);
-						thisEnemy.atk_elem = 0b01000000;
-						thisEnemy.atk_ailment = 0b00000000;
-						thisEnemy.monster_type = 0b00000010;
-						thisEnemy.elem_resist = 0b11000000;
-						thisEnemy.elem_weakness = 0b00010000;
-						break;
-					case 3: // Ice Elemental
-						thisEnemy.num_hits = 1;
-						thisEnemy.critrate = 1;
-						thisEnemy.damage = rollEnemyStrength(tier, 5);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 6);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 2);
-						thisEnemy.agility = rollEnemyEvade(tier, 7);
-						thisEnemy.atk_elem = 0b00100000;
-						thisEnemy.atk_ailment = 0b00000000;
-						thisEnemy.monster_type = 0b00000010;
-						thisEnemy.elem_resist = 0b10100010;
-						thisEnemy.elem_weakness = 0b01010000;
-						break;
-					case 4: // Fire Elemental
-						thisEnemy.num_hits = 1;
-						thisEnemy.critrate = 1;
-						thisEnemy.damage = rollEnemyStrength(tier, 7);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 7);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 5);
-						thisEnemy.agility = rollEnemyEvade(tier, 6);
-						thisEnemy.atk_elem = 0b00010000;
-						thisEnemy.atk_ailment = 0b00000000;
-						thisEnemy.monster_type = 0b00000010;
-						thisEnemy.elem_resist = 0b10010000;
-						thisEnemy.elem_weakness = 0b00100010;
-						break;
-					case 5: // Death Elemental
-						thisEnemy.num_hits = 1;
-						thisEnemy.critrate = 1;
-						thisEnemy.damage = rollEnemyStrength(tier, 6);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 6);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 6);
-						thisEnemy.agility = rollEnemyEvade(tier, 3);
-						thisEnemy.atk_elem = 0b00001000;
-						thisEnemy.atk_ailment = 0b00010000;
-						thisEnemy.monster_type = 0b00001010;
-						thisEnemy.elem_resist = 0b10101011;
-						thisEnemy.elem_weakness = 0b00010000;
-						break;
-					case 6: // Time Elemental
-						thisEnemy.num_hits = 1;
-						thisEnemy.critrate = 12;
-						thisEnemy.damage = rollEnemyStrength(tier, 6);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 7);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 6);
-						thisEnemy.agility = rollEnemyEvade(tier, 6);
-						thisEnemy.atk_elem = 0b00000100;
-						thisEnemy.atk_ailment = 0b00010000;
-						thisEnemy.monster_type = 0b00000011;
-						thisEnemy.elem_resist = 0b10001111;
-						thisEnemy.elem_weakness = 0b01110000;
-						break;
-					case 7: // Poison Elemental
-						thisEnemy.num_hits = 1;
-						thisEnemy.critrate = 1;
-						thisEnemy.damage = rollEnemyStrength(tier, 6);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 5);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 2);
-						thisEnemy.agility = rollEnemyEvade(tier, 6);
-						thisEnemy.atk_elem = 0b00000010;
-						thisEnemy.atk_ailment = 0b00000000;
-						thisEnemy.monster_type = 0b00000010;
-						thisEnemy.elem_resist = 0b10000000;
-						thisEnemy.elem_weakness = 0b00100000;
-						break;
-					case 8: // Status Elemental
-						thisEnemy.num_hits = 1;
-						thisEnemy.critrate = 3;
-						thisEnemy.damage = rollEnemyStrength(tier, 4);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 5);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 5);
-						thisEnemy.agility = rollEnemyEvade(tier, 5);
-						thisEnemy.atk_elem = 0b00000001;
-						thisEnemy.atk_ailment = 0b01000000;
-						thisEnemy.monster_type = 0b00000011;
-						thisEnemy.elem_resist = 0b01110001;
-						thisEnemy.elem_weakness = 0b00000000;
-						if (thisEnemy.AIscript == 0xFF)
-						{
-							thisEnemy.AIscript = ENE_PickForcedAIScript(tier);
-						}
-						break;
-					default: // Standard Dragon
-						thisEnemy.num_hits = 1;
-						thisEnemy.critrate = 1;
-						thisEnemy.damage = rollEnemyStrength(tier, 6);
-						thisEnemy.accuracy = rollEnemyAccuracy(tier, 6);
-						thisEnemy.absorb = rollEnemyAbsorb(tier, 6);
-						thisEnemy.agility = rollEnemyEvade(tier, 6);
-						thisEnemy.atk_elem = 0b00000000;
-						thisEnemy.atk_ailment = 0b00000000;
-						thisEnemy.monster_type = 0b00000010;
-						thisEnemy.elem_resist = 0b00000000;
-						thisEnemy.elem_weakness = 0b00000000;
-						break;
-				}
-			}
-
-			public byte ENE_PickForcedAIScript(int tier)
-			{
-				if (tier >= 0 && tier <= 2)
-					return 0x1A; // tier 0-2 uses RockGOL script
-				else if (tier >= 3 && tier <= 4)
-					return 0x0D; // tier 3-4 uses R.GOYLE script
-				else if (tier == 5)
-					return 0x19; // tier 5 uses MudGOL script
-				else if (tier >= 6 && tier <= 7)
-					return 0x1D; // tier 6-7 uses MAGE script
-				else if (tier >= 8 && tier <= 9)
-					return 0x1C; // tier 8-9 uses EVILMAN script
-				else
-					return 0xFF; // invalid tier returns no script
-			}
-
-			public int ENE_GetEnemySkillTier(byte skill)
-			{
-				if (skill >= 64)
-					return 0;
-				return skilltiers_enemy[skill];
-			}
-
-			public int ENE_GetEnemySpellTier(byte spell)
-			{
-				if (spell >= 64)
-					return 0;
-				return spelltiers_enemy[spell];
-			}
-
-			public bool DoFormations(MT19337 rng, bool didEnemies)
-			{
-				// sort enemies into zones
-				foreach(byte mon in uniqueEnemyIDs) // only sort through generic enemies that appear in uniqueEnemyIDs
-				{
-					int limit = Large(mon) ? 4 : 9;
-					for(int i = 0; i < zonecountmin.Length; ++i)
+				case 1: // Earth Elemental
+					thisEnemy.num_hits = 1;
+					thisEnemy.critrate = 1;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 7);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 7);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 5);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 2);
+					thisEnemy.atk_elem = 0b10000000;
+					thisEnemy.atk_ailment = 0b00000000;
+					thisEnemy.monster_type = 0b00000001;
+					thisEnemy.elem_resist = 0b11101011;
+					thisEnemy.elem_weakness = 0b00010000;
+					break;
+				case 2: // Lightning Elemental
+					thisEnemy.num_hits = 1;
+					thisEnemy.critrate = 20;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 5);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 5);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 2);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 6);
+					thisEnemy.atk_elem = 0b01000000;
+					thisEnemy.atk_ailment = 0b00100000;
+					thisEnemy.monster_type = 0b00000001;
+					thisEnemy.elem_resist = 0b11011001;
+					thisEnemy.elem_weakness = 0b00000110;
+					break;
+				case 3: // Ice Elemental
+					thisEnemy.num_hits = 1;
+					thisEnemy.critrate = 1;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 5);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 7);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 6);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 2);
+					thisEnemy.atk_elem = 0b00100000;
+					thisEnemy.atk_ailment = 0b00010000;
+					thisEnemy.monster_type = 0b00000001;
+					thisEnemy.elem_resist = 0b11101011;
+					thisEnemy.elem_weakness = 0b00010000;
+					break;
+				case 4: // Fire Elemental
+					thisEnemy.num_hits = 1;
+					thisEnemy.critrate = 1;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 6);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 7);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 5);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 2);
+					thisEnemy.atk_elem = 0b00010000;
+					thisEnemy.atk_ailment = 0b00000000;
+					thisEnemy.monster_type = 0b00000001;
+					thisEnemy.elem_resist = 0b11011011;
+					thisEnemy.elem_weakness = 0b00100000;
+					break;
+				case 5: // Death Elemental
+					thisEnemy.num_hits = 2;
+					thisEnemy.critrate = 1;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 7);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 4);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 4);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 4);
+					thisEnemy.atk_elem = 0b00001000;
+					thisEnemy.atk_ailment = 0b00001000;
+					thisEnemy.monster_type = 0b00001001;
+					thisEnemy.elem_resist = 0b10101011;
+					thisEnemy.elem_weakness = 0b00010000;
+					break;
+				case 6: // Time Elemental
+					thisEnemy.num_hits = rng.Between(4, 6);
+					thisEnemy.critrate = 1;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 4);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 4);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 4);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 5);
+					thisEnemy.atk_elem = 0b00000100;
+					thisEnemy.atk_ailment = 0b00010000;
+					thisEnemy.monster_type = 0b00000001;
+					thisEnemy.elem_resist = 0b10001111;
+					thisEnemy.elem_weakness = 0b01110000;
+					break;
+				case 7: // Poison Elemental
+					thisEnemy.num_hits = 1;
+					thisEnemy.critrate = 1;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 6);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 7);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 2);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 6);
+					thisEnemy.atk_elem = 0b00000010;
+					thisEnemy.atk_ailment = 0b00000100;
+					thisEnemy.monster_type = 0b10000001;
+					thisEnemy.elem_resist = 0b10001011;
+					thisEnemy.elem_weakness = 0b00000000;
+					break;
+				case 8: // Status Elemental
+					thisEnemy.num_hits = 1;
+					thisEnemy.critrate = 3;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 4);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 7);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 5);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 5);
+					thisEnemy.atk_elem = 0b00000001;
+					thisEnemy.atk_ailment = 0b01000000;
+					thisEnemy.monster_type = 0b00000001;
+					thisEnemy.elem_resist = 0b11111011;
+					thisEnemy.elem_weakness = 0b00000000;
+					if (thisEnemy.AIscript == 0xFF)
 					{
-						if(enemyStats[mon].exp <= zonexpreqs[i, 2] && enemyStats[mon].exp * limit >= zonexpreqs[i, 0])
-						{
-							enemyZones[mon].Add(i);
-							zonemons[i].Add(mon);
-						}
+						thisEnemy.AIscript = ENE_PickForcedAIScript(tier);
 					}
-				}
-				// roll special encounters for: imp, phantom, warmech, vampire, astos, pirates, garland (and ignore fiend encounters
-				ENF_DrawBumFight(rng, 0x00);
-				ENF_DrawForcedSingleFight(rng, 3, 0x01); // this is the wizard fight
-				ENF_DrawForcedSingleFight(rng, 6, 0x02); // this is the eye fight
-				ENF_DrawForcedSingleFight(rng, 6, 0x03); // this is the zombieD fight
-				ENF_DrawBossEncounter(rng, Enemy.Phantom, 1, 0x02, true, 4, 0x04);
-				ENF_DrawBossEncounter(rng, ENF_PickAVamp(rng), 1, 0x02, true, 4, 0x7C); // vampire fight tries to pick a vampire, or any monster < 3000 xp (yes, this can mean fighting a literal Bum!)
-				ENF_DrawBossEncounter(rng, Enemy.Astos, 1, 0x02, true, 4, 0x7D);
-				ENF_DrawBossEncounter(rng, Enemy.Pirate, 9, 0x00, true, 4, 0x7E);
-				ENF_DrawBossEncounter(rng, Enemy.Garland, 1, 0x02, true, 4, 0x7F);
-				ENF_DrawBossEncounter(rng, Enemy.WarMech, 1, 0x02, false, 75, warmech_encounter);
-				imp_encounter = 0x80; // resetting important encounter IDs
-				wizard_encounter = 0x81;
-				eye_encounter = 0x82;
-				zombieD_encounter = 0x83;
-				phantom_encounter = 0x04;
-				// reserve so many slots for different surprise rates and unrunnables
-				int[,] surprisetiers = { { 10, 19 }, { 24, 36 }, { 48, 62 }, { 70, 100 } };
-				const int surp1 = 9;
-				const int surp2 = 12;
-				const int surp3 = 4;
-				const int surp4 = 2;
-				int[] surpcount = { surp1, surp2, surp3, surp4 };
-				const int regularformations = 0x05; // we start rolling formations from where we stopped rolling special-case formations
-				const int bossformations = 0x73; // we stop rolling formations once we reach boss formations
-				for(byte i = regularformations; i < bossformations; ++i) // general loop for formation generation
-				{
-					if (i == imp_encounter || i == phantom_encounter || i == warmech_encounter)
-						continue; // don't do these encounters (we will roll them as special exceptions)
-					Formation f = new Formation(); // this is the formation we are hoping to write
-					// we will start narrowing down the list of monsters we can feature
-					List<byte> availablemons = new List<byte> { };
-					// first, we check if all monsters have been featured yet
-					if(uniqueEnemyIDs.Where(NotFeatured).Count() == 0)
-					{
-						// if we have featured all monsters, reset the featured array
-						foreach (byte mon in uniqueEnemyIDs)
-						{
-							featured[mon] = false;
-						}
-					}
-					// first, we determine which zones we have yet to reach the minimum for.  if they have yet to reach the minimum, they can join the union if the mon hasn't been featured yet
-					for(int j = 0; j < zonecountmin.Length; ++j)
-					{
-						if(zone[j].Count < zonecountmin[j])
-						{
-							availablemons = availablemons.Union(zonemons[j].Where(NotFeatured)).ToList();
-						}
-					}
-					// if we have already met the minimums for each zone, then any zone which has not reached its maximum can be chosen, if they have not been featured yet in this cycle
-					if(availablemons.Count == 0)
-					{
-						for (int j = 0; j < zonecountmax.Length; ++j)
-						{
-							if (zone[j].Count < zonecountmax[j])
-							{
-								availablemons = availablemons.Union(zonemons[j].Where(NotFeatured)).ToList();
-							}
-						}
-					}
-					// if we still don't have any mons available, then we can freely pick from all mon IDs that have yet to be featured
-					if (availablemons.Count == 0)
-					{
-						availablemons = uniqueEnemyIDs.Where(NotFeatured).ToList();
-						// and if we simply don't have mons available because they've all been featured, all mons are considered available (this should never execute)
-						if(availablemons.Count == 0)
-						{
-							availablemons = uniqueEnemyIDs.ToList();
-						}
-					}
-					// now we pick one of the availablemons at random as our first mon
-					f.Top = availablemons.PickRandom(rng);
-					f.tileset = enemyTilesets[f.Top]; // and we pick the corresponding tileset
-					// we need to select which zone we are aiming to fill on the B-Side (and if we require a Large-only or Small-only formation to do that, we set the shape of the formation accordingly)
-					List<int> availablezones = enemyZones[f.Top].Where(index => zone[index].Count < zonecountmin[index]).ToList();
-					if (availablezones.Count == 0) // if there are no zones available that haven't reached their mincount, check for maxcount instead
-						availablezones = enemyZones[f.Top].Where(index => zone[index].Count < zonecountmax[index]).ToList();
-					if (availablezones.Count == 0) // and if we've filled mincount and maxcount, just list all available zones
-						availablezones = enemyZones[f.Top].ToList();
-					if(availablezones.Count == 0) // and if by some freak chance the enemy has not been assigned any zones, write an error report to Console and abort Formation shuffle
-					{
-						Console.WriteLine(f.Top);
-						Console.WriteLine(enemyStats[f.Top].exp);
-						Console.WriteLine("This Enemy Has No Zones");
-						return false;
-					}
-					int zoneB = availablezones.PickRandom(rng); // the B-Side zone we are trying to fill
-					int limit = Large(f.Top) ? 2 : 6;
-					if (enemyStats[f.Top].exp * limit < zonexpreqs[zoneB, 1])
-						f.shape = Large(f.Top) ? 0x01 : 0x00;
-					else
-					{
-						if (rng.Between(0, 2) == 0)
-							f.shape = Large(f.Top) ? 0x01 : 0x00;
-						else
-							f.shape = 0x02;
-					}
-					// now we look for what we can pick for the second mon
-					if(f.shape == 0x00)
-					{
-						availablemons = enemiesInTileset[f.tileset].Where(mon => Small(mon) && NotFeatured(mon) && mon != f.Top).ToList();
-						if (availablemons.Count == 0)
-							availablemons = enemiesInTileset[f.tileset].Where(Small).ToList();
-					}
-					else if (f.shape == 0x01)
-					{
-						availablemons = enemiesInTileset[f.tileset].Where(mon => Large(mon) && NotFeatured(mon) && mon != f.Top).ToList();
-						if (availablemons.Count == 0)
-							availablemons = enemiesInTileset[f.tileset].Where(Large).ToList();
-					}
-					else
-					{
-						availablemons = enemiesInTileset[f.tileset].Where(mon => NotFeatured(mon) && mon != f.Top).ToList();
-						if (availablemons.Count == 0)
-							availablemons = enemiesInTileset[f.tileset].Where(mon=> mon != f.Top).ToList(); // if all other mons in this tileset have been featured, all mons in this tileset are eligible as a second mon
-					}
-					f.id[1] = availablemons.PickRandom(rng); // and pick a random mon from the available IDs to be mon 2 (and the primary monster of the A-side)
-					// we will attempt to hit a zone with the A-Side but if we can't we'll just try to make an encounter as close as possible to the goal
-					availablezones = enemyZones[f.id[1]].Where(index => zone[index].Count < zonecountmin[index]).ToList();
-					if (availablezones.Count == 0) // if there are no zones available that haven't reached their mincount, check for maxcount instead
-						availablezones = enemyZones[f.id[1]].Where(index => zone[index].Count < zonecountmax[index]).ToList();
-					if (availablezones.Count == 0) // and if we've filled mincount and maxcount, just list all available zones
-						availablezones = enemyZones[f.id[1]].ToList();
-					if (availablezones.Count == 0) // and if by some freak chance the enemy has not been assigned any zones, write an error report to Console and abort Formation shuffle
-					{
-						Console.WriteLine(f.id[1]);
-						Console.WriteLine(enemyStats[f.id[1]].exp);
-						Console.WriteLine("This Enemy Has No Zones");
-						return false;
-					}
-					int zoneA = availablezones.PickRandom(rng);
-					// now we set the palettes
-					f.pal1 = enemyPalettes[f.Top];
-					if (enemyPalettes[f.Top] != enemyPalettes[f.id[1]])
-						f.pal2 = enemyPalettes[f.id[1]];
-					else // if first and second enemies in the formation have the same palette, draw a second palette at random
-					{
-						List<byte> availablepalettes = palettesInTileset[f.tileset].Where(pal => pal != f.pal1).ToList();
-						if (availablepalettes.Count == 0)
-							f.pal2 = f.pal1; // if there is only one palette in the tileset, just set the second palette to the same value as the first
-						else
-							f.pal2 = availablepalettes.PickRandom(rng);
-					}
-					// and we draw any monsters that conform to both the tileset and palette choices as the third and fourth monsters (if there are more than two, they are dropped after a shuffle of the list)
-					availablemons = enemiesInTileset[f.tileset].Where(mon => mon != f.Top && mon != f.id[1] && (enemyPalettes[mon] == f.pal1 || enemyPalettes[mon] == f.pal2)).ToList();
-					switch (f.shape)
-					{
-						case 0x00:
-							availablemons = availablemons.Where(Small).ToList();
-							break;
-						case 0x01:
-							availablemons = availablemons.Where(Large).ToList();
-							break;
-					}
-					if (availablemons.Count > 0)
-					{
-						availablemons.Shuffle(rng);
-						f.id[2] = availablemons[0];
-						if (availablemons.Count > 1)
-							f.id[3] = availablemons[1];
-					}
-					// now we can decide how many monsters to aim for in the formation.  we call two functions, one to draw the B-side, and another to draw the A-side
-					zoneB = ENF_Picker_BSide(rng, f, zoneB, 0);
-					zoneA = ENF_Picker_ASide(rng, f, zoneA, 1);
-					if(zoneA == -1 || zoneB == -1)
-					{
-						featured[f.Top] = true;
-						featured[f.id[1]] = true;
-						--i;
-						continue; // loop again after setting the problematic monsters to featured status so they are de-prioritized and won't cause an infinite loop problem
-					}
-					// assign the pic and palette bytes to each monster slot
-					ENF_AssignPicAndPaletteBytes(f);
-					// set surprise rate and unrunnability flags
-					f.unrunnable = rng.Between(0, 29) + (zoneA > zoneB ? zoneA : zoneB) >= 32 ? true : false; // unrunnable chance is higher for later zones
-					if (f.unrunnable)
-						f.surprise = (byte)rng.Between(3, 30);
-					else
-					{
-						if(bossformations - surpcount.Sum() <= i)
-						{
-							// automatically roll a surprise chance
-							int s_roll = rng.Between(1, surpcount.Sum());
-							int s_tier = -1;
-							if (s_roll <= surpcount[0])
-								s_tier = 0;
-							else if (s_roll <= surpcount[0] + surpcount[1] && s_roll > surpcount[0])
-								s_tier = 1;
-							else if (s_roll <= surpcount[0] + surpcount[1] + surpcount[2] && s_roll > surpcount[0] + surpcount[1])
-								s_tier = 2;
-							else if (s_roll <= surpcount[0] + surpcount[1] + surpcount[2] + surpcount[3] && s_roll > surpcount[0] + surpcount[1] + surpcount[2])
-								s_tier = 3;
-							if (s_tier == -1)
-							{
-								f.surprise = (byte)rng.Between(3, 9);
-							}
-							else
-							{
-								f.surprise = (byte)rng.Between(surprisetiers[s_tier, 0], surprisetiers[s_tier, 1]);
-								surpcount[s_tier]--;
-							}
-						}
-						else
-						{
-							// random chance to roll additional surprise rate
-							int s_tier = -1;
-							int s_roll = rng.Between(regularformations, bossformations);
-							if (s_roll > bossformations - surp4)
-								s_tier = 3;
-							else if (s_roll > bossformations - surp4 - surp3)
-								s_tier = 2;
-							else if (s_roll > bossformations - surp4 - surp3 - surp2)
-								s_tier = 1;
-							else if (s_roll > bossformations - surp4 - surp3 - surp2 - surp1)
-								s_tier = 0;
-							if (s_tier == -1)
-							{
-								f.surprise = (byte)rng.Between(3, 9);
-							}
-							else
-							{
-								if (surpcount[s_tier] > 0)
-								{
-									f.surprise = (byte)rng.Between(surprisetiers[s_tier, 0], surprisetiers[s_tier, 1]);
-									surpcount[s_tier]--;
-								}
-								else
-								{
-									f.surprise = (byte)rng.Between(3, 9);
-								}
-							}
-						}
-					}
-					// add the A-Side and B-Side to their respective zones
-					zone[zoneA].Add(i);
-					zone[zoneB].Add((byte)(i | 0x80));
-					// log and compress this formation
-					LogAndCompressFormation(f, i);
-				}
-				PrintFormationInfo();
-				return true;
-			}
-
-			public int ENF_Picker_BSide(MT19337 rng, Formation f, int zone, int priority)
-			{
-				// draw B-Side formation, prioritizing the priority monster (defaults to f.id[0] if given an invalid priority)
-				if (priority < 0 || priority > 1)
-					priority = 0;
-				if (f.id[priority] == 0xFF)
-					priority = 0;
-				if (f.Top == 0xFF)
-					return -1; // do not draw mons if there is no valid mon as priority
-				f.monMin[priority + 4] = 1; // there will always be at least one mon of the priority
-				f.monMax[priority + 4] = 1;
-				int minXP = enemyStats[f.id[priority]].exp;
-				int maxXP = enemyStats[f.id[priority]].exp;
-				// add to the maxcount for priority until we reach the minimum-maximum for this zone, or we run out of space in this formation to place more
-				int smallLimit = 0, largeLimit = 0;
-				switch(f.shape)
-				{
-					case 0x00:
-						smallLimit = 9;
-						largeLimit = 0;
-						break;
-					case 0x01:
-						smallLimit = 0;
-						largeLimit = 4;
-						break;
-					case 0x02:
-						smallLimit = 6;
-						largeLimit = 2;
-						break;
-				}
-				if (Large(f.id[priority]))
-					largeLimit--;
-				else
-					smallLimit--;
-				while(smallLimit > 0 && largeLimit > 0 && maxXP < zonexpreqs[zone, 1])
-				{
-					f.monMax[priority + 4]++;
-					if (Large(f.id[priority]))
-						largeLimit--;
-					else
-						smallLimit--;
-					maxXP += enemyStats[f.id[priority]].exp;
-					if (maxXP > zonexpreqs[zone, 2])
-					{
-						f.monMax[priority + 4]--;
-						if (Large(f.id[priority]))
-							largeLimit++;
-						else
-							smallLimit++;
-						maxXP -= enemyStats[f.id[priority]].exp;
-						break;
-					}
-				}
-				// now, we can add to the maxcount from either mon until we surpass the max XP for this zone, but monsters that don't contribute enough to zone requirements will not be selected
-				List<int> validindices = new List<int> { priority };
-				for(int i = 0; i < 1; ++i)
-				{
-					if (f.id[i] == 0xFF)
-						continue; // don't include mons with an invalid index
-					int sizeFactor = Large(f.id[i]) ? 6 : 12;
-					if (enemyStats[f.id[i]].exp > zonexpreqs[zone, 2] / sizeFactor)
-						validindices.Add(i); // valid monsters must contribute experience equal to 1/12th of the xp cap for this zone
-				}
-				while((smallLimit > 0 || largeLimit > 0) && validindices.Count > 0 && rng.Between(0, 14) > 0) // there is a 6.66% chance of ending new monster addition every cycle
-				{
-					int index = validindices.PickRandom(rng);
-					if(maxXP + enemyStats[f.id[index]].exp <= zonexpreqs[zone, 2] && ((Large(f.id[index]) && largeLimit > 0) || (Small(f.id[index]) && smallLimit > 0)))
-					{
-						f.monMax[index + 4]++;
-						maxXP += enemyStats[f.id[index]].exp;
-						if (Large(f.id[index]))
-							largeLimit--;
-						else
-							smallLimit--;
-					}
-					else
-					{
-						validindices.Remove(index);
-					}
-				}
-				// now that we have the maximums, we determine the minimums. first, we ensure that we can hit the minimum for this zone
-				validindices = new List<int> { };
-				for (int i = 0; i < 1; ++i)
-				{
-					if (f.monMax[i + 4] > 0)
-						validindices.Add(i); // add any monster that has a maxcount
-				}
-				while (minXP < zonexpreqs[zone, 0] && validindices.Count > 0)
-				{
-					int index = validindices.PickRandom(rng);
-					if (f.monMin[index + 4] < f.monMax[index + 4])
-					{
-						f.monMin[index + 4]++;
-						minXP += enemyStats[f.id[index]].exp;
-					}
-					else
-						validindices.Remove(index);
-				}
-				// set the minimums to a random number between the current minimum and the maximum
-				if (f.monMax[4] > 0)
-					f.monMin[4] = rng.Between(f.monMin[4], f.monMax[4]);
-				if (f.monMax[5] > 0)
-					f.monMin[5] = rng.Between(f.monMin[5], f.monMax[5]);
-				// if we were able to conform to all requirements of the zone, return false, but if we couldn't conform to the zone requirements return true so we know to calc the new zone
-				return ENF_Calc_BSide_Zone(f);
-			}
-
-			public int ENF_Picker_ASide(MT19337 rng, Formation f, int zone, int priority)
-			{
-				// draw A-Side formation, prioritizing the priority monster (defaults to f.id[0] if given an invalid priority)
-				if (priority < 0 || priority > 3)
-					priority = 0;
-				if (f.id[priority] == 0xFF)
-					priority = 0;
-				if (f.Top == 0xFF)
-					return -1; // do not draw mons if there is no valid mon as priority
-				f.monMin[priority] = 1; // there will always be at least one mon of the priority
-				f.monMax[priority] = 1;
-				int minXP = enemyStats[f.id[priority]].exp;
-				int maxXP = enemyStats[f.id[priority]].exp;
-				int smallLimit = 0, largeLimit = 0;
-				switch (f.shape)
-				{
-					case 0x00:
-						smallLimit = 9;
-						largeLimit = 0;
-						break;
-					case 0x01:
-						smallLimit = 0;
-						largeLimit = 4;
-						break;
-					case 0x02:
-						smallLimit = 6;
-						largeLimit = 2;
-						break;
-				}
-				if (Large(f.id[priority]))
-					largeLimit--;
-				else
-					smallLimit--;
-				// unlike the B-Side where we force the priority monster to be placed early, here there is no such requirement.  we just start adding to maxcounts
-				List<int> validindices = new List<int> { }; // no weighting selection towards priority in A-Side
-				List<int> trashindices = new List<int> { }; // list of "trash mons" that may be optionally added in after general mon selection
-				for (int i = 0; i < 3; ++i)
-				{
-					if (f.id[i] == 0xFF)
-						continue; // don't include mons with an invalid index
-					int sizeFactor = Large(f.id[i]) ? 6 : 12;
-					if (enemyStats[f.id[i]].exp > zonexpreqs[zone, 2] / sizeFactor)
-						validindices.Add(i); // valid monsters must contribute experience equal to 1/12th of the xp cap for this zone
-					else if (Small(f.id[i]))
-						trashindices.Add(i);
-				}
-				if(validindices.Count == 0) // if we have no valid indices (possible if some zones), we use the minimum-maximum instead of total max
-				{
-					trashindices.Clear();
-					for (int i = 0; i < 3; ++i)
-					{
-						if (f.id[i] == 0xFF)
-							continue; // don't include mons with an invalid index
-						int sizeFactor = Large(f.id[i]) ? 6 : 12;
-						if (enemyStats[f.id[i]].exp > zonexpreqs[zone, 1] / sizeFactor)
-							validindices.Add(i); // valid monsters must contribute experience equal to 1/12th of the xp cap for this zone
-						else if (Small(f.id[i]))
-							trashindices.Add(i);
-					}
-				}
-				while ((smallLimit > 0 || largeLimit > 0) && validindices.Count > 0)
-				{
-					if (rng.Between(0, 14) == 0 && maxXP > zonexpreqs[zone, 1])
-						break; // 6.66% chance of ending the while loop if we have already met the minimum-maximum
-					int index = validindices.PickRandom(rng);
-					if (maxXP + enemyStats[f.id[index]].exp <= zonexpreqs[zone, 2] && ((Large(f.id[index]) && largeLimit > 0) || (Small(f.id[index]) && smallLimit > 0)))
-					{
-						f.monMax[index]++;
-						maxXP += enemyStats[f.id[index]].exp;
-						if (Large(f.id[index]))
-							largeLimit--;
-						else
-							smallLimit--;
-					}
-					else
-					{
-						validindices.Remove(index);
-					}
-				}
-				// now, hopefully, we got the minimum-maximums we wanted from that.  time to raise minimums
-				validindices = new List<int> { };
-				for (int i = 0; i < 3; ++i)
-				{
-					if (f.id[i] == 0xFF)
-						continue;
-					if (f.monMax[i] > 0)
-						validindices.Add(i); // add any monster that has a maxcount
-				}
-				while (minXP < zonexpreqs[zone, 0] && validindices.Count > 0)
-				{
-					int index = validindices.PickRandom(rng);
-					if (f.monMin[index] < f.monMax[index])
-					{
-						f.monMin[index]++;
-						minXP += enemyStats[f.id[index]].exp;
-					}
-					else
-						validindices.Remove(index);
-				}
-				// set the minimums to a random number between the current minimum and the maximum
-				for(int i = 0; i < 3; ++i)
-				{
-					f.monMin[i] = rng.Between(f.monMin[i], f.monMax[i]);
-				}
-				// if there is space, we can add 1-2 of each trash index (so long as they do not exceed the zone's maximum).  only smalls can be trash mons.
-				if(trashindices.Count > 0 && smallLimit > 0)
-				{
-					for(int i = 0; i < trashindices.Count; ++i)
-					{
-						if(rng.Between(0, 2) == 0) // 33% chance of rejecting a trash index
-						{
-							if(Small(f.id[trashindices[i]]))
-							{
-								if(maxXP + enemyStats[f.id[trashindices[i]]].exp < zonexpreqs[zone, 2])
-								{
-									smallLimit--;
-									f.monMax[trashindices[i]]++;
-									maxXP += enemyStats[f.id[trashindices[i]]].exp;
-								}
-								if(rng.Between(0, 1) == 0) // 50% chance of adding a second trash mon of the same type
-								{
-									if (maxXP + enemyStats[f.id[trashindices[i]]].exp < zonexpreqs[zone, 2])
-									{
-										smallLimit--;
-										f.monMax[trashindices[i]]++;
-										maxXP += enemyStats[f.id[trashindices[i]]].exp;
-									}
-								}
-							}
-						}
-					}
-				}
-				// if we were able to conform to all requirements of the zone, return false, but if we couldn't conform to the zone requirements return true so we know to calc the new zone
-				return ENF_Calc_ASide_Zone(f);
-			}
-
-			public int ENF_Calc_BSide_Zone(Formation f)
-			{
-				// calculates a zone for the encounter to fit if we couldn't reach our goal zone (return -1 if the zone is completely invalid)
-				int return_value = -1;
-				List<int> acceptableValues = new List<int> { };
-				int minXP = 0, maxXP = 0;
-				if(f.monMax[4] > 0)
-				{
-					minXP += f.monMin[4] * enemyStats[f.id[0]].exp;
-					maxXP += f.monMax[4] * enemyStats[f.id[0]].exp;
-				}
-				if(f.monMax[5] > 0)
-				{
-					minXP += f.monMin[5] * enemyStats[f.id[1]].exp;
-					maxXP += f.monMax[5] * enemyStats[f.id[1]].exp;
-				}
-				for(int i = 0; i < zonecountmin.Length; ++i)
-				{
-					if (minXP >= zonexpreqs[i, 0] && maxXP >= zonexpreqs[i, 1] && maxXP <= zonexpreqs[i, 2])
-						acceptableValues.Add(i);
-				}
-				List<int> mincountValues = acceptableValues.Where(id => zone[id].Count < zonecountmin[id]).ToList();
-				if (mincountValues.Count == 0)
-					mincountValues = acceptableValues.Where(id => zone[id].Count < zonecountmax[id]).ToList();
-				if (mincountValues.Count > 0)
-					return_value = mincountValues.Max();
-				else
-				{
-					if(acceptableValues.Count > 0)
-						return_value = acceptableValues.Max();
-				}
-				return return_value;
-			}
-
-			public int ENF_Calc_ASide_Zone(Formation f)
-			{
-				// calculates a zone for the encounter to fit if we couldn't reach our goal zone (return -1 if the zone is completely invalid)
-				int return_value = -1;
-				List<int> acceptableValues = new List<int> { };
-				int minXP = 0, maxXP = 0;
-				for(int i = 0; i < 3; ++i)
-				{
-					if (f.id[i] == 0xFF)
-						continue;
-					if(f.monMax[i] > 0)
-					{
-						minXP += f.monMin[i] * enemyStats[f.id[i]].exp;
-						maxXP += f.monMax[i] * enemyStats[f.id[i]].exp;
-					}
-				}
-				for (int i = 0; i < zonecountmin.Length; ++i)
-				{
-					if (minXP >= zonexpreqs[i, 0] && maxXP >= zonexpreqs[i, 1] && maxXP <= zonexpreqs[i, 2])
-						acceptableValues.Add(i);
-				}
-				List<int> mincountValues = acceptableValues.Where(id => zone[id].Count < zonecountmin[id]).ToList();
-				if (mincountValues.Count == 0)
-					mincountValues = acceptableValues.Where(id => zone[id].Count < zonecountmax[id]).ToList();
-				if (mincountValues.Count > 0)
-					return_value = mincountValues.Max();
-				else
-				{
-					if (acceptableValues.Count > 0)
-						return_value = acceptableValues.Max();
-				}
-				return return_value;
-			}
-
-			public void ENF_AssignPicAndPaletteBytes(Formation f)
-			{
-				for (int i = 0; i < 4; ++i)
-				{
-					if (f.id[i] == 0xFF)
-						continue;
-					if (enemyPalettes[f.id[i]] == f.pal2)
-						f.paletteassignment |= (byte)(0b00010000 << (3 - i));
-					f.pics |= (byte)(enemyPics[f.id[i]] << (i * 2));
-				}
-			}
-
-			public void ENF_DrawForcedSingleFight(MT19337 rng, int zoneB, byte id)
-			{
-				// draws an encounter whose B-Side is always a group of one monster type, pulled from the specified.  it will always produce a fight near the maximum XP for this zone.
-				// the A-Side will be a random assortment of monsters that may or may not include the B-Side monster.  if it is possible to fit the zone requirement in a 2-6 formation, that will always be selected
-				// this formation is always unrunnable (this routine is used for the replacements for the Wizard, Eye, and Zombie Dragon fight replacements)
-				Formation f = new Formation();
-				f.Top = zonemons[zoneB].PickRandom(rng);
-				f.tileset = enemyTilesets[f.Top];
-				int limit = Large(f.Top) ? 2 : 6;
-				if (enemyStats[f.Top].exp * limit < zonexpreqs[zoneB, 2])
-					f.shape = Large(f.Top) ? 0x01 : 0x00;
-				else
-					f.shape = 0x02;
-				f.monMax[4] = zonexpreqs[zoneB, 2] / enemyStats[f.Top].exp;
-				if (f.monMax[4] > GetMonLimit(f.Top, f.shape))
-					f.monMax[4] = GetMonLimit(f.Top, f.shape);
-				f.monMin[4] = zonexpreqs[zoneB, 1] / enemyStats[f.Top].exp;
-				if (f.monMin[4] > f.monMax[4])
-					f.monMin[4] = f.monMax[4];
-				if(f.monMax[4] == 0) // this should never execute but just in case
-				{
-					f.monMin[4] = 1;
-					f.monMax[4] = 1;
-				}
-				if (f.monMin[4] == 0)
-					f.monMin[4] = 1;
-				// draw all potential mons for A-Side
-				List<byte> availablemons = enemiesInTileset[f.tileset].Where(mon => mon != f.Top).ToList();
-				switch(f.shape)
-				{
-					case 0x00:
-						availablemons = availablemons.Where(Small).ToList();
-						break;
-					case 0x01:
-						availablemons = availablemons.Where(Large).ToList();
-						break;
-				}
-				f.id[1] = availablemons.PickRandom(rng);
-				f.pal1 = enemyPalettes[f.Top];
-				f.pal2 = enemyPalettes[f.id[1]]; // if these are both the same, i don't really care
-				availablemons = enemiesInTileset[f.tileset].Where(mon => mon != f.Top && mon != f.id[1] && (enemyPalettes[mon] == f.pal1 || enemyPalettes[mon] == f.pal2)).ToList();
-				switch (f.shape)
-				{
-					case 0x00:
-						availablemons = availablemons.Where(Small).ToList();
-						break;
-					case 0x01:
-						availablemons = availablemons.Where(Large).ToList();
-						break;
-				}
-				if (availablemons.Count > 0)
-				{
-					availablemons.Shuffle(rng);
-					f.id[2] = availablemons[0];
-					if (availablemons.Count > 1)
-						f.id[3] = availablemons[1];
-				}
-				int zoneA = enemyZones[f.id[1]].PickRandom(rng); // pick a random zone to aim for from the second mon
-				// now we actually run the generic picker
-				zoneA = ENF_Picker_ASide(rng, f, zoneA, 1);
-				zone[zoneB].Add((byte)(id | 0x80));
-				if (zoneA != -1)
-					zone[zoneA].Add(id); // if for some reason we didn't fill any valid zone from the A-side, we simply don't add it to any zones (and thus it will never be seen)
-				f.surprise = 4;
-				f.unrunnable = true; // these fights are always unrunnable
-				// put on the finishing touches and log and compress this formation
-				ENF_AssignPicAndPaletteBytes(f);
-				LogAndCompressFormation(f, id);
-			}
-
-			public void ENF_DrawBossEncounter(MT19337 rng, int bossmonster, int quantity, byte shape, bool unrunnable, byte surpriserate, byte id)
-			{
-				// draws a boss encounter on the A side, with the specified monster, quantity thereof, and shape on the A-Side, and information about runnability (true for most, but false for warmech) / surprise rate
-				// the B-Side will feature one or two monsters from the same tileset that are compatible with the boss' palette and another palette chosen at random
-				// the B-Side will be available as a random encounter.
-				Formation f = new Formation();
-				f.id[2] = (byte)bossmonster; // we place the boss monster in the third slot
-				f.tileset = enemyTilesets[f.id[2]];
-				f.pal1 = enemyPalettes[f.id[2]];
-				f.shape = shape;
-				f.monMin[2] = quantity;
-				f.monMax[2] = quantity; // always produce the necessary number of enemies
-				// draw mons for B-Side
-				List<byte> availablemons = enemiesInTileset[f.tileset].ToList();
-				switch (f.shape)
-				{
-					case 0x00:
-						availablemons = availablemons.Where(Small).ToList();
-						break;
-					case 0x01:
-						availablemons = availablemons.Where(Large).ToList();
-						break;
-				}
-				if(availablemons.Count > 0)
-				{
-					f.Top = availablemons.PickRandom(rng);
-					f.pal2 = enemyPalettes[f.Top];
-					availablemons = availablemons.Where(mon => mon != f.Top && mon != f.id[2] && (enemyPalettes[mon] == f.pal1 || enemyPalettes[mon] == f.pal2)).ToList();
-					if (availablemons.Count > 0)
-					{
-						f.id[1] = availablemons.PickRandom(rng);
-					}
-					int zoneB = enemyZones[f.Top].PickRandom(rng);
-					zoneB = ENF_Picker_BSide(rng, f, zoneB, 0);
-					if (zoneB != -1)
-						zone[zoneB].Add((byte)(id | 0x80)); // if for some reason we didn't fill any valid zone from the B-side, we simply don't add it to any zones (and thus it will never be seen)
-				}			
-				// if for some reason there were no available mons, then a B-Side is not drawn at all and no formation is added to the zones, so this slot will remain unused.  this shouldn't happen, though
-				ENF_AssignPicAndPaletteBytes(f);
-				f.unrunnable = true;
-				f.surprise = 4;
-				LogAndCompressFormation(f, id);
-			}
-
-			public void ENF_DrawBumFight(MT19337 rng, byte id)
-			{
-				// draws the bum fight around Coneria Castle.  this will always be 3-4 weak noodle enemies (default IMPs) that are placed on the B-Side.  the A-side will be a generic battle which may or may not
-				// include more bums
-				Formation f = new Formation();
-				f.Top = Enemy.Imp;
-				f.tileset = enemyTilesets[f.Top];
-				f.shape = Large(f.Top) ? 0x01 : 0x00;
-				f.pal1 = enemyPalettes[f.Top];
-				f.monMin[4] = 3;
-				f.monMax[4] = 4;
-				// draw mons for A-Side
-				List<byte> availablemons = enemiesInTileset[f.tileset].Where(mon => mon != f.Top && enemyPalettes[mon] != f.pal1).ToList();
-				switch (f.shape)
-				{
-					case 0x00:
-						availablemons = availablemons.Where(Small).ToList();
-						break;
-					case 0x01:
-						availablemons = availablemons.Where(Large).ToList();
-						break;
-				}
-				f.id[1] = availablemons.PickRandom(rng);
-				f.pal2 = enemyPalettes[f.id[1]];
-				availablemons = enemiesInTileset[f.tileset].Where(mon => mon != f.Top && mon != f.id[1] && (enemyPalettes[mon] == f.pal1 || enemyPalettes[mon] == f.pal2)).ToList();
-				switch (f.shape)
-				{
-					case 0x00:
-						availablemons = availablemons.Where(Small).ToList();
-						break;
-					case 0x01:
-						availablemons = availablemons.Where(Large).ToList();
-						break;
-				}
-				if (availablemons.Count > 0)
-				{
-					availablemons.Shuffle(rng);
-					f.id[2] = availablemons[0];
-					if (availablemons.Count > 1)
-						f.id[3] = availablemons[1];
-				}
-				int zoneA = enemyZones[f.id[1]].PickRandom(rng);
-				zoneA = ENF_Picker_ASide(rng, f, zoneA, 1);
-				if (zoneA != -1)
-					zone[zoneA].Add(id); // if for some reason we didn't fill any valid zone from the A-side, we simply don't add it to any zones (and thus it will never be seen)
-				// if for some reason there were no available mons to draw, we don't draw an A-Side and it will never be added to a zone, thus it will never be used
-				ENF_AssignPicAndPaletteBytes(f);
-				LogAndCompressFormation(f, id);
-			}
-
-			public byte ENF_PickAVamp(MT19337 rng)
-			{
-				// picks a random vampire for the Earth Cave fight.  priority is given to vampires that give out less than 3000 experience points, then to any monster under 3000 experience points
-				List<byte> vamps = uniqueEnemyIDs.Where(mon => enemyImage[mon] == 24 && enemyStats[mon].exp <= 3000).ToList();
-				if (vamps.Count == 0)
-					vamps = uniqueEnemyIDs.Where(mon => enemyStats[mon].exp <= 3000).ToList();
-				return vamps.PickRandom(rng);
-			}
-
-			public void DoDomains(MT19337 rng)
-			{
-				// load the addresses of all known trap tiles (these addresses are hardcoded for now - i'm not going to consider altered maps)
-				traptile_addresses[(int)TrapTiles.TRAP_IMAGES] = 0x1B3;
-				traptile_addresses[(int)TrapTiles.TRAP_MUMMIES] = 0x1B5;
-				traptile_addresses[(int)TrapTiles.TRAP_MUDGOLS] = 0x1B7;
-				traptile_addresses[(int)TrapTiles.TRAP_NITEMARES] = 0x1B9;
-				traptile_addresses[(int)TrapTiles.TRAP_ZOMBIE_D] = 0x1BB;
-				traptile_addresses[(int)TrapTiles.TRAP_GARGOYLES] = 0x541;
-				traptile_addresses[(int)TrapTiles.TRAP_SEAFOOD_PARTY_MIX] = 0x543;
-				traptile_addresses[(int)TrapTiles.TRAP_SHARKNADO] = 0x545;
-				traptile_addresses[(int)TrapTiles.TRAP_WATERS] = 0x547;
-				traptile_addresses[(int)TrapTiles.TRAP_SEASHRINE_MUMMIES] = 0x549;
-				traptile_addresses[(int)TrapTiles.TRAP_ZOMBIES] = 0x5A5;
-				traptile_addresses[(int)TrapTiles.TRAP_GARGOYLES2] = 0x5A9;
-				traptile_addresses[(int)TrapTiles.TRAP_GIANTS] = 0x237;
-				traptile_addresses[(int)TrapTiles.TRAP_GIANTS_IGUANAS] = 0x239;
-				traptile_addresses[(int)TrapTiles.TRAP_EARTH] = 0x23B;
-				traptile_addresses[(int)TrapTiles.TRAP_OGRES_HYENAS] = 0x23D;
-				traptile_addresses[(int)TrapTiles.TRAP_SPHINX] = 0x243;
-				traptile_addresses[(int)TrapTiles.TRAP_FIRE] = 0x245;
-				traptile_addresses[(int)TrapTiles.TRAP_GREYWORM] = 0x247;
-				traptile_addresses[(int)TrapTiles.TRAP_AGAMA] = 0x25F;
-				traptile_addresses[(int)TrapTiles.TRAP_RED_D] = 0x281;
-				traptile_addresses[(int)TrapTiles.TRAP_UNDEAD_PARTYMIX] = 0x381;
-				traptile_addresses[(int)TrapTiles.TRAP_FROSTRURUS] = 0x383;
-				traptile_addresses[(int)TrapTiles.TRAP_FROSTGIANT] = 0x385;
-				traptile_addresses[(int)TrapTiles.TRAP_MAGES] = 0x387;
-				traptile_addresses[(int)TrapTiles.TRAP_FROST_D] = 0x389;
-				traptile_addresses[(int)TrapTiles.TRAP_EYE] = 0x38B;
-				traptile_addresses[(int)TrapTiles.TRAP_WATERFALL_MUMMIES] = 0x391;
-				traptile_addresses[(int)TrapTiles.TRAP_WIZARDS] = 0x433;
-				traptile_addresses[(int)TrapTiles.TRAP_WIZARDS2] = 0x435;
-				traptile_addresses[(int)TrapTiles.TRAP_COBRAS] = 0x437;
-				traptile_addresses[(int)TrapTiles.TRAP_BLUE_D] = 0x439;
-				traptile_addresses[(int)TrapTiles.TRAP_SLIMES] = 0x43B;
-				traptile_addresses[(int)TrapTiles.TRAP_PHANTOM] = 0x7AD;
-
-				// assign monsters to trap tiles
-				zone[2].Shuffle(rng);
-				zone[3].Shuffle(rng);
-				zone[4].Shuffle(rng);
-				zone[5].Shuffle(rng);
-				zone[6].Shuffle(rng);
-				zone[8].Shuffle(rng);
-				zone[9].Shuffle(rng);
-				traptile_formations[(int)TrapTiles.TRAP_IMAGES] = zone[3][0];
-				traptile_formations[(int)TrapTiles.TRAP_MUMMIES] = zone[3][1];
-				traptile_formations[(int)TrapTiles.TRAP_MUDGOLS] = zone[6][0];
-				traptile_formations[(int)TrapTiles.TRAP_NITEMARES] = zone[6][1];
-				traptile_formations[(int)TrapTiles.TRAP_ZOMBIE_D] = zombieD_encounter;
-				traptile_formations[(int)TrapTiles.TRAP_GARGOYLES] = zone[2][0];
-				traptile_formations[(int)TrapTiles.TRAP_SEAFOOD_PARTY_MIX] = zone[8][0];
-				traptile_formations[(int)TrapTiles.TRAP_SHARKNADO] = zone[8][1];
-				traptile_formations[(int)TrapTiles.TRAP_WATERS] = zone[8][2];
-				traptile_formations[(int)TrapTiles.TRAP_SEASHRINE_MUMMIES] = zone[8][3];
-				traptile_formations[(int)TrapTiles.TRAP_ZOMBIES] = zone[0][0];
-				traptile_formations[(int)TrapTiles.TRAP_GARGOYLES2] = zone[2][1];
-				traptile_formations[(int)TrapTiles.TRAP_GIANTS] = zone[4][0];
-				traptile_formations[(int)TrapTiles.TRAP_GIANTS_IGUANAS] = zone[4][1];
-				traptile_formations[(int)TrapTiles.TRAP_EARTH] = zone[4][2];
-				traptile_formations[(int)TrapTiles.TRAP_OGRES_HYENAS] = zone[4][3];
-				traptile_formations[(int)TrapTiles.TRAP_SPHINX] = zone[5][0];
-				traptile_formations[(int)TrapTiles.TRAP_FIRE] = zone[5][1];
-				traptile_formations[(int)TrapTiles.TRAP_GREYWORM] = zone[5][2];
-				traptile_formations[(int)TrapTiles.TRAP_AGAMA] = zone[5][3];
-				traptile_formations[(int)TrapTiles.TRAP_RED_D] = zone[5][4];
-				traptile_formations[(int)TrapTiles.TRAP_UNDEAD_PARTYMIX] = zone[5][5];
-				traptile_formations[(int)TrapTiles.TRAP_FROSTRURUS] = zone[5][6];
-				traptile_formations[(int)TrapTiles.TRAP_FROSTGIANT] = zone[5][7];
-				traptile_formations[(int)TrapTiles.TRAP_MAGES] = zone[5][8];
-				traptile_formations[(int)TrapTiles.TRAP_FROST_D] = zone[5][9];
-				traptile_formations[(int)TrapTiles.TRAP_EYE] = eye_encounter;
-				traptile_formations[(int)TrapTiles.TRAP_WATERFALL_MUMMIES] = zone[8][3];
-				traptile_formations[(int)TrapTiles.TRAP_WIZARDS] = wizard_encounter;
-				traptile_formations[(int)TrapTiles.TRAP_WIZARDS2] = wizard_encounter;
-				traptile_formations[(int)TrapTiles.TRAP_COBRAS] = zone[3][2];
-				traptile_formations[(int)TrapTiles.TRAP_BLUE_D] = zone[9][0];
-				traptile_formations[(int)TrapTiles.TRAP_SLIMES] = zone[9][1];
-				traptile_formations[(int)TrapTiles.TRAP_PHANTOM] = phantom_encounter;
-				// proceed to place mons in all zones
-				zone[2].Shuffle(rng); // re-shuffling zone lists
-				zone[3].Shuffle(rng);
-				zone[4].Shuffle(rng);
-				zone[5].Shuffle(rng);
-				zone[6].Shuffle(rng);
-				zone[8].Shuffle(rng);
-				zone[9].Shuffle(rng);
-				for (int i = 0; i < zonecountmin.Length; ++i)
-				{
-					int loop = 0;
-					int f = 0;
-					int a = 0;
-					while(f < zone[i].Count)
-					{
-						if(loop == 0)
-						{
-							for(int j = 0; j < 8; ++j)
-							{
-								PutD(zoneaddr[i][a] + j, zone[i][f]); // first loop: fill the domain with the encounter type
-							}
-						}
-						if(loop == 1)
-						{
-							for (int j = 0; j < 8; j += 2)
-							{
-								PutD(zoneaddr[i][a] + j, zone[i][f]); // second loop: 1, 3, 5, and 7 are filled with the second formation
-							}
-						}
-						if(loop == 2)
-						{
-							PutD(zoneaddr[i][a] + 2, zone[i][f]); // third loop: 3, 6, and 8 are filled with the third encounter
-							PutD(zoneaddr[i][a] + 5, zone[i][f]);
-							PutD(zoneaddr[i][a] + 7, zone[i][f]);
-						}
-						if(loop == 3)
-						{
-							PutD(zoneaddr[i][a] + 3, zone[i][f]); // fourth loop: 4 and 7 are filled with the 4th encounter
-							PutD(zoneaddr[i][a] + 6, zone[i][f]);
-						}
-						if(loop == 4)
-						{
-							PutD(zoneaddr[i][a] + 4, zone[i][f]); // fifth loop: 5 and 6 are filled with the 5th encounter
-							PutD(zoneaddr[i][a] + 5, zone[i][f]);
-						}
-						if(loop > 4)
-						{
-							PutD(zoneaddr[i][a] + loop, zone[i][f]); // sicth-eigth loop: slot 6, 7, or 8 is filled depending on which loop we are at
-						}
-						f++;
-						a++;
-						if(a == zoneaddr[i].Count)
-						{
-							a = 0;
-							loop++;
-							if (loop == 8)
-								break; // place no more than 8 encounters per domain even if formations are left to be placed (this should basically never happen)
-						}
-					}
-				}
-				// duplicate entries in the overworld that clone other areas
-				foreach(int[] array in zoneclone)
-				{
-					byte[] dataToCopy = new byte[8];
-					for(int i = 0; i < 8; ++i)
-					{
-						dataToCopy[i] = GetD(array[0] + i);
-					}
-					for(int i = 1; i < array.Length; ++i)
-					{
-						for(int j = 0; j < 8; ++j)
-						{
-							PutD(array[i] + j, dataToCopy[j]);
-						}
-					}
-				}
-				// special zone placement for overworld 4,4 and 4,5: replace the first four encounters with encounter 0x80 (imp group)
-				PutD(0x120, imp_encounter); PutD(0x121, imp_encounter); PutD(0x122, imp_encounter); PutD(0x123, imp_encounter); PutD(0x160, imp_encounter); PutD(0x161, imp_encounter); PutD(0x162, imp_encounter); PutD(0x163, imp_encounter);
-				PutD(0x39E, 0x56); // replace 7th encounter on sky 5F with warmech
+					break;
+				default: // Raw Mana Elemental
+					thisEnemy.num_hits = 1;
+					thisEnemy.critrate = 1;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 5);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 5);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 5);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 2);
+					thisEnemy.atk_elem = 0b00000000;
+					thisEnemy.atk_ailment = 0b00000000;
+					thisEnemy.monster_type = 0b00000001;
+					thisEnemy.elem_resist = 0b11111011;
+					thisEnemy.elem_weakness = 0b00000000;
+					break;
 			}
 		}
 
-		public void DoEnemizer(MT19337 rng, bool enemies, bool formations, bool battledomains)
+		public void ENE_rollSmallElemental(MT19337 rng, ref EnemyInfo thisEnemy, int element)
 		{
-			Enemizer en = new Enemizer();
+			int tier = thisEnemy.tier;
+			switch (element)
+			{
+				case 1: // Earth Elemental
+					thisEnemy.num_hits = 1;
+					thisEnemy.critrate = 1;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 6);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 7);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 5);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 2);
+					thisEnemy.atk_elem = 0b10000000;
+					thisEnemy.atk_ailment = 0b00000000;
+					thisEnemy.monster_type = 0b00000001;
+					thisEnemy.elem_resist = 0b10101011;
+					thisEnemy.elem_weakness = 0b01010000;
+					break;
+				case 2: // Lightning Elemental
+					thisEnemy.num_hits = 1;
+					thisEnemy.critrate = 10;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 5);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 5);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 2);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 6);
+					thisEnemy.atk_elem = 0b01000000;
+					thisEnemy.atk_ailment = 0b00100000;
+					thisEnemy.monster_type = 0b00000001;
+					thisEnemy.elem_resist = 0b11011001;
+					thisEnemy.elem_weakness = 0b00000110;
+					break;
+				case 3: // Water Elemental
+					thisEnemy.num_hits = 1;
+					thisEnemy.critrate = 1;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 6);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 6);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 4);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 5);
+					thisEnemy.atk_elem = 0b00100000;
+					thisEnemy.atk_ailment = 0b00000000;
+					thisEnemy.monster_type = 0b00000001;
+					thisEnemy.elem_resist = 0b10011011;
+					thisEnemy.elem_weakness = 0b00100000;
+					break;
+				case 4: // Fire Elemental
+					thisEnemy.num_hits = 1;
+					thisEnemy.critrate = 1;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 5);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 6);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 3);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 6);
+					thisEnemy.atk_elem = 0b00010000;
+					thisEnemy.atk_ailment = 0b00000000;
+					thisEnemy.monster_type = 0b00000001;
+					thisEnemy.elem_resist = 0b10011001;
+					thisEnemy.elem_weakness = 0b00100000;
+					break;
+				case 5: // Death Elemental
+					thisEnemy.num_hits = 2;
+					thisEnemy.critrate = 1;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 7);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 4);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 4);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 4);
+					thisEnemy.atk_elem = 0b00001000;
+					thisEnemy.atk_ailment = 0b00001000;
+					thisEnemy.monster_type = 0b00001001;
+					thisEnemy.elem_resist = 0b10101011;
+					thisEnemy.elem_weakness = 0b00010000;
+					break;
+				case 6: // Time Elemental
+					thisEnemy.num_hits = rng.Between(2, 5);
+					thisEnemy.critrate = 1;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 4);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 4);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 4);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 5);
+					thisEnemy.atk_elem = 0b00000100;
+					thisEnemy.atk_ailment = 0b00010000;
+					thisEnemy.monster_type = 0b00000001;
+					thisEnemy.elem_resist = 0b10001111;
+					thisEnemy.elem_weakness = 0b01110000;
+					break;
+				case 7: // Poison Elemental
+					thisEnemy.num_hits = 1;
+					thisEnemy.critrate = 1;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 6);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 7);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 2);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 6);
+					thisEnemy.atk_elem = 0b00000010;
+					thisEnemy.atk_ailment = 0b00100000;
+					thisEnemy.monster_type = 0b10000001;
+					thisEnemy.elem_resist = 0b10001011;
+					thisEnemy.elem_weakness = 0b00000100;
+					break;
+				case 8: // Status Elemental
+					thisEnemy.num_hits = 2;
+					thisEnemy.critrate = 3;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 4);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 4);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 4);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 4);
+					thisEnemy.atk_elem = 0b00000001;
+					thisEnemy.atk_ailment = 0b01000000;
+					thisEnemy.monster_type = 0b00000001;
+					thisEnemy.elem_resist = 0b11111011;
+					thisEnemy.elem_weakness = 0b00000000;
+					if (thisEnemy.AIscript == 0xFF)
+					{
+						thisEnemy.AIscript = ENE_PickForcedAIScript(tier);
+					}
+					break;
+				default: // Air Elemental
+					thisEnemy.num_hits = 1;
+					thisEnemy.critrate = 1;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 5);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 6);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 2);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 7);
+					thisEnemy.atk_elem = 0b00000000;
+					thisEnemy.atk_ailment = 0b00000000;
+					thisEnemy.monster_type = 0b00000001;
+					thisEnemy.elem_resist = 0b10001011;
+					thisEnemy.elem_weakness = 0b00000000;
+					break;
+			}
+		}
+
+		public void ENE_rollDragon(MT19337 rng, ref EnemyInfo thisEnemy, int element)
+		{
+			int tier = thisEnemy.tier;
+			switch (element)
+			{
+				case 1: // Earth Elemental
+					thisEnemy.num_hits = 1;
+					thisEnemy.critrate = 1;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 6);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 4);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 7);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 1);
+					thisEnemy.atk_elem = 0b10000000;
+					thisEnemy.atk_ailment = 0b00000000;
+					thisEnemy.monster_type = 0b00000010;
+					thisEnemy.elem_resist = 0b11100000;
+					thisEnemy.elem_weakness = 0b00000010;
+					break;
+				case 2: // Lightning Elemental
+					thisEnemy.num_hits = 1;
+					thisEnemy.critrate = 5;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 7);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 6);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 3);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 6);
+					thisEnemy.atk_elem = 0b01000000;
+					thisEnemy.atk_ailment = 0b00000000;
+					thisEnemy.monster_type = 0b00000010;
+					thisEnemy.elem_resist = 0b11000000;
+					thisEnemy.elem_weakness = 0b00010000;
+					break;
+				case 3: // Ice Elemental
+					thisEnemy.num_hits = 1;
+					thisEnemy.critrate = 1;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 5);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 6);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 2);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 7);
+					thisEnemy.atk_elem = 0b00100000;
+					thisEnemy.atk_ailment = 0b00000000;
+					thisEnemy.monster_type = 0b00000010;
+					thisEnemy.elem_resist = 0b10100010;
+					thisEnemy.elem_weakness = 0b01010000;
+					break;
+				case 4: // Fire Elemental
+					thisEnemy.num_hits = 1;
+					thisEnemy.critrate = 1;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 7);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 7);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 5);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 6);
+					thisEnemy.atk_elem = 0b00010000;
+					thisEnemy.atk_ailment = 0b00000000;
+					thisEnemy.monster_type = 0b00000010;
+					thisEnemy.elem_resist = 0b10010000;
+					thisEnemy.elem_weakness = 0b00100010;
+					break;
+				case 5: // Death Elemental
+					thisEnemy.num_hits = 1;
+					thisEnemy.critrate = 1;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 6);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 6);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 6);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 3);
+					thisEnemy.atk_elem = 0b00001000;
+					thisEnemy.atk_ailment = 0b00010000;
+					thisEnemy.monster_type = 0b00001010;
+					thisEnemy.elem_resist = 0b10101011;
+					thisEnemy.elem_weakness = 0b00010000;
+					break;
+				case 6: // Time Elemental
+					thisEnemy.num_hits = 1;
+					thisEnemy.critrate = 12;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 6);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 7);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 6);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 6);
+					thisEnemy.atk_elem = 0b00000100;
+					thisEnemy.atk_ailment = 0b00010000;
+					thisEnemy.monster_type = 0b00000011;
+					thisEnemy.elem_resist = 0b10001111;
+					thisEnemy.elem_weakness = 0b01110000;
+					break;
+				case 7: // Poison Elemental
+					thisEnemy.num_hits = 1;
+					thisEnemy.critrate = 1;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 6);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 5);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 2);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 6);
+					thisEnemy.atk_elem = 0b00000010;
+					thisEnemy.atk_ailment = 0b00000000;
+					thisEnemy.monster_type = 0b00000010;
+					thisEnemy.elem_resist = 0b10000000;
+					thisEnemy.elem_weakness = 0b00100000;
+					break;
+				case 8: // Status Elemental
+					thisEnemy.num_hits = 1;
+					thisEnemy.critrate = 3;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 4);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 5);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 5);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 5);
+					thisEnemy.atk_elem = 0b00000001;
+					thisEnemy.atk_ailment = 0b01000000;
+					thisEnemy.monster_type = 0b00000011;
+					thisEnemy.elem_resist = 0b01110001;
+					thisEnemy.elem_weakness = 0b00000000;
+					if (thisEnemy.AIscript == 0xFF)
+					{
+						thisEnemy.AIscript = ENE_PickForcedAIScript(tier);
+					}
+					break;
+				default: // Standard Dragon
+					thisEnemy.num_hits = 1;
+					thisEnemy.critrate = 1;
+					thisEnemy.damage = ENE_rollEnemyStrength(tier, 6);
+					thisEnemy.accuracy = ENE_rollEnemyAccuracy(tier, 6);
+					thisEnemy.absorb = ENE_rollEnemyAbsorb(tier, 6);
+					thisEnemy.agility = ENE_rollEnemyEvade(tier, 6);
+					thisEnemy.atk_elem = 0b00000000;
+					thisEnemy.atk_ailment = 0b00000000;
+					thisEnemy.monster_type = 0b00000010;
+					thisEnemy.elem_resist = 0b00000000;
+					thisEnemy.elem_weakness = 0b00000000;
+					break;
+			}
+		}
+
+		public byte ENE_PickForcedAIScript(int tier)
+		{
+			if (tier >= 0 && tier <= 2)
+				return 0x1A; // tier 0-2 uses RockGOL script
+			else if (tier >= 3 && tier <= 4)
+				return 0x0D; // tier 3-4 uses R.GOYLE script
+			else if (tier == 5)
+				return 0x19; // tier 5 uses MudGOL script
+			else if (tier >= 6 && tier <= 7)
+				return 0x1D; // tier 6-7 uses MAGE script
+			else if (tier >= 8 && tier <= 9)
+				return 0x1C; // tier 8-9 uses EVILMAN script
+			else
+				return 0xFF; // invalid tier returns no script
+		}
+
+		private bool DoEnemizer_Enemies(MT19337 rng, EnemyInfo[] enemy, SpellInfo[] spell, EnemySkillInfo[] skill, EnemyScriptInfo[] script, string[] enemyNames, EnemizerTrackingInfo en)
+		{
+			Console.WriteLine("Enemies Start");
+			List<byte> enemyImageLUT = new List<byte> { 0b00000000, 0b00000010, 0b00000001, 0b00000011, 0b00000100, 0b00000110, 0b00000101, 0b00000111,
+														0b00001000, 0b00001010, 0b00001001, 0b00001011, 0b00001100, 0b00001110, 0b00001101, 0b00001111,
+														0b00010000, 0b00010010, 0b00010001, 0b00010011, 0b00010100, 0b00010110, 0b00010101, 0b00010111,
+														0b00011000, 0b00011010, 0b00011001, 0b00011011, 0b00011100, 0b00011110, 0b00011101, 0b00011111,
+														0b00100000, 0b00100010, 0b00100001, 0b00100011, 0b00100100, 0b00100110, 0b00100101, 0b00100111,
+														0b00101000, 0b00101010, 0b00101001, 0b00101011, 0b00101100, 0b00101110, 0b00101101, 0b00101111,
+														0b00110000, 0b00110010, 0b00110001, 0b00110011 }; // these are the default tilesets + pics of the enemies we wish to shuffle
+			List<byte> enemyImages = new List<byte> { };
+			for (int i = 0; i < Enemy.Lich; ++i)
+				enemyImages.Add(enemy[i].image); // we are reproducing the iamge array because we only want to shuffle the images, not the monsters themselves
+			List<string>[] monsterClassVariants = new List<string>[52]; // monster class modifiers that have effects on stats
+			monsterClassVariants[0] = new List<string> { "Fr", "R.", "Z.", "Wr", "Wz", "Sea" }; // imp variants with special perks
+			monsterClassVariants[1] = new List<string> { "Fr", "R.", "Z.", "Wz", "Sea" }; // iguana variants with special perks
+			monsterClassVariants[2] = new List<string> { "Fr", "R.", "Z.", "Wr", "Wz" }; // wolf variants with special perks
+			monsterClassVariants[3] = new List<string> { "Fr", "R.", "Z.", "Wz", "Sea" }; // giant variants with special perks
+			monsterClassVariants[4] = new List<string> { "Fr", "Z.", "Wr", "Wz" }; // sahag variants with special perks
+			monsterClassVariants[5] = new List<string> { "Fr", "Z." }; // shark variants with special perks
+			monsterClassVariants[6] = new List<string> { "Fr", "R.", "Z.", "Wz" }; // pirate variants with special perks
+			monsterClassVariants[7] = new List<string> { "Fr", "Z." }; // oddeye variants with special perks
+			monsterClassVariants[8] = new List<string> { "Wz" }; // bone variants with special perks
+			monsterClassVariants[9] = new List<string> { "Fr", "R.", "Z.", "Wz", "Sea" }; // ogre variants with special perks
+			monsterClassVariants[10] = new List<string> { "Fr", "R.", "Z.", "Wr", "Wz", "Sea" }; // creep variants with special perks
+			monsterClassVariants[11] = new List<string> { "Fr", "R.", "Z.", "Wr" }; // hyena variants with special perks
+			monsterClassVariants[12] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // asp variants with special perks
+			monsterClassVariants[13] = new List<string> { "Fr", "R.", "Z.", "Wr", "Wz", "Sea" }; // bull variants with special perks
+			monsterClassVariants[14] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // crab variants with special perks
+			monsterClassVariants[15] = new List<string> { "Fr", "R.", "Z.", "Wz", "Sea" }; // troll variants with special perks
+			monsterClassVariants[16] = new List<string> { "Wz" }; // ghost variants with special perks
+			monsterClassVariants[17] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // worm variants with special perks
+			monsterClassVariants[18] = new List<string> { "Sea" }; // wight variants with special perks
+			monsterClassVariants[19] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // eye variants with special perks
+			monsterClassVariants[20] = new List<string> { "Fr", "R.", "Z.", "Wz", "Sea" }; // medusa variants with special perks
+			monsterClassVariants[21] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // pede variants with special perks
+			monsterClassVariants[22] = new List<string> { "Fr", "R.", "Z.", "Wz" }; // catman variants with special perks
+			monsterClassVariants[23] = new List<string> { "Fr", "R.", "Z.", "Wr" }; // tiger variants with special perks
+			monsterClassVariants[24] = new List<string> { "Wz" }; // vamp variants with special perks
+			monsterClassVariants[25] = new List<string> { }; // large elem variants with special perks
+			monsterClassVariants[26] = new List<string> { "Fr", "R.", "Z.", "Wz", "Sea" }; // goyle variants with special perks
+			monsterClassVariants[27] = new List<string> { }; // drake 1 variants with special perks
+			monsterClassVariants[28] = new List<string> { "Wz" }; // flan variants with special perks
+			monsterClassVariants[29] = new List<string> { "Fr", "R.", "Z.", "Wz", "Sea" }; // manticore variants with special perks
+			monsterClassVariants[30] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // spider variants with special perks
+			monsterClassVariants[31] = new List<string> { "Fr", "R.", "Z." }; // ankylo variants with special perks
+			monsterClassVariants[32] = new List<string> { "Wz" }; // mummy variants with special perks
+			monsterClassVariants[33] = new List<string> { "Fr", "R.", "Z.", "Wr", "Wz" }; // wyvern variants with special perks
+			monsterClassVariants[34] = new List<string> { "Fr", "R.", "Z." }; // bird variants with special perks
+			monsterClassVariants[35] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // tyro variants with special perks
+			monsterClassVariants[36] = new List<string> { "Fr", "Z." }; // caribe variants with special perks
+			monsterClassVariants[37] = new List<string> { "Fr", "Z.", "Wz" }; // ocho variants with special perks
+			monsterClassVariants[38] = new List<string> { "Fr", "Z.", "Wr" }; // gator variants with special perks
+			monsterClassVariants[39] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // hydra variants with special perks
+			monsterClassVariants[40] = new List<string> { }; // bot variants with special perks
+			monsterClassVariants[41] = new List<string> { "Fr", "Z.", "Sea" }; // naga variants with special perks
+			monsterClassVariants[42] = new List<string> { }; // small elem variants with special perks
+			monsterClassVariants[43] = new List<string> { "Z.", "Wr", "Wz" }; // chimera variants with special perks
+			monsterClassVariants[44] = new List<string> { "Z.", "Wz" }; // piscodemon variants with special perks
+			monsterClassVariants[45] = new List<string> { }; // dragon 2 variants with special perks
+			monsterClassVariants[46] = new List<string> { "Fr", "R.", "Z.", "Wz" }; // knight variants with special perks
+			monsterClassVariants[47] = new List<string> { }; // golem variants with special perks
+			monsterClassVariants[48] = new List<string> { "Fr", "R.", "Z.", "Wz" }; // badman variants with special perks
+			monsterClassVariants[49] = new List<string> { "Fr", "R.", "Z.", "Wr", "Sea" }; // pony variants with special perks
+			monsterClassVariants[50] = new List<string> { "Fr", "R.", "Z.", "Sea" }; // elf variants with special perks
+			monsterClassVariants[51] = new List<string> { }; // mech variants with special perks
+			List<string>[] monsterNameVariants = new List<string>[52]; // name variants for monsters to prevent duplicates
+			bool[] monsterBaseNameUsed = new bool[52]; // true if the base name has been used, false if not
+			for (int i = 0; i < 52; ++i)
+			{
+				monsterBaseNameUsed[i] = false; // if enemy is not part of a variant class, by default it uses the base name for the monster
+				monsterNameVariants[i] = new List<string> { "A.", "B.", "C.", "D.", "E.", "F.", "G.", "H.", "I.", "K.", "L.", "M.", "N.", "P.", "S.", "T.", "V.", "W.", "X." };
+			}
+			monsterBaseNameUsed[25] = true; // large elemental
+			monsterBaseNameUsed[27] = true; // dragon 1
+			monsterBaseNameUsed[42] = true; // small elemental
+			monsterBaseNameUsed[45] = true; // dragon 2
+			enemyImageLUT.Shuffle(rng); // shuffle the LUT - whatever image was there in vanilla will be replaced with what is at its position in the LUT
+			enemyImages.Shuffle(rng); // and shuffle the enemy images themselves
+			byte whatIsPirate = enemyImageLUT[enemyImages[Enemy.Pirate]]; // find out what monster was assigned to the pirate
+			for (int i = 0; i < enemyImageLUT.Count(); ++i)
+			{
+				if (enemyImageLUT[i] == 0b00000110)
+				{
+					enemyImageLUT[i] = whatIsPirate; // assign whatever what given the pirate image the image that was assigned to the pirate monster's slot
+					break;
+				}
+			}
+			enemyImageLUT[enemyImages[Enemy.Pirate]] = 0b00000110; // and now assign the pirate himself his proper slot
+			for (int i = 0; i < GenericTilesetsCount; ++i) // generate the palettes for each tileset
+			{
+				en.palettesInTileset[i].Clear();
+				while (en.palettesInTileset[i].Count < 4)
+				{
+					int newPal = rng.Between(0, 0x3F);
+					if (en.palettesInTileset[i].Contains((byte)newPal))
+						continue;
+					en.palettesInTileset[i].Add((byte)newPal);
+				}
+			}
+			for (int i = 0; i < GenericTilesetsCount; ++i)// clear the list of enemies in each tileset
+				en.enemiesInTileset[i].Clear();
+			List<int> elementalsSelected = new List<int> { 0, 1, 2, 3, 4, 5, 6, 7, 8 }; // List of elementals already selected
+			List<int> dragonsSelected = new List<int> { 0, 1, 2, 3, 4, 5, 6, 7, 8 };
+			List<byte>[] enemyImagePalettes = new List<byte>[52]; // create lists of palettes used for each enemy image
+			for (int i = 0; i < 52; ++i)
+				enemyImagePalettes[i] = new List<byte> { };
+			for (byte i = 0; i < Enemy.Lich; ++i) // now start generating the enemies themselves.  we stop before Lich and make special exceptions for various monsters
+			{
+				List<MonsterPerks> perks = new List<MonsterPerks> { MonsterPerks.PERK_GAINSTAT10, MonsterPerks.PERK_LOSESTAT10 }; // list of perks this monster is eligible to receive
+				enemy[i].image = enemyImageLUT[enemyImages[i]]; // assign the monster's pic
+				if (enemy[i].tileset >= GenericTilesetsCount)
+					return false; // enemy was outside the boundaries for acceptable tilesets - abort enemizer
+				bool oldSize = enemy[i].Large; // remember if enemy was small (false) or large (true)
+				List<byte> acceptablepalettes = en.palettesInTileset[enemy[i].tileset].Except(enemyImagePalettes[enemy[i].image]).ToList();
+				if(acceptablepalettes.Count == 0)
+					acceptablepalettes = en.palettesInTileset[enemy[i].tileset].ToList();
+				enemy[i].pal = acceptablepalettes.PickRandom(rng);
+				enemyImagePalettes[enemy[i].image].Add(enemy[i].pal);				
+				// generate the stats for each monster
+				if (enemy[i].tier == -1)
+				{
+					// generate special monsters
+					switch (i)
+					{
+						case Enemy.Imp:
+							enemyNames[i] = "BUM";
+							break;
+						case Enemy.Pirate:
+							break;
+						case Enemy.Phantom:
+							break;
+						case Enemy.Garland:
+							break;
+						case Enemy.Astos:
+							break;
+						case Enemy.WarMech:
+							break;
+					}
+				}
+				else
+				{
+					en.enemiesInTileset[enemy[i].tileset].Add(i); // add enemy to enemiesInTileset unless it is a boss
+																  // adjust HP, EXP, and GP if enemy changes size
+					if (oldSize && enemy[i].Small) // large became small
+					{
+						enemy[i].hp *= 4;
+						enemy[i].hp /= 5;
+						enemy[i].exp *= 9;
+						enemy[i].exp /= 10;
+						enemy[i].gp *= 9;
+						enemy[i].gp /= 10;
+					}
+					else if (!oldSize && enemy[i].Large) // small became large
+					{
+						enemy[i].hp *= 5;
+						enemy[i].hp /= 4;
+						enemy[i].exp *= 10;
+						enemy[i].exp /= 9;
+						enemy[i].gp *= 10;
+						enemy[i].gp /= 9;
+					}
+					int elemental = 9; // track elemental affinity for certain classes of monsters (elementals and dragons)
+									   // generate BASE stats for generic monsters and their base name
+					switch (enemy[i].image)
+					{
+						case 0: // Imp
+							enemyNames[i] = "IMP";
+							enemy[i].num_hits = rng.Between(1, 3);
+							enemy[i].critrate = rng.Between(1, 5);
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 4);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 4);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 5);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 3);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000100;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 1: // Iguana
+							enemyNames[i] = "SAUR";
+							enemy[i].num_hits = rng.Between(1, 3);
+							enemy[i].critrate = rng.Between(1, 5);
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 4);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 5);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 5);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 2);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000010;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 2: // Wolf
+							enemyNames[i] = "WOLF";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = rng.Between(1, 5);
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 4);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 5);
+							enemy[i].absorb = 0;
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 6);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000000;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							break;
+						case 3: // Giant
+							enemyNames[i] = "GIANT";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = rng.Between(1, 5);
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 6);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 6);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 3);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 4);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000100;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							break;
+						case 4: // Sahag
+							enemyNames[i] = "SAHAG";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = 1;
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 4);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 2);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 3);
+							enemy[i].agility = 72 + enemy[i].exp / 40;
+							if (enemy[i].agility > 100)
+								enemy[i].agility = 100;
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00100000;
+							enemy[i].elem_resist = 0b10010000;
+							enemy[i].elem_weakness = 0b01000000;
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 5: // Shark
+							enemyNames[i] = "SHARK";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = 1;
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 6);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 5);
+							enemy[i].absorb = rng.Between(0, 8);
+							enemy[i].agility = 72 + enemy[i].exp / 40;
+							if (enemy[i].agility > 100)
+								enemy[i].agility = 100;
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00100000;
+							enemy[i].elem_resist = 0b10010000;
+							enemy[i].elem_weakness = 0b01000000;
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							break;
+						case 6: // Pirate
+							enemyNames[i] = "BRUTE";
+							enemy[i].num_hits = rng.Between(1, 2);
+							enemy[i].critrate = rng.Between(1, 5);
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 4);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 4);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 4);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 4);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000000;
+							enemy[i].elem_resist = 0b10000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 7: // Oddeye
+							enemyNames[i] = "EYE";
+							enemy[i].num_hits = rng.Between(1, 4);
+							enemy[i].critrate = 1;
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 2);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 5);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 2);
+							enemy[i].agility = enemy[i].exp > 400 ? ENE_rollEnemyEvade(enemy[i].tier, 4) : ENE_rollEnemyEvade(enemy[i].tier, 7);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00100000;
+							enemy[i].elem_resist = 0b10010000;
+							enemy[i].elem_weakness = 0b01000000;
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 8: // Skeleton
+							enemyNames[i] = "BONE";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = rng.Between(1, 2);
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 5);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 4);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 2);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 4);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00001000;
+							enemy[i].elem_resist = 0b00101011;
+							enemy[i].elem_weakness = 0b00010000;
+							break;
+						case 9: // Hyena
+							enemyNames[i] = "DOG";
+							enemy[i].num_hits = rng.Between(1, 2);
+							enemy[i].critrate = rng.Between(1, 3);
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 4);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 4);
+							enemy[i].absorb = rng.Between(0, 12);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 5);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000000;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 10: // Creep
+							enemyNames[i] = "CRAWL";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = 1;
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 6);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 4);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 4);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 4);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000000;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00010000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 11: // Ogre
+							enemyNames[i] = "OGRE";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = rng.Between(1, 5);
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 5);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 4);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 4);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 4);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000100;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							break;
+						case 12: // Asp
+							enemyNames[i] = "ASP";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = rng.Between(1, 31);
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 4);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 4);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 3);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 5);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000010;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 13: // Bull
+							enemyNames[i] = "BULL";
+							enemy[i].num_hits = 2;
+							enemy[i].critrate = rng.Between(1, 3);
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 4);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 5);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 4);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 5);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000000;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 14: // Crab
+							enemyNames[i] = "CRAB";
+							enemy[i].num_hits = rng.Between(2, 4);
+							enemy[i].critrate = 1;
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 5);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 3);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 4);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 6);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000000;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							break;
+						case 15: // Troll
+							enemyNames[i] = "TROLL";
+							enemy[i].num_hits = 3;
+							enemy[i].critrate = 1;
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 4);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 4);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 4);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 4);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b10000000;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 16: // Spectral Undead
+							enemyNames[i] = "GHOST";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = 1;
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 6);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 3);
+							enemy[i].absorb = rng.Between(0, 4) == 4 ? ENE_rollEnemyAbsorb(enemy[i].tier, 4) : rng.Between(0, 8);
+							enemy[i].agility = rng.Between(0, 2) == 2 ? ENE_rollEnemyEvade(enemy[i].tier, 4) : ENE_rollEnemyEvade(enemy[i].tier, 7);
+							enemy[i].atk_elem = 0b00000001;
+							enemy[i].atk_ailment = enemy[i].exp < 150 ? (byte)0b00001000 : (byte)0b00010000; // darkness for low xp enemies, stun for high xp enemies
+							enemy[i].monster_type = 0b00001001;
+							enemy[i].elem_resist = 0b10101011;
+							enemy[i].elem_weakness = 0b00010000;
+							break;
+						case 17: // Worm
+							enemyNames[i] = "WORM";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = 1;
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 5);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 7);
+							enemy[i].absorb = enemy[i].exp < 100 ? rng.Between(0, 10) : (enemy[i].exp > 1200 ? rng.Between(10, 40) : rng.Between(10, 20));
+							enemy[i].agility = rng.Between(0, 60);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000000;
+							enemy[i].elem_resist = 0b10000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 18: // Zombie Undead
+							enemyNames[i] = "WIGHT";
+							enemy[i].num_hits = rng.Between(0, 4) == 4 || enemy[i].exp < 100 ? 1 : 3;
+							enemy[i].critrate = 1;
+							enemy[i].damage = enemy[i].num_hits == 3 ? ENE_rollEnemyStrength(enemy[i].tier, 2) : ENE_rollEnemyStrength(enemy[i].tier, 4);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 2);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 2);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 5);
+							enemy[i].atk_elem = 0b00000001;
+							enemy[i].atk_ailment = enemy[i].exp > 80 ? (byte)0b00010000 : (byte)0b00000000;
+							enemy[i].monster_type = 0b00001000;
+							enemy[i].elem_resist = 0b00101011;
+							enemy[i].elem_weakness = 0b00010000;
+							break;
+						case 19: // Eyes that are totally not Beholders plz no sue
+							enemyNames[i] = "DRUJ";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = 1;
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 4);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 4);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 6);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 2);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b01000000;
+							enemy[i].elem_resist = 0b10000000;
+							enemy[i].elem_weakness = 0b00000000;
+							if (enemy[i].AIscript == 0xFF)
+								enemy[i].AIscript = ENE_PickForcedAIScript(enemy[i].tier);
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 20: // Medusa
+							enemyNames[i] = "LAMIA";
+							enemy[i].num_hits = rng.Between(0, 1) == 1 ? 1 : rng.Between(6, 10);
+							enemy[i].critrate = rng.Between(1, 5);
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 4);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 2);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 2);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 5);
+							enemy[i].atk_elem = 0b00000001;
+							enemy[i].atk_ailment = enemy[i].exp > 200 ? (byte)0b00010000 : (byte)0b00000000;
+							enemy[i].monster_type = 0b00000000;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							break;
+						case 21: // Pede
+							enemyNames[i] = "PEDE";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = 1;
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 7);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 5);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 5);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 4);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000000;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							break;
+						case 22: // Were
+							enemyNames[i] = "CAT";
+							enemy[i].num_hits = rng.Between(2, 3);
+							enemy[i].critrate = rng.Between(1, 2);
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 5);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 4);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 4);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 5);
+							enemy[i].atk_elem = 0b00000010;
+							enemy[i].atk_ailment = 0b00000100;
+							enemy[i].monster_type = 0b00010000;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							break;
+						case 23: // Tiger
+							enemyNames[i] = "TIGER";
+							enemy[i].num_hits = 2;
+							enemy[i].critrate = rng.Between(20, 100);
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 4);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 4);
+							enemy[i].absorb = 8;
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 5);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000000;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 24: // Blah, it's a Vampire!
+							enemyNames[i] = "VAMP";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = rng.Between(1, 5);
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 6);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 4);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 5);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 6);
+							enemy[i].atk_elem = 0b00000001;
+							enemy[i].atk_ailment = 0b00010000;
+							enemy[i].monster_type = 0b10001001;
+							enemy[i].elem_resist = 0b10101011;
+							enemy[i].elem_weakness = 0b00010000;
+							break;
+						case 25: // Large Elemental
+							if (elementalsSelected.Count > 0)
+								elemental = elementalsSelected.PickRandom(rng);
+							ENE_rollLargeElemental(rng, ref enemy[i], elemental);
+							switch (elemental)
+							{
+								case 1:
+									enemyNames[i] = "EARTH";
+									break;
+								case 2:
+									enemyNames[i] = "STORM";
+									break;
+								case 3:
+									enemyNames[i] = "ICE";
+									break;
+								case 4:
+									enemyNames[i] = "FIRE";
+									break;
+								case 5:
+									enemyNames[i] = "DEATH";
+									break;
+								case 6:
+									enemyNames[i] = "CRONO";
+									break;
+								case 7:
+									enemyNames[i] = "VENOM";
+									break;
+								case 8:
+									enemyNames[i] = "DJINN";
+									break;
+								default:
+									enemyNames[i] = "FORCE";
+									break;
+							}
+							if (elemental != 9)
+								elementalsSelected.Remove(elemental);
+							break;
+						case 26: // Gargoyle
+							enemyNames[i] = "GOYLE";
+							enemy[i].num_hits = 4;
+							enemy[i].critrate = 1;
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 4);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 3);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 4);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 5);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000001;
+							enemy[i].elem_resist = 0b10000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 27: // Dragon Type 1
+							if (dragonsSelected.Count > 0)
+								elemental = dragonsSelected.PickRandom(rng);
+							ENE_rollDragon(rng, ref enemy[i], elemental);
+							switch (elemental)
+							{
+								case 1:
+									enemyNames[i] = "Earth D";
+									break;
+								case 2:
+									enemyNames[i] = "Elec D";
+									break;
+								case 3:
+									enemyNames[i] = "Ice D";
+									break;
+								case 4:
+									enemyNames[i] = "Fire D";
+									break;
+								case 5:
+									enemyNames[i] = "Death D";
+									break;
+								case 6:
+									enemyNames[i] = "Time D";
+									break;
+								case 7:
+									enemyNames[i] = "Gas D";
+									break;
+								case 8:
+									enemyNames[i] = "Magic D";
+									break;
+								default:
+									enemyNames[i] = "DRAKE";
+									break;
+							}
+							if (elemental != 9)
+								dragonsSelected.Remove(elemental);
+							break;
+						case 28: // Slime
+							enemyNames[i] = "FLAN";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = 1;
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 6);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 2);
+							enemy[i].absorb = rng.Between(0, 2) == 2 ? rng.Between(0, 12) : 255;
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 1);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000001;
+							enemy[i].elem_weakness = (byte)(rng.Between(1, 6) << 4); // can be fire, ice, fire+ice, lit, fire+lit, or ice+lit weak
+							enemy[i].elem_resist = (byte)((0b11111111 ^ enemy[i].elem_weakness) & 0b11111011); // resist all other elements except time
+							break;
+						case 29: // Manticore
+							enemyNames[i] = "MANT";
+							enemy[i].num_hits = rng.Between(2, 3);
+							enemy[i].critrate = rng.Between(1, 3);
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 4);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 5);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 2);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 7);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000000;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 30: // Spider
+							enemyNames[i] = "BUG";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = 1;
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 3);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 4);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 4);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 4);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000000;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 31: // Ankylo
+							enemyNames[i] = "ANK";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = rng.Between(1, 3);
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 7);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 6);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 7);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 4);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000000;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							break;
+						case 32: // Mummy
+							enemyNames[i] = "MUMMY";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = rng.Between(1, 3);
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 3);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 4);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 5);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 3);
+							enemy[i].atk_elem = 0b00000001;
+							enemy[i].atk_ailment = 0b00100000;
+							enemy[i].monster_type = 0b00001000;
+							enemy[i].elem_resist = 0b00101011;
+							enemy[i].elem_weakness = 0b00010000;
+							break;
+						case 33: // Wyvern
+							enemyNames[i] = "WYRM";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = 1;
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 5);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 6);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 4);
+							enemy[i].agility = 72 + enemy[i].exp / 40;
+							if (enemy[i].agility > 100)
+								enemy[i].agility = 100;
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000010;
+							enemy[i].elem_resist = 0b10000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							break;
+						case 34: // Jerk Bird
+							enemyNames[i] = "BIRD";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = 1;
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 3);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 3);
+							enemy[i].absorb = rng.Between(0, 8);
+							enemy[i].agility = 72;
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000000;
+							enemy[i].elem_resist = 0b10000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 35: // Steak
+							enemyNames[i] = "TYRO";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = rng.Between(20, 40);
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 7);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 7);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 2);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 6);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000010;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							break;
+						case 36: // Pirahna
+							enemyNames[i] = "FISH";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = 1;
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 4);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 4);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 2);
+							enemy[i].agility = 72;
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00100000;
+							enemy[i].elem_resist = 0b10010000;
+							enemy[i].elem_weakness = 0b01000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							break;
+						case 37: // Ocho
+							enemyNames[i] = "OCHO";
+							enemy[i].num_hits = 3;
+							enemy[i].critrate = 1;
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 4);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 6);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 5);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 4);
+							enemy[i].atk_elem = 0b00000010;
+							enemy[i].atk_ailment = 0b00000100;
+							enemy[i].monster_type = 0b00100000;
+							enemy[i].elem_resist = 0b10010000;
+							enemy[i].elem_weakness = 0b01000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 38: // Gator
+							enemyNames[i] = "GATOR";
+							enemy[i].num_hits = rng.Between(2, 3);
+							enemy[i].critrate = 1;
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 6);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 5);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 4);
+							enemy[i].agility = 48;
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00100010;
+							enemy[i].elem_resist = 0b10010000;
+							enemy[i].elem_weakness = 0b01000000;
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 39: // Hydra
+							enemyNames[i] = "HYDRA";
+							enemy[i].num_hits = 4;
+							enemy[i].critrate = 1;
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 4);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 5);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 4);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 5);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000010;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 40: // Robot
+							enemyNames[i] = "BOT";
+							enemy[i].num_hits = rng.Between(1, 2);
+							enemy[i].critrate = rng.Between(1, 5);
+							enemy[i].damage = enemy[i].num_hits == 1 ? ENE_rollEnemyStrength(enemy[i].tier, 7) : ENE_rollEnemyStrength(enemy[i].tier, 5);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 6);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 7);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 6);
+							enemy[i].atk_elem = 0b00000001;
+							enemy[i].atk_ailment = enemy[i].num_hits == 1 ? (byte)0b00000000 : (byte)0b00010000;
+							enemy[i].monster_type = 0b00000000;
+							enemy[i].elem_resist = 0b00001011;
+							enemy[i].elem_weakness = 0b01000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 41: // Naga
+							enemyNames[i] = "NAGA";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = 1;
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 1);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 7);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 2);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 6);
+							enemy[i].atk_elem = 0b00000010;
+							enemy[i].atk_ailment = 0b00000100;
+							enemy[i].monster_type = 0b01000000;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							if (enemy[i].AIscript == 0xFF)
+								enemy[i].AIscript = ENE_PickForcedAIScript(enemy[i].tier);
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							break;
+						case 42: // Small Elemental
+							enemyNames[i] = "AIR";
+							if (elementalsSelected.Count > 0)
+								elemental = elementalsSelected.PickRandom(rng);
+							ENE_rollSmallElemental(rng, ref enemy[i], elemental);
+							switch (elemental)
+							{
+								case 1:
+									enemyNames[i] = "SHARD";
+									break;
+								case 2:
+									enemyNames[i] = "WIND";
+									break;
+								case 3:
+									enemyNames[i] = "WATER";
+									break;
+								case 4:
+									enemyNames[i] = "FLARE";
+									break;
+								case 5:
+									enemyNames[i] = "DOOM";
+									break;
+								case 6:
+									enemyNames[i] = "TIME";
+									break;
+								case 7:
+									enemyNames[i] = "BANE";
+									break;
+								case 8:
+									enemyNames[i] = "MAGIC";
+									break;
+								default:
+									enemyNames[i] = "AIR";
+									break;
+							}
+							if (elemental != 9)
+								elementalsSelected.Remove(elemental);
+							break;
+						case 43: // Chimera
+							enemyNames[i] = "BEAST";
+							enemy[i].num_hits = 4;
+							enemy[i].critrate = rng.Between(1, 3);
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 6);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 6);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 4);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 6);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000010;
+							enemy[i].elem_resist = 0b10010000;
+							enemy[i].elem_weakness = 0b00100000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 44: // Piscodemon
+							enemyNames[i] = "SQUID";
+							enemy[i].num_hits = rng.Between(2, 3);
+							enemy[i].critrate = 1;
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 5);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 4);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 5);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 6);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000000;
+							enemy[i].elem_resist = 0b00110011;
+							enemy[i].elem_weakness = 0b00000000;
+							break;
+						case 45: // Dragon Type 2
+							if (dragonsSelected.Count > 0)
+								elemental = dragonsSelected.PickRandom(rng);
+							ENE_rollDragon(rng, ref enemy[i], elemental);
+							switch (elemental)
+							{
+								case 1:
+									enemyNames[i] = "Earth D";
+									break;
+								case 2:
+									enemyNames[i] = "Elec D";
+									break;
+								case 3:
+									enemyNames[i] = "Ice D";
+									break;
+								case 4:
+									enemyNames[i] = "Fire D";
+									break;
+								case 5:
+									enemyNames[i] = "Death D";
+									break;
+								case 6:
+									enemyNames[i] = "Time D";
+									break;
+								case 7:
+									enemyNames[i] = "Gas D";
+									break;
+								case 8:
+									enemyNames[i] = "Magic D";
+									break;
+								default:
+									enemyNames[i] = "DRAGON";
+									break;
+							}
+							if (elemental != 9)
+								dragonsSelected.Remove(elemental);
+							break;
+						case 46: // Knight Type 1
+							enemyNames[i] = "KNIGHT";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = rng.Between(1, 10);
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 5);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 5);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 5);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 5);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000000;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 47: // Golem
+							enemyNames[i] = "GOLEM";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = 1;
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 6);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 4);
+							enemy[i].absorb = rng.Between(7, 60);
+							if (enemy[i].exp > 4000)
+								enemy[i].absorb = (enemy[i].absorb * 2) + 30;
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 4);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000000;
+							enemy[i].elem_resist = 0b11111011;
+							if (enemy[i].absorb > 60)
+							{
+								switch (rng.Between(0, 2))
+								{
+									case 0:
+										enemy[i].elem_resist &= 0b10111111;
+										break;
+									case 1:
+										enemy[i].elem_resist &= 0b11011111;
+										break;
+									case 2:
+										enemy[i].elem_resist &= 0b11101111;
+										break;
+								}
+							}
+							enemy[i].elem_weakness = 0b00000000;
+							break;
+						case 48: // Knight Type 2
+							enemyNames[i] = "RANGER";
+							enemy[i].num_hits = rng.Between(1, 2);
+							enemy[i].critrate = rng.Between(1, 5);
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 6);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 6);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 6);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 4);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000000;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 49: // Pony
+							enemyNames[i] = "PONY";
+							enemy[i].num_hits = rng.Between(2, 4);
+							enemy[i].critrate = rng.Between(1, 3);
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 5);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 5);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 4);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 6);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b00000000;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							break;
+						case 50: // Elf
+							enemyNames[i] = "ELF";
+							enemy[i].num_hits = 1;
+							enemy[i].critrate = rng.Between(1, 5);
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 4);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 4);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 6);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 7);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b01000000;
+							enemy[i].elem_resist = 0b00000000;
+							enemy[i].elem_weakness = 0b00000000;
+							if (enemy[i].AIscript == 0xFF)
+								enemy[i].AIscript = ENE_PickForcedAIScript(enemy[i].tier);
+							perks.Add(MonsterPerks.PERK_LOWRESIST);
+							perks.Add(MonsterPerks.PERK_HIGHRESIST);
+							perks.Add(MonsterPerks.PERK_LOWWEAKNESS);
+							perks.Add(MonsterPerks.PERK_HIGHWEAKNESS);
+							perks.Add(MonsterPerks.PERK_PLUSONEHIT);
+							perks.Add(MonsterPerks.PERK_POISONTOUCH);
+							perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
+							perks.Add(MonsterPerks.PERK_MUTETOUCH);
+							break;
+						case 51: // War Machine
+							enemyNames[i] = "MECH";
+							enemy[i].num_hits = 2;
+							enemy[i].critrate = 1;
+							enemy[i].damage = ENE_rollEnemyStrength(enemy[i].tier, 7);
+							enemy[i].accuracy = ENE_rollEnemyAccuracy(enemy[i].tier, 7);
+							enemy[i].absorb = ENE_rollEnemyAbsorb(enemy[i].tier, 7);
+							enemy[i].agility = ENE_rollEnemyEvade(enemy[i].tier, 4);
+							enemy[i].atk_elem = 0b00000000;
+							enemy[i].atk_ailment = 0b00000000;
+							enemy[i].monster_type = 0b10000000;
+							enemy[i].elem_resist = 0b00111011;
+							enemy[i].elem_weakness = 0b01000000;
+							enemy[i].exp *= 9;
+							enemy[i].exp /= 8;
+							break;
+					}
+					bool hasGlobalPerk = false;
+					bool didntChooseVariantClass = true; // false if this monster rolled a variant class and thus doesn't need a name modifier
+														 // if enemy has a global perk, apply it now and skip all other perks
+					if (i == Enemy.Crawl)
+					{
+						// Global Perk - multi-hitter with weak attacks but stun touch guaranteed (overrides existing atk ailment)
+						enemy[i].atk_elem = 0b00000001;
+						enemy[i].atk_ailment = 0b00010000;
+						enemy[i].num_hits = 8;
+						enemy[i].damage = 1;
+						hasGlobalPerk = true;
+					}
+					else if (i == Enemy.Coctrice)
+					{
+						// Global Perk - stonetouch (overrides other atk_elem and ailment), -1 hit if num_hits > 1
+						enemy[i].atk_elem = 0b00000010;
+						enemy[i].atk_ailment = 0b00000010;
+						if (enemy[i].num_hits > 1)
+							enemy[i].num_hits--;
+						hasGlobalPerk = true;
+					}
+					else if (i == Enemy.Mancat)
+					{
+						// Global Perk - Mancat (resistance to all elements except time and no weaknesses)
+						enemy[i].elem_resist = 0b11111011;
+						enemy[i].elem_weakness = 0b00000000;
+						hasGlobalPerk = true;
+					}
+					else if (i == Enemy.Sorceror)
+					{
+						// Global Perk - deathtouch
+						enemy[i].atk_elem = 0b00000000;
+						enemy[i].atk_ailment = 0b00000001;
+						hasGlobalPerk = true;
+					}
+					else if (i == Enemy.Nitemare)
+					{
+						// Global Perk - resist all except one low element and time, weak to selected element
+						switch (rng.Between(0, 2))
+						{
+							case 0:
+								enemy[i].elem_resist = 0b10111011;
+								enemy[i].elem_weakness = 0b01000000;
+								break;
+							case 1:
+								enemy[i].elem_resist = 0b11011011;
+								enemy[i].elem_weakness = 0b00100000;
+								break;
+							case 2:
+								enemy[i].elem_resist = 0b11101011;
+								enemy[i].elem_weakness = 0b00010000;
+								break;
+						}
+					}
+					else
+					{
+						// else, roll the chance for an enemy to get a class modifier.  Each class of monster can have Frost, Red, Zombie, Were, and Wizard variants, though some monster classes can't use some of these
+						// this perk restricts the monster from rolling any other perks
+						if (rng.Between(0, 11) < monsterClassVariants[enemy[i].image].Count())
+						{
+							didntChooseVariantClass = false;
+							string classModifier = monsterClassVariants[enemy[i].image].PickRandom(rng);
+							switch (classModifier) // apply the traits of this enemy class
+							{
+								case "Wz":
+									if (enemy[i].AIscript == 0xFF)
+									{
+										enemy[i].AIscript = ENE_PickForcedAIScript(enemy[i].tier);
+									}
+									break;
+								case "Fr":
+									enemy[i].elem_resist |= 0b00100000;
+									enemy[i].elem_resist &= 0b11101111;
+									enemy[i].elem_weakness |= 0b00010000;
+									enemy[i].elem_weakness &= 0b11011111;
+									enemy[i].atk_elem = 0b00100000;
+									break;
+								case "R.":
+									enemy[i].elem_resist |= 0b00010000;
+									enemy[i].elem_resist &= 0b11011111;
+									enemy[i].elem_weakness |= 0b00100000;
+									enemy[i].elem_weakness &= 0b11101111;
+									enemy[i].atk_elem = 0b00010000;
+									break;
+								case "Z.":
+									enemy[i].elem_resist |= 0b00101011;
+									enemy[i].elem_resist &= 0b11101111;
+									enemy[i].elem_weakness |= 0b00010000;
+									enemy[i].elem_weakness &= 0b11010100;
+									enemy[i].monster_type |= 0b00001000;
+									if (enemy[i].atk_ailment == 0)
+									{
+										enemy[i].atk_ailment = 0b00010000;
+										enemy[i].atk_elem = 0b00000001;
+									}
+									break;
+								case "Sea":
+									enemy[i].elem_resist |= 0b10010000;
+									enemy[i].elem_resist &= 0b10111111;
+									enemy[i].elem_weakness |= 0b01000000;
+									enemy[i].elem_weakness &= 0b01101111;
+									enemy[i].monster_type |= 0b00100000;
+									break;
+								case "Wr":
+									enemy[i].atk_ailment = 0b00000100;
+									enemy[i].atk_elem = 0b00000010;
+									enemy[i].monster_type |= 0b00010000;
+									break;
+							}
+							enemyNames[i] = classModifier + enemyNames[i]; // change the enemy's name
+							monsterClassVariants[enemy[i].image].Remove(classModifier); // remove this variant from the list of variants available for this enemy image
+						}
+					}
+					if (didntChooseVariantClass)
+					{
+						// else, roll minor perks.  there is a 75% chance to gain a perk, then 62.5%, 50%, and so on.  monsters cannot gain more than 4 perks
+						int num_perks = 0;
+						if (!hasGlobalPerk)
+						{
+							while (rng.Between(0, 7) > 1 + num_perks && num_perks < 4)
+							{
+								// select from the list of available perks
+								MonsterPerks this_perk = perks.PickRandom(rng);
+								bool didPerkRoll = true;
+								switch (this_perk)
+								{
+									case MonsterPerks.PERK_GAINSTAT10: // pick a random stat to increase by 10%, +3% XP
+										switch (rng.Between(0, 2))
+										{
+											case 0:
+												enemy[i].hp *= 11;
+												enemy[i].hp /= 10;
+												break;
+											case 1:
+												enemy[i].damage *= 11;
+												enemy[i].damage /= 10;
+												break;
+											case 2:
+												enemy[i].absorb *= 11;
+												enemy[i].absorb /= 10;
+												break;
+										}
+										enemy[i].exp *= 103;
+										enemy[i].exp /= 100;
+										break;
+									case MonsterPerks.PERK_LOSESTAT10: // pick a random stat to decrease by 10%, -3% XP
+										switch (rng.Between(0, 2))
+										{
+											case 0:
+												enemy[i].hp *= 9;
+												enemy[i].hp /= 10;
+												break;
+											case 1:
+												enemy[i].damage *= 9;
+												enemy[i].damage /= 10;
+												break;
+											case 2:
+												enemy[i].absorb *= 9;
+												enemy[i].absorb /= 10;
+												break;
+										}
+										enemy[i].exp *= 97;
+										enemy[i].exp /= 100;
+										break;
+									case MonsterPerks.PERK_LOWRESIST: // pick a low resist or remove the corresponding weakness, +4% XP
+										switch (rng.Between(0, 3))
+										{
+											case 0:
+												if ((enemy[i].elem_weakness & 0b10000000) == 0b10000000)
+													enemy[i].elem_weakness &= 0b01111111;
+												else
+													enemy[i].elem_resist |= 0b10000000;
+												break;
+											case 1:
+												if ((enemy[i].elem_weakness & 0b01000000) == 0b01000000)
+													enemy[i].elem_weakness &= 0b10111111;
+												else
+													enemy[i].elem_resist |= 0b01000000;
+												break;
+											case 2:
+												if ((enemy[i].elem_weakness & 0b00100000) == 0b00100000)
+													enemy[i].elem_weakness &= 0b11011111;
+												else
+													enemy[i].elem_resist |= 0b00100000;
+												break;
+											case 3:
+												if ((enemy[i].elem_weakness & 0b00010000) == 0b00001000)
+													enemy[i].elem_weakness &= 0b11101111;
+												else
+													enemy[i].elem_resist |= 0b00010000;
+												break;
+										}
+										enemy[i].exp *= 104;
+										enemy[i].exp /= 100;
+										break;
+									case MonsterPerks.PERK_LOWWEAKNESS: // pick a low weakness (or cancel a resist, or ignore for earth resist), -5% XP
+										switch (rng.Between(0, 3))
+										{
+											case 0:
+												if ((enemy[i].elem_resist & 0b10000000) == 0b10000000)
+													didPerkRoll = false;
+												else
+													enemy[i].elem_weakness |= 0b10000000;
+												break;
+											case 1:
+												if ((enemy[i].elem_resist & 0b01000000) == 0b01000000)
+													enemy[i].elem_resist &= 0b10111111;
+												else
+													enemy[i].elem_weakness |= 0b01000000;
+												break;
+											case 2:
+												if ((enemy[i].elem_resist & 0b00100000) == 0b00100000)
+													enemy[i].elem_resist &= 0b11011111;
+												else
+													enemy[i].elem_weakness |= 0b00100000;
+												break;
+											case 3:
+												if ((enemy[i].elem_resist & 0b00010000) == 0b00010000)
+													enemy[i].elem_resist &= 0b11101111;
+												else
+													enemy[i].elem_weakness |= 0b00010000;
+												break;
+										}
+										if (didPerkRoll)
+										{
+											enemy[i].exp *= 95;
+											enemy[i].exp /= 100;
+										}
+										break;
+									case MonsterPerks.PERK_HIGHRESIST:  // pick a high resist and remove the corresponding weakness, +3% XP
+										switch (rng.Between(0, 3))
+										{
+											case 0:
+												enemy[i].elem_resist |= 0b00001000;
+												enemy[i].elem_weakness &= 0b11110111;
+												break;
+											case 1:
+												enemy[i].elem_resist |= 0b00000100;
+												enemy[i].elem_weakness &= 0b11111011;
+												break;
+											case 2:
+												enemy[i].elem_resist |= 0b00000010;
+												enemy[i].elem_weakness &= 0b11111101;
+												break;
+											case 3:
+												enemy[i].elem_resist |= 0b00000001;
+												enemy[i].elem_weakness &= 0b11111110;
+												break;
+										}
+										enemy[i].exp *= 103;
+										enemy[i].exp /= 100;
+										break;
+									case MonsterPerks.PERK_HIGHWEAKNESS:
+										switch (rng.Between(0, 3))
+										{
+											case 0:
+												if ((enemy[i].elem_resist & 0b00001000) == 0b00001000)
+													enemy[i].elem_resist &= 0b11110111;
+												else
+													enemy[i].elem_weakness |= 0b00001000;
+												break;
+											case 1:
+												if ((enemy[i].elem_resist & 0b00000100) == 0b00000100)
+													enemy[i].elem_resist &= 0b11111011;
+												else
+													enemy[i].elem_weakness |= 0b00000100;
+												break;
+											case 2:
+												if ((enemy[i].elem_resist & 0b00000010) == 0b00000010)
+													enemy[i].elem_resist &= 0b11111101;
+												else
+													enemy[i].elem_weakness |= 0b00000010;
+												break;
+											case 3:
+												if ((enemy[i].elem_resist & 0b00000001) == 0b00000001)
+													enemy[i].elem_resist &= 0b11111110;
+												else
+													enemy[i].elem_weakness |= 0b00000001;
+												break;
+										}
+										if (didPerkRoll)
+										{
+											enemy[i].exp *= 97;
+											enemy[i].exp /= 100;
+										}
+										break;
+									case MonsterPerks.PERK_PLUSONEHIT: // +1 hit, +5/3/2/1... XP for an addition hit
+										enemy[i].num_hits++;
+										switch (enemy[i].num_hits)
+										{
+											case 2:
+												enemy[i].exp *= 21;
+												enemy[i].exp /= 20;
+												break;
+											case 3:
+												enemy[i].exp *= 103;
+												enemy[i].exp /= 100;
+												break;
+											case 4:
+												enemy[i].exp *= 51;
+												enemy[i].exp /= 50;
+												break;
+											default:
+												enemy[i].exp *= 101;
+												enemy[i].exp /= 100;
+												break;
+										}
+										break;
+									case MonsterPerks.PERK_POISONTOUCH: // adds poisontouch if enemy has no atk_ailment already, no XP increase
+										if (enemy[i].atk_ailment == 0)
+										{
+											enemy[i].atk_ailment = 0b00000100;
+											enemy[i].atk_elem = 0b00000010;
+										}
+										break;
+									case MonsterPerks.PERK_STUNSLEEPTOUCH: // adds stun or sleep touch if enemy has no atk_ailment already
+										if (enemy[i].atk_ailment == 0)
+										{
+											enemy[i].atk_ailment = rng.Between(0, 1) == 0 ? (byte)0b00100000 : (byte)0b00010000;
+											enemy[i].atk_elem = 0b00000001;
+											enemy[i].exp *= 103;
+											enemy[i].exp /= 100;
+										}
+										break;
+									case MonsterPerks.PERK_MUTETOUCH: // adds mute touch if enemy has no atk_ailment already
+										if (enemy[i].atk_ailment == 0)
+										{
+											enemy[i].atk_ailment = 0b01000000;
+											enemy[i].atk_elem = 0b00000001;
+											enemy[i].exp *= 51;
+											enemy[i].exp /= 50;
+										}
+										break;
+								}
+								num_perks++;
+							}
+						}
+						// if enemy's vanilla name has already been used, add a name modifier
+						if (elemental == 9) // don't make alternate names for elementals
+						{
+							if (monsterBaseNameUsed[enemy[i].image])
+							{
+								string nameModifier = monsterNameVariants[enemy[i].image].PickRandom(rng);
+								enemyNames[i] = nameModifier + enemyNames[i];
+							}
+							else
+								monsterBaseNameUsed[enemy[i].image] = true;
+						}
+					}
+					if (enemy[i].AIscript != 0xFF) // set monster type to Mage if it has a script
+						enemy[i].monster_type |= 0b01000000;
+					for (int j = 1; j < enemy[i].num_hits; ++j) // for each hit past the first, reduce the base damage by one for every 15 points of damage rating
+					{
+						enemy[i].damage = enemy[i].damage - enemy[i].damage / 15;
+					}
+					enemy[i].damage = rng.Between(enemy[i].damage - enemy[i].damage / 25, enemy[i].damage + enemy[i].damage / 25); // variance for damage rating
+					enemy[i].hp = rng.Between(enemy[i].hp - enemy[i].hp / 30, enemy[i].hp + enemy[i].hp / 30); // variance for hp rating
+					enemy[i].gp = rng.Between(enemy[i].gp - enemy[i].gp / 20, enemy[i].gp + enemy[i].gp / 20); // variance for gp reward
+					enemy[i].exp = rng.Between(enemy[i].exp - enemy[i].exp / 40, enemy[i].exp + enemy[i].exp / 40); // variance for exp reward
+				}
+			}
+			for (int i = 0; i < GenericTilesetsCount; ++i) // remove palettes from tilesets where there are no mons using those palettes
+			{
+				List<byte> palRemoveList = new List<byte> { };
+				foreach (byte pal in en.palettesInTileset[i])
+				{
+					bool nopalettematch = true;
+					foreach (byte mon in en.enemiesInTileset[i])
+					{
+						if (enemy[mon].pal == pal)
+						{
+							nopalettematch = false;
+							break;
+						}
+					}
+					if (nopalettematch)
+					{
+						palRemoveList.Add(pal);
+					}
+				}
+				foreach (byte pal in palRemoveList)
+				{
+					en.palettesInTileset[i].Remove(pal);
+				}
+			}
+			// modify scripts - all scripts that are skills-only gain a magic list full of spells in the same tier (with 24/128 chance of activating)
+			// each spell is then selected from a list of spells available for that tier.  it is not possible to promote to a higher tier
+			// skills will remain the same
+			for (int i = 0; i < ScriptCount - 10; ++i) // exclude the last 10 scripts
+			{
+				if (script[i].spell_chance == 0)
+				{
+					byte whichSpell = 0; // index for CURE, a tier 1 enemy spell
+					switch (skill[script[i].skill_list[0]].tier)
+					{
+						case 2:
+							whichSpell = 5; // these are just spell indices of spells that correspond to the tier, we will replace them later
+							break;
+						case 3:
+							whichSpell = 21;
+							break;
+						case 4:
+							whichSpell = 37;
+							break;
+						case 5:
+							whichSpell = 0xFF; // if a tier 5 is encountered, we don't fill the spell list (the skill is nasty enough!) - by default this only applies to warmech
+							break;
+					}
+					for (byte j = 0; j < 8; ++j)
+					{
+						script[i].spell_list[j] = whichSpell;
+					}
+					if (whichSpell != 0xFF)
+						script[i].spell_chance = 24;
+				}
+				// start replacing each spell with another spell from the same tier
+				for (byte j = 0; j < 8; ++j)
+				{
+					if (script[i].spell_list[j] == 0xFF)
+						continue; // skip blank spells
+					int whichTier = spell[script[i].spell_list[j]].tier;
+					List<byte> eligibleSpellIDs = new List<byte> { };
+					for (byte k = 0; k < 64; ++k)
+					{
+						if (spell[k].tier == whichTier)
+							eligibleSpellIDs.Add(k);
+					}
+					script[i].spell_list[j] = eligibleSpellIDs.PickRandom(rng);
+				}
+			}
+			return true;
+		}
+
+		public void DoEnemizer(MT19337 rng, bool doEnemies, bool doFormations)
+		{
+			Console.WriteLine("Enemizer Start");
+			// code modification to allow any formation except 0x00 to be a trap (lifted from ShuffleTrapTiles)
+			Data[0x7CDC5] = 0xD0; // changes the game's programming
+			bool IsBattleTile(Blob tuple) => tuple[0] == 0x0A;
+			bool IsRandomBattleTile(Blob tuple) => IsBattleTile(tuple) && (tuple[1] & 0x80) != 0x00;
+			var tilesets = Get(TilesetDataOffset, TilesetDataCount * TilesetDataSize * TilesetCount).Chunk(TilesetDataSize).ToList();
+			tilesets.ForEach(tile => { if (IsRandomBattleTile(tile)) tile[1] = 0x00; });
+			Put(TilesetDataOffset, tilesets.SelectMany(tileset => tileset.ToBytes()).ToArray());// set all random battle tiles to zero
+
+			SpellInfo[] spell = new SpellInfo[MagicCount]; // list of spells and their appropriate tiers
+			EnemySkillInfo[] skill = new EnemySkillInfo[EnemySkillCount]; // list of enemy skills and their appropriate tiers
+			EnemyScriptInfo[] script = new EnemyScriptInfo[ScriptCount]; // list of enemy scripts
+			
 			// load vanilla values from ROM into the enemizer
-			en.PutAllFormationData(Get(FormationDataOffset, FormationDataSize * FormationDataCount));
-			en.PutAllDomainData(Get(ZoneFormationsOffset, ZoneFormationsSize * ZoneCount));
-			for(int i = 0; i < MagicCount; ++i)
+			byte[] spelltiers_enemy = new byte[]
 			{
-				byte[] spellInfo = Get(MagicOffset + i * MagicSize, MagicSize);
-				en.ReadSpellDataFromMagicBytes(en.decompressSpellData(spellInfo), i);
+				1, 0, 1, 3, 1, 2, 1, 1,
+				0, 2, 2, 1, 2, 1, 2, 2,
+				2, 0, 2, 2, 3, 3, 3, 2,
+				0, 0, 2, 1, 2, 3, 0, 3,
+				3, 0, 0, 3, 4, 4, 0, 3,
+				0, 0, 3, 3, 4, 3, 4, 3,
+				4, 0, 3, 4, 4, 4, 2, 1,
+				0, 5, 4, 4, 5, 4, 4, 4
+			};
+			byte[] skilltiers_enemy = new byte[]
+			{
+				3, 2, 3, 1, 2, 1, 4, 3, 3, 4, 4, 4, 5, 3, 4, 3, 4, 4, 4, 1, 5, 2, 2, 1, 5, 5
+			};
+			for (int i = 0; i < MagicCount; ++i)
+			{
+				spell[i] = new SpellInfo();
+				spell[i].decompressData(Get(MagicOffset + i * MagicSize, MagicSize));
+				spell[i].tier = spelltiers_enemy[i];
 			}
-			for (int i = 0; i < EnemyCount; ++i)
+			for(int i = 0; i < EnemySkillCount; ++i)
 			{
-				byte[] enemyInfo = Get(EnemyOffset + i * EnemySize, EnemySize);
-				en.ReadEnemyDataFromEnemies(en.decompressEnemyData(enemyInfo), i);
-			}
-			en.enemyNames = ReadText(EnemyTextPointerOffset, EnemyTextPointerBase, EnemyCount); // load all the enemy names into the array for use by enemizer
-			for(int i = 0; i < EnemyCount; ++i) // we want to know how many characters are in enemy names so we don't make random names that are too long for the ROM to hold
-			{
-				en.numEnemyNameCharacters += en.enemyNames[i].Length;
+				skill[i] = new EnemySkillInfo();
+				skill[i].decompressData(Get(EnemySkillOffset + i * EnemySkillSize, EnemySkillSize));
+				skill[i].tier = skilltiers_enemy[i];
 			}
 			for (int i = 0; i < ScriptCount; ++i)
 			{
-				byte[] scriptInfo = Get(ScriptOffset + i * ScriptSize, ScriptSize);
-				en.ReadScriptDataFromScript(en.decompressEnemyScript(scriptInfo), i);
-			}
-			for (int i = 0; i < FormationCount; ++i)
+				script[i] = new EnemyScriptInfo();
+				script[i].decompressData(Get(ScriptOffset + i * ScriptSize, ScriptSize));
+			}	
+			EnemyInfo[] enemy = new EnemyInfo[EnemyCount]; // list of enemies, including information that is either inferred from formation inspection or tier lists that I have just made up
+			EnemizerTrackingInfo en = new EnemizerTrackingInfo(); // structure that contains many lists and other information that is helpful for managing formation generation efficiently
+			// set enemy default tier list.  these listings are based on a combination of where the enemy is placed in the game, its xp yield, its rough difficulty, whether it has a script or not, and gut feels
+			// -1 indicates a monster with special rules for enemy generation (usually a boss_
+			int[] enemyTierList = new int[] {	 -1, 0, 0, 1, 1, 3, 1, 6, 5, 4, 6, 6, 0, 1, 4, -1,
+												  1, 2, 5, 0, 7, 0, 3, 1, 2, 2, 4, 2, 2, 5, 1, 2,
+												  5, 2, 5, 3, 4, 4, 5, 1, 2, 3, 5, 0, 1, 1, 2, 8,
+												  5, 5, 7, -1, 4, 5, 4, 4, 4, 5, 3, 4, 5, 7, 1, 3,
+												  4, 5, 5, 6, 6, 1, 2, 2, 7, 0, 1, 5, 4, 6, 7, 3,
+												  5, 2, 3, 5, 5, 7, 9, 2, 4, 4, 5, 4, 7, 4, 5, 6,
+												  8, 6, 6, 6, 7, 6, 8, 2, 4, -1, 8, 8, 5, 6, 9, 6,
+												  7, -1, 4, 7, 1, 5, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
+			for (int i = 0; i < EnemyCount; ++i)
 			{
-				byte[] formationData = Get(FormationDataOffset + FormationDataSize * i, FormationDataSize).ToBytes();
-				en.ReadEnemyDataFromFormation(en.decompressFormation(formationData), i); // read information about enemy formations from the ROM
+				enemy[i] = new EnemyInfo();
+				enemy[i].decompressData(Get(EnemyOffset + i * EnemySize, EnemySize));
+				enemy[i].tier = enemyTierList[i];
+			}		
+			string[] enemyNames = ReadText(EnemyTextPointerOffset, EnemyTextPointerBase, EnemyCount); // load all the enemy names into the array for use by enemizer
+			for (int i = 0; i < FormationCount; ++i) // we need to scour the formations list for enemy information, and to give the enemizer tracking info construct information it can work with
+			{
+				FormationInfo f = new FormationInfo();
+				f.decompressData(Get(FormationDataOffset + i * FormationSize, FormationSize));
+				en.ReadEnemyDataFromFormation(f, enemy);
 			}
 			en.PurgeIDFromEnemyTilesetList(Enemy.Imp);
 			en.PurgeIDFromEnemyTilesetList(Enemy.Pirate);
@@ -3919,22 +3564,22 @@ namespace FF1Lib
 			en.PurgeIDFromEnemyTilesetList(Enemy.Astos);
 			en.PurgeIDFromEnemyTilesetList(Enemy.Garland);
 			en.PurgeIDFromEnemyTilesetList(Enemy.WarMech); // purging enemies from the generic enemy lists that we don't want to appear outside of set battles
-			if (enemies)
+			if (doEnemies)
 			{
 				// do enemizer stuff
-				if(en.DoEnemies(rng))
+				if(DoEnemizer_Enemies(rng, enemy, spell, skill, script, enemyNames, en))
 				{
-					formations = true; // must use formation generator with enemizer
-					for(int i = 0; i < EnemyCount; ++i)
+					doFormations = true; // must use formation generator with enemizer
+					for (int i = 0; i < EnemyCount; ++i)
 					{
-						Put(EnemyOffset + EnemySize * i, en.enemyStats[i].CompressData()); // move every entry from the enemizer to the ROM
+						Put(EnemyOffset + EnemySize * i, enemy[i].compressData()); // move every entry from the enemizer to the ROM
 					}
-					for(int i = 0; i < ScriptCount; ++i)
+					for (int i = 0; i < ScriptCount; ++i)
 					{
-						Put(ScriptOffset + ScriptSize * i, en.enemyScripts[i].compressData()); // and move the modified scripts as well
+						Put(ScriptOffset + ScriptSize * i, script[i].compressData()); // and move the modified scripts as well
 					}
-					var enemyTextPart1 = en.enemyNames.Take(2).ToArray();
-					var enemyTextPart2 = en.enemyNames.Skip(2).ToArray();
+					var enemyTextPart1 = enemyNames.Take(2).ToArray();
+					var enemyTextPart2 = enemyNames.Skip(2).ToArray();
 					WriteText(enemyTextPart1, EnemyTextPointerOffset, EnemyTextPointerBase, 0x2CFEC);
 					WriteText(enemyTextPart2, EnemyTextPointerOffset + 4, EnemyTextPointerBase, EnemyTextOffset);
 					en.PurgeIDFromEnemyTilesetList(Enemy.Imp);
@@ -3950,36 +3595,9 @@ namespace FF1Lib
 					throw new InsaneException("Something went wrong with Enemy Generation (Enemizer)!");
 				}
 			}
-			if(formations)
+			if(doFormations)
 			{
-				if(en.DoFormations(rng, enemies))
-				{
-					Put(FormationsOffset, en.GetFormationData());
-					if(en.imp_encounter != 0x80)
-						throw new InsaneException(en.imp_encounter.ToString());
-					// we must also do the domains
-					// This code is partially lifted from ShuffleTrapTiles
-					Data[0x7CDC5] = 0xD0; // changes the game's programming
-
-					bool IsBattleTile(Blob tuple) => tuple[0] == 0x0A;
-					bool IsRandomBattleTile(Blob tuple) => IsBattleTile(tuple) && (tuple[1] & 0x80) != 0x00;
-
-					var tilesets = Get(TilesetDataOffset, TilesetDataCount * TilesetDataSize * TilesetCount).Chunk(TilesetDataSize).ToList();
-					tilesets.ForEach(tile => { if (IsRandomBattleTile(tile)) tile[1] = 0x00; });
-					Put(TilesetDataOffset, tilesets.SelectMany(tileset => tileset.ToBytes()).ToArray());// set all random battle tiles to zero
-					
-					en.DoDomains(rng);
-					// write domains information
-					Put(ZoneFormationsOffset, en.GetDomainData());
-
-					// write trap tile information
-					for (int i = 0; i < en.traptile_addresses.Length; ++i)
-					{
-						Data[TilesetDataOffset + en.traptile_addresses[i]] = en.traptile_formations[i];
-					}
-				}
-					
-				else
+				if(!DoEnemizer_Formations(rng, enemy, en))
 				{
 					Console.WriteLine("Fission Mailed - Abort Formation Shuffle");
 					throw new InsaneException("Something went wrong with Formation Generation (Enemizer)!");

--- a/FF1Lib/Enemizer.cs
+++ b/FF1Lib/Enemizer.cs
@@ -99,7 +99,7 @@ namespace FF1Lib
 
 			public void decompressData(byte[] data)
 			{
-				if (data.Length < MagicSize)
+				if (data.Length != MagicSize)
 				{
 					accuracy = 0x00;
 					effect = 0x00;
@@ -147,7 +147,7 @@ namespace FF1Lib
 
 			public void decompressData(byte[] data)
 			{
-				if (data.Length < EnemySkillSize)
+				if (data.Length != EnemySkillSize)
 				{
 					accuracy = 0x00;
 					effect = 0x00;
@@ -589,7 +589,6 @@ namespace FF1Lib
 
 		private bool DoEnemizer_Formations(MT19337 rng, EnemyInfo[] enemy, EnemizerTrackingInfo en)
 		{
-			Console.WriteLine("Formations Start");
 			bool NotFeatured(byte mon) => !en.featured[mon];
 			bool Small(byte mon) => enemy[mon].Small;
 			bool Large(byte mon) => enemy[mon].Large;
@@ -1787,7 +1786,6 @@ namespace FF1Lib
 
 		private bool DoEnemizer_Enemies(MT19337 rng, EnemyInfo[] enemy, SpellInfo[] spell, EnemySkillInfo[] skill, EnemyScriptInfo[] script, string[] enemyNames, EnemizerTrackingInfo en)
 		{
-			Console.WriteLine("Enemies Start");
 			List<byte> enemyImageLUT = new List<byte> { 0b00000000, 0b00000010, 0b00000001, 0b00000011, 0b00000100, 0b00000110, 0b00000101, 0b00000111,
 														0b00001000, 0b00001010, 0b00001001, 0b00001011, 0b00001100, 0b00001110, 0b00001101, 0b00001111,
 														0b00010000, 0b00010010, 0b00010001, 0b00010011, 0b00010100, 0b00010110, 0b00010101, 0b00010111,
@@ -1928,7 +1926,7 @@ namespace FF1Lib
 				else
 				{
 					en.enemiesInTileset[enemy[i].tileset].Add(i); // add enemy to enemiesInTileset unless it is a boss
-																  // adjust HP, EXP, and GP if enemy changes size
+					// adjust HP, EXP, and GP if enemy changes size
 					if (oldSize && enemy[i].Small) // large became small
 					{
 						enemy[i].hp *= 4;
@@ -1948,7 +1946,7 @@ namespace FF1Lib
 						enemy[i].gp /= 9;
 					}
 					int elemental = 9; // track elemental affinity for certain classes of monsters (elementals and dragons)
-									   // generate BASE stats for generic monsters and their base name
+					// generate BASE stats for generic monsters and their base name
 					switch (enemy[i].image)
 					{
 						case 0: // Imp
@@ -3487,7 +3485,6 @@ namespace FF1Lib
 
 		public void DoEnemizer(MT19337 rng, bool doEnemies, bool doFormations)
 		{
-			Console.WriteLine("Enemizer Start");
 			// code modification to allow any formation except 0x00 to be a trap (lifted from ShuffleTrapTiles)
 			Data[0x7CDC5] = 0xD0; // changes the game's programming
 			bool IsBattleTile(Blob tuple) => tuple[0] == 0x0A;
@@ -3582,12 +3579,6 @@ namespace FF1Lib
 					var enemyTextPart2 = enemyNames.Skip(2).ToArray();
 					WriteText(enemyTextPart1, EnemyTextPointerOffset, EnemyTextPointerBase, 0x2CFEC);
 					WriteText(enemyTextPart2, EnemyTextPointerOffset + 4, EnemyTextPointerBase, EnemyTextOffset);
-					en.PurgeIDFromEnemyTilesetList(Enemy.Imp);
-					en.PurgeIDFromEnemyTilesetList(Enemy.Pirate);
-					en.PurgeIDFromEnemyTilesetList(Enemy.Phantom);
-					en.PurgeIDFromEnemyTilesetList(Enemy.Astos);
-					en.PurgeIDFromEnemyTilesetList(Enemy.Garland);
-					en.PurgeIDFromEnemyTilesetList(Enemy.WarMech); // making doubleplus sure these don't appear, probably not necessary
 				}
 				else
 				{

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -345,7 +345,7 @@ namespace FF1Lib
 			// Put this before other encounter / trap tile edits.
 			if ((bool)flags.AllowUnsafeMelmond)
 			{
-				EnableMelmondGhetto(flags.RandomizeFormationEnemizer);
+				EnableMelmondGhetto(flags.RandomizeFormationEnemizer || flags.RandomizeEnemizer);
 			}
 
 			// After unrunnable shuffle and before formation shuffle. Perfect!

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -169,6 +169,7 @@ namespace FF1Lib
 
 			if (flags.RandomizeEnemizer || flags.RandomizeFormationEnemizer)
 			{
+				FixEnemyPalettes(); // fixes a big in the original game's programming that causes third enemy slot's palette to render incorrectly
 				DoEnemizer(rng, flags.RandomizeEnemizer, flags.RandomizeFormationEnemizer);
 			}
 

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -167,9 +167,9 @@ namespace FF1Lib
 			}
 #endif
 
-			if (flags.RandomizeFormationEnemizer)
+			if (flags.RandomizeEnemizer || flags.RandomizeFormationEnemizer)
 			{
-				DoEnemizer(rng, false, flags.RandomizeFormationEnemizer, false);
+				DoEnemizer(rng, flags.RandomizeEnemizer, flags.RandomizeFormationEnemizer, false);
 			}
 
 			if (preferences.ModernBattlefield)
@@ -364,12 +364,12 @@ namespace FF1Lib
 				FiendShuffle(rng);
 			}
 
-			if (flags.FormationShuffleMode != FormationShuffleMode.None)
+			if (flags.FormationShuffleMode != FormationShuffleMode.None && !flags.RandomizeEnemizer && !flags.RandomizeFormationEnemizer)
 			{
 				ShuffleEnemyFormations(rng, flags.FormationShuffleMode);
 			}
 
-			if (((bool)flags.EnemyTrapTiles))
+			if (((bool)flags.EnemyTrapTiles) && !flags.RandomizeEnemizer && !flags.RandomizeFormationEnemizer)
 			{
 				ShuffleTrapTiles(rng, ((bool)flags.RandomTrapFormations));
 			}
@@ -538,7 +538,7 @@ namespace FF1Lib
 				FixEnemyElementalResistances();
 			}
 
-			if (preferences.FunEnemyNames)
+			if (preferences.FunEnemyNames && !flags.RandomizeEnemizer && !flags.RandomizeFormationEnemizer)
 			{
 				FunEnemyNames(preferences.TeamSteak);
 			}
@@ -607,7 +607,7 @@ namespace FF1Lib
 				UseVariablePaletteForCursorAndStone();
 			}
 
-			if (preferences.PaletteSwap)
+			if (preferences.PaletteSwap && !flags.RandomizeEnemizer && !flags.RandomizeFormationEnemizer)
 			{
 				PaletteSwap(rng);
 			}

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -169,7 +169,7 @@ namespace FF1Lib
 
 			if (flags.RandomizeEnemizer || flags.RandomizeFormationEnemizer)
 			{
-				DoEnemizer(rng, flags.RandomizeEnemizer, flags.RandomizeFormationEnemizer, false);
+				DoEnemizer(rng, flags.RandomizeEnemizer, flags.RandomizeFormationEnemizer);
 			}
 
 			if (preferences.ModernBattlefield)

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -101,6 +101,7 @@ namespace FF1Lib
 			PermanentCaravan();
 			ShiftEarthOrbDown();
 			CastableItemTargeting();
+			FixEnemyPalettes(); // fixes a bug in the original game's programming that causes third enemy slot's palette to render incorrectly
 			flags = Flags.ConvertAllTriState(flags, rng);
 
 
@@ -166,10 +167,8 @@ namespace FF1Lib
 				}
 			}
 #endif
-
-			if (flags.RandomizeEnemizer || flags.RandomizeFormationEnemizer)
+			if (flags.EnemizerEnabled)
 			{
-				FixEnemyPalettes(); // fixes a big in the original game's programming that causes third enemy slot's palette to render incorrectly
 				DoEnemizer(rng, flags.RandomizeEnemizer, flags.RandomizeFormationEnemizer);
 			}
 
@@ -346,7 +345,7 @@ namespace FF1Lib
 			// Put this before other encounter / trap tile edits.
 			if ((bool)flags.AllowUnsafeMelmond)
 			{
-				EnableMelmondGhetto(flags.RandomizeFormationEnemizer || flags.RandomizeEnemizer);
+				EnableMelmondGhetto(flags.EnemizerEnabled);
 			}
 
 			// After unrunnable shuffle and before formation shuffle. Perfect!
@@ -365,12 +364,12 @@ namespace FF1Lib
 				FiendShuffle(rng);
 			}
 
-			if (flags.FormationShuffleMode != FormationShuffleMode.None && !flags.RandomizeEnemizer && !flags.RandomizeFormationEnemizer)
+			if (flags.FormationShuffleMode != FormationShuffleMode.None && !flags.EnemizerEnabled)
 			{
 				ShuffleEnemyFormations(rng, flags.FormationShuffleMode);
 			}
 
-			if (((bool)flags.EnemyTrapTiles) && !flags.RandomizeEnemizer && !flags.RandomizeFormationEnemizer)
+			if (((bool)flags.EnemyTrapTiles) && !flags.EnemizerEnabled)
 			{
 				ShuffleTrapTiles(rng, ((bool)flags.RandomTrapFormations));
 			}
@@ -539,7 +538,7 @@ namespace FF1Lib
 				FixEnemyElementalResistances();
 			}
 
-			if (preferences.FunEnemyNames && !flags.RandomizeEnemizer && !flags.RandomizeFormationEnemizer)
+			if (preferences.FunEnemyNames && !flags.EnemizerEnabled)
 			{
 				FunEnemyNames(preferences.TeamSteak);
 			}
@@ -608,7 +607,7 @@ namespace FF1Lib
 				UseVariablePaletteForCursorAndStone();
 			}
 
-			if (preferences.PaletteSwap && !flags.RandomizeEnemizer && !flags.RandomizeFormationEnemizer)
+			if (preferences.PaletteSwap && !flags.EnemizerEnabled)
 			{
 				PaletteSwap(rng);
 			}

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -449,7 +449,7 @@ namespace FF1Lib
 			return (Flags)this.MemberwiseClone();
 		}
 
-		public bool? ImmediatePureAndSoftRequired => EnemyStatusAttacks | Entrances | MapOpenProgression | RandomizeFormationEnemizer;
+		public bool? ImmediatePureAndSoftRequired => EnemyStatusAttacks | Entrances | MapOpenProgression | RandomizeFormationEnemizer | RandomizeEnemizer;
 
 		public bool? FreeLute => ChaosRush | ShortToFR;
 

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -217,6 +217,7 @@ namespace FF1Lib
 		public bool FiendShuffle { get; set; } = false;
 		public bool DisableTentSaving { get; set; } = false;
 		public bool DisableInnSaving { get; set; } = false;
+		public bool RandomizeEnemizer { get; set; } = false;
 		public bool RandomizeFormationEnemizer { get; set; } = false;
 		public bool ThiefHitRate { get; set; } = false;
 
@@ -629,6 +630,7 @@ namespace FF1Lib
 			sum = AddBoolean(sum, flags.FiendShuffle);
 			sum = AddBoolean(sum, flags.DisableTentSaving);
 			sum = AddBoolean(sum, flags.DisableInnSaving);
+			sum = AddBoolean(sum, flags.RandomizeEnemizer);
 			sum = AddBoolean(sum, flags.RandomizeFormationEnemizer);
 			sum = AddBoolean(sum, flags.ThiefHitRate);
 			sum = AddNumeric(sum, Enum.GetValues(typeof(FormationShuffleMode)).Cast<int>().Max() + 1, (int)flags.FormationShuffleMode);
@@ -654,6 +656,7 @@ namespace FF1Lib
 				MDefMode = (MDEFGrowthMode)GetNumeric(ref sum, Enum.GetValues(typeof(MDEFGrowthMode)).Cast<int>().Max() + 1),
 				FormationShuffleMode = (FormationShuffleMode)GetNumeric(ref sum, Enum.GetValues(typeof(FormationShuffleMode)).Cast<int>().Max() + 1),
 				ThiefHitRate = GetBoolean(ref sum),
+				RandomizeEnemizer = GetBoolean(ref sum),
 				RandomizeFormationEnemizer = GetBoolean(ref sum),
 				DisableInnSaving = GetBoolean(ref sum),
 				DisableTentSaving = GetBoolean(ref sum),

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -456,6 +456,8 @@ namespace FF1Lib
 		public bool? DeepCastlesPossible => Entrances & Floors;
 		public bool? DeepTownsPossible => Towns & Entrances & Floors & EntrancesMixedWithTowns;
 
+		public bool EnemizerEnabled => RandomizeFormationEnemizer | RandomizeEnemizer;
+
 		public static string EncodeFlagsText(Flags flags)
 		{
 			BigInteger sum = 0;

--- a/FF1Lib/FlagsViewModel.cs
+++ b/FF1Lib/FlagsViewModel.cs
@@ -1803,6 +1803,15 @@ namespace FF1Lib
 				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("DisableInnSaving"));
 			}
 		}
+		public bool RandomizeEnemizer
+		{
+			get => Flags.RandomizeEnemizer;
+			set
+			{
+				Flags.RandomizeEnemizer = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("RandomizeEnemizer"));
+			}
+		}
 		public bool RandomizeFormationEnemizer
 		{
 			get => Flags.RandomizeFormationEnemizer;

--- a/FF1Lib/Hacks.cs
+++ b/FF1Lib/Hacks.cs
@@ -583,7 +583,7 @@ namespace FF1Lib
 			// Set town desert tile to random encounters.
 			// If enabled, trap tile shuffle will change that second byte to 0x00 afterward.
 			Data[0x00864] = 0x0A;
-			Data[0x00865] = 0x80;
+			Data[0x00865] = enemizerOn ? (byte)0x00 : (byte)0x80;
 
 			// Give Melmond Desert backdrop
 			Data[0x0334D] = (byte)Backdrop.Desert;


### PR DESCRIPTION
This is the enemizer update that finally, well, enemizes.  It adds the option to create totally new enemies.
I also included a fix for the Zozo Melmond issue that occurs in the current alpha, and enabling any part of Enemizer will disable shuffling formations, shuffling trap tiles, and fun% enemy names / palette swap.  (Three of these are effectively moot with Enemizer on, and the other is only marginally different and would require me to write branching paths in ShuffleTrapTiles for basically everything which I really don't want to do.)

I've completely re-did the way formations are generated, which should produce far fewer (if any) crashes, since I programmed it in a way to be a lot more tolerant and to always have some way to generate a formation (most crashes were caused by a list having nothing to select from with PickRandom or Shuffle, which is something I've consciously avoided in the current version).  Additionally, there should be no possibility whatsoever of drawing an inappropriate monster (boss or fiend) for any random formation.

The only issues I have found so far is that sometimes the formation generator creates a duplicate formation (this is something I can resolve but I'd have to go back and check every formation for duplicates and store information in memory).  There is also a potential issue with two distinct enemies of the same image sharing a palette, which I have encountered once.  I don't know the source of the issue yet but I can figure it out if I see it again and inspect the ROM.  None of these issues cause a fatal crash or anything other than mild annoyance.