### PR TITLE
Splitting Unrunnables

### DIFF
--- a/FF1Lib/Enemizer.cs
+++ b/FF1Lib/Enemizer.cs
@@ -740,7 +740,8 @@ namespace FF1Lib
 			public byte pal2;
 			public byte surprise;
 			public byte paletteassignment = 0b00000000;
-			public bool unrunnable;
+			public bool unrunnable_a;
+			public bool unrunnable_b;
 
 			public byte Top
 			{
@@ -771,8 +772,10 @@ namespace FF1Lib
 				formationData[11] = pal2;
 				formationData[12] = surprise;
 				formationData[13] = paletteassignment;
-				if (unrunnable)
+				if (unrunnable_a)
 					formationData[13] |= 0x01;
+				if (unrunnable_b)
+					formationData[13] |= 0x02;
 				formationData[14] = (byte)((monMin[4] << 4) | monMax[4]);
 				formationData[15] = (byte)((monMin[5] << 4) | monMax[5]);
 				return formationData;
@@ -801,7 +804,8 @@ namespace FF1Lib
 				pal2 = data[11];
 				surprise = data[12];
 				paletteassignment = (byte)(data[13] & 0xF0);
-				unrunnable = (data[13] & 0x01) == 0x01 ? true : false;
+				unrunnable_a = (data[13] & 0x01) == 0x01 ? true : false;
+				unrunnable_b = (data[13] & 0x02) == 0x02 ? true : false;
 				monMin[4] = (data[14] & 0xF0) >> 4;
 				monMax[4] = data[14] & 0x0F;
 				monMin[5] = (data[15] & 0xF0) >> 4;
@@ -1211,8 +1215,9 @@ namespace FF1Lib
 				// assign the pic and palette bytes to each monster slot
 				ENF_AssignPicAndPaletteBytes(enemy, f);
 				// set surprise rate and unrunnability flags
-				f.unrunnable = rng.Between(0, 47) + (zoneA > zoneB ? zoneA : zoneB) >= 50 ? true : false; // unrunnable chance is higher for later zones
-				if (f.unrunnable)
+				f.unrunnable_a = rng.Between(0, 47) + zoneA >= 50 ? true : false; // unrunnable chance is higher for later zones
+				f.unrunnable_b = rng.Between(0, 47) + zoneB >= 50 ? true : false;
+				if (f.unrunnable_a && f.unrunnable_b)
 					f.surprise = (byte)rng.Between(3, 30);
 				else
 				{
@@ -1655,10 +1660,13 @@ namespace FF1Lib
 				zoneB = ENF_Picker_Generic(en, enemy, rng, f, zoneB, 0, true);
 				if (zoneB != -1)
 					en.zone[zoneB].forms.Add((byte)(formid | 0x80)); // if for some reason we didn't fill any valid zone from the B-side, we simply don't add it to any zones (and thus it will never be seen)
+				f.unrunnable_b = rng.Between(0, 47) + zoneB >= 50 ? true : false;
 			}
+			else
+				f.unrunnable_b = false;
 			// if for some reason there were no available mons, then a B-Side is not drawn at all and no formation is added to the zones, so this slot will remain unused.  this shouldn't happen, though
 			ENF_AssignPicAndPaletteBytes(enemy, f);
-			f.unrunnable = unrunnable;
+			f.unrunnable_a = unrunnable;
 			f.surprise = surprise;
 			en.LogFeatured(f);
 			return f.compressData();
@@ -1727,7 +1735,8 @@ namespace FF1Lib
 			if (zoneA != -1)
 				en.zone[zoneA].forms.Add(formid); // if for some reason we didn't fill any valid zone from the A-side, we simply don't add it to any zones (and thus it will never be seen)
 			f.surprise = 4;
-			f.unrunnable = true; // these fights are always unrunnable
+			f.unrunnable_a = rng.Between(0, 47) + zoneA >= 50 ? true : false;
+			f.unrunnable_b = true; // the trap side is always unrunnable
 			// put on the finishing touches and log and compress this formation
 			ENF_AssignPicAndPaletteBytes(enemy, f);
 			en.LogFeatured(f);

--- a/FF1Lib/Enemizer.cs
+++ b/FF1Lib/Enemizer.cs
@@ -142,7 +142,7 @@ namespace FF1Lib
 								tier = 2;
 							else if (effect < 36)
 								tier = 3;
-							else if (effect < 75)
+							else if (effect < 68)
 								tier = 4;
 							else
 								tier = 5;
@@ -806,8 +806,8 @@ namespace FF1Lib
 				pal2 = data[11];
 				surprise = data[12];
 				paletteassignment = (byte)(data[13] & 0xF0);
-				unrunnable_a = (data[13] & 0x01) == 0x01 ? true : false;
-				unrunnable_b = (data[13] & 0x02) == 0x02 ? true : false;
+				unrunnable_a = (data[13] & 0x01) == 0x01;
+				unrunnable_b = (data[13] & 0x02) == 0x02;
 				monMin[4] = (data[14] & 0xF0) >> 4;
 				monMax[4] = data[14] & 0x0F;
 				monMin[5] = (data[15] & 0xF0) >> 4;

--- a/FF1Lib/Enemizer.cs
+++ b/FF1Lib/Enemizer.cs
@@ -17,6 +17,8 @@ namespace FF1Lib
 		public const int EnemySkillTextPointerBase = 0x20000;
 		public const int EnemySkillTextOffset = 0x2B634;
 
+		public const int EnemizerUnrunnabilityWeight = 31; // weight given to determine unrunnability.  for the highest level of encounters, this means 8/32 probability of a formation being unrunnable
+
 		enum MonsterPerks
 		{
 			PERK_GAINSTAT10, // increases a minor stat by 10%, +2% XP
@@ -1215,8 +1217,8 @@ namespace FF1Lib
 				// assign the pic and palette bytes to each monster slot
 				ENF_AssignPicAndPaletteBytes(enemy, f);
 				// set surprise rate and unrunnability flags
-				f.unrunnable_a = rng.Between(0, 47) + zoneA >= 50 ? true : false; // unrunnable chance is higher for later zones
-				f.unrunnable_b = rng.Between(0, 47) + zoneB >= 50 ? true : false;
+				f.unrunnable_a = rng.Between(0, EnemizerUnrunnabilityWeight) + zoneA >= EnemizerUnrunnabilityWeight + 3 ? true : false; // unrunnable chance is higher for later zones
+				f.unrunnable_b = rng.Between(0, EnemizerUnrunnabilityWeight) + zoneB >= EnemizerUnrunnabilityWeight + 3 ? true : false;
 				if (f.unrunnable_a && f.unrunnable_b)
 					f.surprise = (byte)rng.Between(3, 30);
 				else
@@ -1660,7 +1662,7 @@ namespace FF1Lib
 				zoneB = ENF_Picker_Generic(en, enemy, rng, f, zoneB, 0, true);
 				if (zoneB != -1)
 					en.zone[zoneB].forms.Add((byte)(formid | 0x80)); // if for some reason we didn't fill any valid zone from the B-side, we simply don't add it to any zones (and thus it will never be seen)
-				f.unrunnable_b = rng.Between(0, 47) + zoneB >= 50 ? true : false;
+				f.unrunnable_b = rng.Between(0, EnemizerUnrunnabilityWeight) + zoneB >= EnemizerUnrunnabilityWeight + 3 ? true : false;
 			}
 			else
 				f.unrunnable_b = false;
@@ -1735,7 +1737,7 @@ namespace FF1Lib
 			if (zoneA != -1)
 				en.zone[zoneA].forms.Add(formid); // if for some reason we didn't fill any valid zone from the A-side, we simply don't add it to any zones (and thus it will never be seen)
 			f.surprise = 4;
-			f.unrunnable_a = rng.Between(0, 47) + zoneA >= 50 ? true : false;
+			f.unrunnable_a = rng.Between(0, EnemizerUnrunnabilityWeight) + zoneA >= EnemizerUnrunnabilityWeight + 3 ? true : false;
 			f.unrunnable_b = true; // the trap side is always unrunnable
 			// put on the finishing touches and log and compress this formation
 			ENF_AssignPicAndPaletteBytes(enemy, f);

--- a/FF1Lib/EnemyFormations.cs
+++ b/FF1Lib/EnemyFormations.cs
@@ -57,15 +57,15 @@ namespace FF1Lib
 			}
 			// Generate a shuffled list of ids for encounters
 			// We include - all normal formation A-Sides except encounter 00 (imps), all normal formation B-Sides, and the four B-sides at the end
