### PR TITLE
Slight tweak to Spellcrafter

### DIFF
--- a/FF1Lib/Enemizer.cs
+++ b/FF1Lib/Enemizer.cs
@@ -2327,6 +2327,8 @@ namespace FF1Lib
 					{
 						case Enemy.Imp:
 							enemyNames[i] = "BUM";
+							enemy[i].elem_weakness = 0b11111111;
+							enemy[i].monster_type = 0b11111111;
 							break;
 						case Enemy.Pirate:
 							break;

--- a/FF1Lib/Spellcrafter.cs
+++ b/FF1Lib/Spellcrafter.cs
@@ -60,7 +60,7 @@ namespace FF1Lib
 					spellPermissions[i] = 0x0F; // white mage can learn all white magic between tiers 1 and 6 except WARP, EXIT, CUR4, LIF2 and some tier 7 spell effects
 				else if (i >= 40 && i < 46)
 					spellPermissions[i] = 0xF0; // black mage can learn all black magic between tiers 1 and 6 except WARP, EXIT, CUR4, LIF2 and some tier 7 spell effects
-				else if (i >= 48 && i < 52)
+				else if (i >= 48 && i < 51)
 					spellPermissions[i] = 0x0F; // knight can learn all white magic between tiers 1 and 3 (their permissions will never be revoked)
 				else if (i >= 56 && i < 60)
 					spellPermissions[i] = 0xF0; // ninja can learn all black magic between tiers 1 and 4 (their permissions will never be revoked)


### PR DESCRIPTION
FAST spells now require tier 5 or higher (as was intended), self-casting agility spells (QUIK) are in tiers 3-4.
Knight now properly learns tiers 1-3 instead of tiers 1-4 in white magic.
BUMs (Imp enemy) are weak to everything and have all monster types (including regenerative).  Chances are if regenerative is problematic, BUMs are not a good source of exp for your party anyway.