-			List<int> ids = Enumerable.Range(1, NormalFormationCount - 1).Concat(Enumerable.Range(128, NormalFormationCount)).Concat(Enumerable.Range(FormationCount + ChaosFormationIndex + 1, 4)).ToList();
+			List<int> ids = Enumerable.Range(1, NormalFormationCount - 1).Concat(Enumerable.Range(FormationCount, NormalFormationCount)).Concat(Enumerable.Range(FormationCount + ChaosFormationIndex + 1, 4)).ToList();
 			ids.Shuffle(rng);
 			ids = ids.Take(unrunnableAcount + unrunnableBcount).ToList(); // combine the number of unrunnables between both sides
 			foreach (int id in ids)
 			{
-				if (id < 128)
+				if (id < FormationCount)
 					formations[id][UnrunnableOffset] |= 0x01; // last bit is A-Side unrunnability
 				else
-					formations[id - 128][UnrunnableOffset] |= 0x02; // and second-to-last bit is B-Side unrunnability
+					formations[id - FormationCount][UnrunnableOffset] |= 0x02; // and second-to-last bit is B-Side unrunnability
 			}
 			Put(FormationsOffset, formations.SelectMany(formation => formation.ToBytes()).ToArray()); // and put it all back in the ROM
 		}

--- a/FF1Lib/EnemyFormations.cs
+++ b/FF1Lib/EnemyFormations.cs
@@ -64,7 +64,7 @@ namespace FF1Lib
 					unrunnableBcount++;
 				formations[i][UnrunnableOffset] &= 0xFD;
 			}
-			ids = Enumerable.Range(0, NormalFormationCount).Union(Enumerable.Range(ChaosFormationIndex + 1, 4)).ToList();
+			ids = Enumerable.Range(0, NormalFormationCount).Concat(Enumerable.Range(ChaosFormationIndex + 1, 4)).ToList();
 			ids.Shuffle(rng);
 			ids = ids.Take(unrunnableBcount).ToList();
 			ids.ForEach(id => formations[id][UnrunnableOffset] |= 0x02);

--- a/FF1Lib/EnemyFormations.cs
+++ b/FF1Lib/EnemyFormations.cs
@@ -43,7 +43,7 @@ namespace FF1Lib
 			int unrunnableAcount = 0, unrunnableBcount = 0; // number of formations marked as unrunnable on both sides
 			foreach (Blob formation in formations)
 			{
-				if ((formation[UnrunnableOffset] & 0x01) != 0)
+				if ((formation[UnrunnableOffset] & 0x01) == 0x01)
 					unrunnableAcount++;
 				formation[UnrunnableOffset] &= 0xFE;
 			}
@@ -56,11 +56,13 @@ namespace FF1Lib
 
 			// And we repeat the process for B-Side unrunnables
 			formations = Get(FormationsOffset, FormationSize * FormationCount).Chunk(FormationSize); // for B-Side we include ALL formations
-			foreach (Blob formation in formations)
+			for (int i = 0; i < FormationCount; ++i)
 			{
-				if ((formation[UnrunnableOffset] & 0x02) != 0)
+				if (i >= NormalFormationCount && i <= ChaosFormationIndex)
+					continue; // skip fiends and Chaos
+				if ((formations[i][UnrunnableOffset] & 0x02) == 0x02)
 					unrunnableBcount++;
-				formation[UnrunnableOffset] &= 0xFD;
+				formations[i][UnrunnableOffset] &= 0xFD;
 			}
 			ids = Enumerable.Range(0, FormationCount).ToList();
 			ids.Shuffle(rng);

--- a/FF1Lib/EnemyFormations.cs
+++ b/FF1Lib/EnemyFormations.cs
@@ -64,7 +64,7 @@ namespace FF1Lib
 					unrunnableBcount++;
 				formations[i][UnrunnableOffset] &= 0xFD;
 			}
-			ids = Enumerable.Range(0, FormationCount).ToList();
+			ids = Enumerable.Range(0, NormalFormationCount).Union(Enumerable.Range(ChaosFormationIndex + 1, 4)).ToList();
 			ids.Shuffle(rng);
 			ids = ids.Take(unrunnableBcount).ToList();
 			ids.ForEach(id => formations[id][UnrunnableOffset] |= 0x02);

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -103,6 +103,7 @@ namespace FF1Lib
 			CastableItemTargeting();
 			FixEnemyPalettes(); // fixes a bug in the original game's programming that causes third enemy slot's palette to render incorrectly
 			FixWarpBug(); // The warp bug must be fixed for magic level shuffle and spellcrafter
+			SeparateUnrunnables();
 			flags = Flags.ConvertAllTriState(flags, rng);
 
 
@@ -749,7 +750,7 @@ namespace FF1Lib
 			PutInBank(0x0F, 0x8700, Blob.FromHex("988DCE038DEE03A90F8DCC03A9008DCD03A9308DCF0360"));
 
 			// Move DrawCommandMenu out of Bank F so we can add no Escape to it
-			PutInBank(0x0F, 0x8740, Blob.FromHex("A000A200B91BFA9D9E6AE8C01BD015AD916D2901F00EA9139D9E6AE8C8A9F79D9E6AE8C8E005D0052090F6A200C8C01ED0D260"));
+			PutInBank(0x0F, 0x8740, Blob.FromHex("A000A200B91BFA9D9E6AE8C01BD015AD916D2903F00EA9139D9E6AE8C8A9F79D9E6AE8C8E005D0052090F6A200C8C01ED0D260"));
 
 			// Create a clone of IsOnBridge that checks the canal too.
 			PutInBank(0x0F, 0x8780, Blob.FromHex("AD0860F014A512CD0960D00DA513CD0A60D006A90085451860A512CD0D60D00DA513CD0E60D006A900854518603860"));

--- a/FF1Lib/Hacks.cs
+++ b/FF1Lib/Hacks.cs
@@ -578,13 +578,15 @@ namespace FF1Lib
 			Put(0x313D3, Blob.FromHex("03")); // changes AND #$01 to AND #$03 when checking start of battle for unrunnability
 			// the second change is done in AllowStrikeFirstAndSurprise, which checks the unrunnability in battle
 			// alter the default formation data to set unrunnability of a formation to both sides if the unrunnable flag is set
-			var formData = Get(FormationDataOffset, FormationDataSize * NormalFormationCount).Chunk(FormationDataSize);
+			var formData = Get(FormationDataOffset, FormationDataSize * FormationCount).Chunk(FormationDataSize);
 			for(int i = 0; i < NormalFormationCount; ++i)
 			{
 				if ((formData[i][UnrunnableOffset] & 0x01) != 0)
 					formData[i][UnrunnableOffset] |= 0x02;
 			}
-			// for the B-Side of Vampire/Astos/Pirates/Garland, the default last bit remains unrunnable, but the B-Side unrunnability is already false, so we don't need to do anything
+			formData[126][UnrunnableOffset] |= 0x02; // set unrunnability for WzSahag/R.Sahag fight
+			formData[127][UnrunnableOffset] |= 0x02; // set unrunnability for IronGol fight
+			
 			Put(FormationsOffset, formData.SelectMany(formation => formation.ToBytes()).ToArray());
 		}
 

--- a/FF1Lib/Hacks.cs
+++ b/FF1Lib/Hacks.cs
@@ -578,12 +578,13 @@ namespace FF1Lib
 			Put(0x313D3, Blob.FromHex("03")); // changes AND #$01 to AND #$03 when checking start of battle for unrunnability
 			// the second change is done in AllowStrikeFirstAndSurprise, which checks the unrunnability in battle
 			// alter the default formation data to set unrunnability of a formation to both sides if the unrunnable flag is set
-			var formData = Get(FormationDataOffset, FormationDataSize * FormationDataCount).Chunk(FormationDataSize);
-			foreach (Blob data in formData)
+			var formData = Get(FormationDataOffset, FormationDataSize * NormalFormationCount).Chunk(FormationDataSize);
+			for(int i = 0; i < NormalFormationCount; ++i)
 			{
-				if ((data[0x0D] & 0x01) != 0)
-					data[0x0D] |= 0x03;
+				if ((formData[i][UnrunnableOffset] & 0x01) != 0)
+					formData[i][UnrunnableOffset] |= 0x02;
 			}
+			// for the B-Side of Vampire/Astos/Pirates/Garland, the default last bit remains unrunnable, but the B-Side unrunnability is already false, so we don't need to do anything
 			Put(FormationsOffset, formData.SelectMany(formation => formation.ToBytes()).ToArray());
 		}
 

--- a/FF1Lib/Hacks.cs
+++ b/FF1Lib/Hacks.cs
@@ -585,11 +585,6 @@ namespace FF1Lib
 					data[0x0D] |= 0x03;
 			}
 			Put(FormationsOffset, formData.SelectMany(formation => formation.ToBytes()).ToArray());
-			// FOR TESTING: Set the domain around Coneria to alternating fights 00 and 80, and set 00 to runnable and 80 to unrunnable
-			var formation00 = Get(FormationDataOffset, FormationDataSize);
-			formation00[0x0D] = 0x42;
-			Put(FormationDataOffset, formation00);
-			Put(0x2C120, Blob.FromHex("0080008000800080"));
 		}
 
 		public void ImproveTurnOrderRandomization(MT19337 rng)

--- a/FF1Lib/Hacks.cs
+++ b/FF1Lib/Hacks.cs
@@ -565,6 +565,33 @@ namespace FF1Lib
 			// new delta to special unrunnable message handler done in 
 		}
 
+		public void SeparateUnrunnables()
+		{
+			// See SetRunnability.asm
+			// replace a segment of code in PrepareEnemyFormation with a JSR to a new routine in dummied ROM space in bank 0B
+			Put(0x2E141, Blob.FromHex("200C9B"));
+			// pad the excised code with NOPs
+			PutInBank(0x0B, 0xA144, Enumerable.Repeat((byte)0xEA, 0x1C).ToArray());
+			// write the new routine
+			Put(0x2DB0C, Blob.FromHex("AD6A001023AD926D8D8A6DAD936D8D8B6DA2008E886D8E896D8E8C6D8E8D6DAD916D29FE8D916D60AD916D29FD8D916D60"));
+			// change checks for unrunnability in bank 0C to check last two bits instead of last bit
+			Put(0x313D3, Blob.FromHex("03")); // changes AND #$01 to AND #$03 when checking start of battle for unrunnability
+			// the second change is done in AllowStrikeFirstAndSurprise, which checks the unrunnability in battle
+			// alter the default formation data to set unrunnability of a formation to both sides if the unrunnable flag is set
+			var formData = Get(FormationDataOffset, FormationDataSize * FormationDataCount).Chunk(FormationDataSize);
+			foreach (Blob data in formData)
+			{
+				if ((data[0x0D] & 0x01) != 0)
+					data[0x0D] |= 0x03;
+			}
+			Put(FormationsOffset, formData.SelectMany(formation => formation.ToBytes()).ToArray());
+			// FOR TESTING: Set the domain around Coneria to alternating fights 00 and 80, and set 00 to runnable and 80 to unrunnable
+			var formation00 = Get(FormationDataOffset, FormationDataSize);
+			formation00[0x0D] = 0x41;
+			Put(FormationDataOffset, formation00);
+			Put(0x2C120, Blob.FromHex("0080008000800080"));
+		}
+
 		public void ImproveTurnOrderRandomization(MT19337 rng)
 		{
 			// Shuffle the initial bias so enemies are no longer always at the start initially.

--- a/FF1Lib/Hacks.cs
+++ b/FF1Lib/Hacks.cs
@@ -587,7 +587,7 @@ namespace FF1Lib
 			Put(FormationsOffset, formData.SelectMany(formation => formation.ToBytes()).ToArray());
 			// FOR TESTING: Set the domain around Coneria to alternating fights 00 and 80, and set 00 to runnable and 80 to unrunnable
 			var formation00 = Get(FormationDataOffset, FormationDataSize);
-			formation00[0x0D] = 0x41;
+			formation00[0x0D] = 0x42;
 			Put(FormationDataOffset, formation00);
 			Put(0x2C120, Blob.FromHex("0080008000800080"));
 		}

--- a/FF1Lib/Spellcrafter.cs
+++ b/FF1Lib/Spellcrafter.cs
@@ -1868,10 +1868,7 @@ namespace FF1Lib
 							spell.effect = (byte)rng.Between(120, 150);
 							break;
 					}
-					if (tier == 7)
-						spell.accuracy = 107;
-					else
-						spell.accuracy = 24;
+					spell.accuracy = 24;
 				}
 				else if (element == 0b00000100)
 				{
@@ -1958,10 +1955,7 @@ namespace FF1Lib
 							spell.effect = (byte)rng.Between(175, 200);
 							break;
 					}
-					if (tier == 7)
-						spell.accuracy = 107;
-					else
-						spell.accuracy = 48;
+					spell.accuracy = 48;
 				}
 				else
 				{

--- a/FF1Lib/Spellcrafter.cs
+++ b/FF1Lib/Spellcrafter.cs
@@ -298,7 +298,6 @@ namespace FF1Lib
 			spellindex.Shuffle(rng);
 
 			// draw remaining spells
-			Console.WriteLine("Crafting Spells");
 			foreach(int index in spellindex)
 			{
 				// first, we determine the routines we can select in the first place
@@ -1641,8 +1640,6 @@ namespace FF1Lib
 			// ensure the Power Gauntlet is turned into an item that increases attack power on self (or single ally), or some other appropriate effect, otherwise it will cast a random level 3-5 black magic spell
 			// all other items receive a random level 3-5 spell, either white magic or black magic, that is fit to cast in battle
 
-			Console.WriteLine("Drawing Item Magic");
-
 			var Spells = GetSpells(); // we have to do it this way because what's the rest of the randomizer lol
 			WriteItemSpellData(Spells[elemspell[1]], Item.MageRod); // write our FIR2 to the Mage Staff
 			WriteItemSpellData(Spells[elemspell[3]], Item.BlackShirt); // write our ICE2 to the Black Shirt
@@ -1697,7 +1694,6 @@ namespace FF1Lib
 					script[i].spell_list[j] = eligibleSpellIDs.PickRandom(rng);
 				}
 			}
-			Console.WriteLine("Drawing Fiend Lists");
 			spellindex = Enumerable.Range(0, 64).ToList(); // refilling the spell indexes to include all spells again
 			var middamagespells = spellindex.Where(id => spell[id].routine == 0x01 && spell[id].tier == 3).ToList(); // this will include some of the guaranteed spells, so there will always be entries
 			var highdamagespells = spellindex.Where(id => spell[id].routine == 0x01 && spell[id].tier == 4).ToList();
@@ -1797,8 +1793,6 @@ namespace FF1Lib
 
 			for (int i = 0; i < ScriptCount; ++i) // write the new scripts to ROM
 				Put(ScriptOffset + ScriptSize * i, script[i].compressData());
-
-			Console.WriteLine("End Spellcrafter");
 		}
 
 		private void SPCR_SetName(string[] spellnames, int index, string initialname, string altname)

--- a/FF1Lib/Spellcrafter.cs
+++ b/FF1Lib/Spellcrafter.cs
@@ -1090,7 +1090,6 @@ namespace FF1Lib
 							else
 								spell[index].targeting = 0x10;
 							spellMessages[index] = 0x19; // Defend magic
-							SPCR_SetPermissionFalse(spellPermissions, index, 9); // red wizard banned
 							resistelems.Add(resistances);
 						}
 						else
@@ -1136,8 +1135,6 @@ namespace FF1Lib
 						}
 						SPCR_CraftAttackUpSpell(rng, spell[index], SpellTier(index), false);
 						SPCR_SetPermissionFalse(spellPermissions, index, 3); // red mage banned
-						if(spell[index].targeting != 0x04)
-							SPCR_SetPermissionFalse(spellPermissions, index, 9); // red wizard banned if spell is not self-caster
 						attackupspell.Add(index);
 					}
 					if(routine == 0x0E) // decrease evade (LOCK)
@@ -1150,7 +1147,6 @@ namespace FF1Lib
 						spell[index].routine = routine;
 						spellMessages[index] = 0x05; // Easy to hit
 						SPCR_SetPermissionFalse(spellPermissions, index, 3); // red mage banned
-						SPCR_SetPermissionFalse(spellPermissions, index, 9); // red wizard banned
 						if (lockspell == -1)
 							lockspell = index;
 						else

--- a/FF1Lib/Spellcrafter.cs
+++ b/FF1Lib/Spellcrafter.cs
@@ -243,7 +243,7 @@ namespace FF1Lib
 			SPCR_CraftAttackUpSpell(rng, spell[sabrspell], SpellTier(sabrspell), true);
 			SPCR_SetPermissionFalse(spellPermissions, sabrspell, 3); // red mage banned
 			spellindex.Remove(sabrspell);
-			int fastspell = spellindex.Where(id => BlackSpell(id) && id > 16).ToList().PickRandom(rng); // guaranteed FAST, we do NOT want this to land on an item and we need to track this
+			int fastspell = spellindex.Where(id => BlackSpell(id)).ToList().PickRandom(rng); // guaranteed FAST, we do NOT want this to land on an item and we need to track this
 			SPCR_CraftFastSpell(spell[fastspell], SpellTier(fastspell));
 			spellMessages[fastspell] = 0x12; // Quick Shot
 			if (spell[fastspell].targeting != 0x04)
@@ -330,7 +330,7 @@ namespace FF1Lib
 					}					
 					if(rollSecondSlow && SpellTier(index) < 4)
 						validroutines.Add(0x04);
-					if(rollSecondFast && SpellTier(index) > 1)
+					if(rollSecondFast)
 						validroutines.Add(0x0C);
 				}
 				if (rollMoraleSpell && SpellTier(index) < 4)
@@ -1115,7 +1115,7 @@ namespace FF1Lib
 					}
 					if(routine == 0x0C) // double number of hits (FAST)
 					{
-						if ((SpellTier(fastspell) < 3 && SpellTier(index) < 3) || (SpellTier(fastspell) == SpellTier(index)) || (SpellTier(fastspell) > 2 && SpellTier(fastspell) < 6 && SpellTier(index) > 2 && SpellTier(index) < 6) || (SpellTier(fastspell) > 5 && SpellTier(index) > 5 ) // if both spells would have the same effect, do not roll
+						if ((SpellTier(fastspell) < 3 && SpellTier(index) < 3) || (SpellTier(fastspell) == SpellTier(index)) || (SpellTier(fastspell) > 2 && SpellTier(fastspell) < 6 && SpellTier(index) > 2 && SpellTier(index) < 6) || (SpellTier(fastspell) > 5 && SpellTier(index) > 5 )) // if both spells would have the same effect, do not roll
 						{
 							validroutines.Remove(0x0C);
 							continue;

--- a/FF1Lib/Spellcrafter.cs
+++ b/FF1Lib/Spellcrafter.cs
@@ -249,7 +249,10 @@ namespace FF1Lib
 			if (spell[fastspell].targeting != 0x04)
 			{
 				SPCR_SetPermissionFalse(spellPermissions, fastspell, 3); // red mage banned
-				SPCR_SetPermissionFalse(spellPermissions, fastspell, 9); // red wizard banned
+			}
+			if (spell[fastspell].targeting == 0x08)
+			{
+				SPCR_SetPermissionFalse(spellPermissions, fastspell, 9); // red wizard banned from AoE FAST
 			}
 			spellindex.Remove(fastspell);
 			int slowspell = spellindex.Where(id => BlackSpell(id) && id > 31 && id < 48).ToList().PickRandom(rng); // guaranteed SLO2 equivalent
@@ -1112,7 +1115,7 @@ namespace FF1Lib
 					}
 					if(routine == 0x0C) // double number of hits (FAST)
 					{
-						if ((SpellTier(fastspell) < 4 && SpellTier(index) < 4) || (SpellTier(fastspell) == SpellTier(index)) || (SpellTier(fastspell) > 3 && SpellTier(fastspell) < 7 && SpellTier(index) > 3 && SpellTier(index) < 7) ) // if both spells would have the same effect, do not roll
+						if ((SpellTier(fastspell) < 3 && SpellTier(index) < 3) || (SpellTier(fastspell) == SpellTier(index)) || (SpellTier(fastspell) > 2 && SpellTier(fastspell) < 6 && SpellTier(index) > 2 && SpellTier(index) < 6) || (SpellTier(fastspell) > 5 && SpellTier(index) > 5 ) // if both spells would have the same effect, do not roll
 						{
 							validroutines.Remove(0x0C);
 							continue;
@@ -1122,7 +1125,10 @@ namespace FF1Lib
 						if(spell[index].targeting != 0x04)
 						{
 							SPCR_SetPermissionFalse(spellPermissions, index, 3); // red mage banned
-							SPCR_SetPermissionFalse(spellPermissions, index, 9); // red wizard banned for all FAST spells tier 5-8
+						}
+						if(spell[index].targeting == 0x08)
+						{
+							SPCR_SetPermissionFalse(spellPermissions, index, 9); // red wizard banned
 						}
 						rollSecondFast = false;
 					}
@@ -2065,9 +2071,9 @@ namespace FF1Lib
 
 		public void SPCR_CraftFastSpell(SpellInfo spell, int tier)
 		{
-			if (tier < 4)
+			if (tier < 3)
 				spell.targeting = 0x04;
-			else if (tier < 7)
+			else if (tier < 6)
 				spell.targeting = 0x10;
 			else
 				spell.targeting = 0x08;

--- a/FF1Lib/asm/0B_9B0C_SetRunnability.asm
+++ b/FF1Lib/asm/0B_9B0C_SetRunnability.asm
@@ -1,0 +1,24 @@
+﻿;; SetRunnability Subroutine
+LDA $006a					; load formation # to check if it is B-Side
+BPL ASIDE                   ; if it is, replace A-formation values with the B-formation values
+	LDA $6d92				; use formation B min/max values (first slot)
+	STA $6d8a
+	LDA $6d93				; use formation B min/max values (second slot)
+	STA $6d8b
+	LDX #$00
+	STX $6d88				; zero the enemy ID and min/max for enemies 2,3
+	STX $6d89				; (only enemies 0,1 are used for B formations)
+	STX $6d8c
+	STX $6d8d
+	LDA $6d91				; load the byte for unrunnability
+	AND #$FE				; mask out the last bit (last bit is A-Side's runnability)
+	STA $6d91				; and store the new runnability bit
+	RTS						; then leave the subroutine
+ASIDE:
+	LDA $6d91				; load the byte for unrunnability
+	AND #$FD				; mask out the second to last bit (second to last bit is B-Side's runnability)
+	STA $6d91				; and store the new runnability bit
+	RTS
+
+;; For this subroutine to work properly, battle formation data must be set by the randomizer to account for the new runnability (if both sides are unrunnable, set both bits)
+;; Additionally, areas of the code that refer to the unrunnability bit must be set to AND #$03 instead of AND #$01

--- a/FF1Lib/asm/0F_8740_Unrunnable.asm
+++ b/FF1Lib/asm/0F_8740_Unrunnable.asm
@@ -13,7 +13,7 @@ Loop:
 	CPY #27       ; After Y reaches 27 we check and print WAIT instead of RUN if unrunnable
 	BNE cont0
 		LDA $6D91 ; Load and check unrunnable bit
-		AND #$01
+		AND #$03 ; this is changed for compatibility with splitting the unrunnables
 		BEQ cont0
 			LDA #$13       ; Replace RUN ptr with WAIT ptr
 			STA $6A9E, X   ; $F713 is in bank 1F immediately after the code that jumps here


### PR DESCRIPTION
Here is the preliminary work I've done on splitting the unrunnables.  It has not been thoroughly tested.  At the moment it includes a test of the feature by changing the domain around Coneria to include formation 00 and formation 80 (00's b-side) and sets the b-side to unrunnable.  I believe the romhack portion works fine, but I have not thoroughly tested the changes I made to other randomizer features to ensure compatibility.

Additionally, ShuffleUnrunnables now checks the formations it cycles through with foreach, and if they were unrunnable normally (either with vanilla stats or with the formation generator's alterations), ShuffleUnrunnables will create that many unrunnables on the A-Side.  On the B-Side, all formations except the fiend fights are included in the shuffle.  This will mean that there are two extra potential unrunnables on the B-Side from the normally empty B-Sides of Vampire and Astos, but Enemizer uses those formation incides.