### PR TITLE
Split Docks out from Open Prog

### DIFF
--- a/FF1Blazorizer/Pages/Randomize.cshtml
+++ b/FF1Blazorizer/Pages/Randomize.cshtml
@@ -225,7 +225,8 @@
 							<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="lefeinShopsCheckBox" bind-Value="@Flags.LefeinShops">Lefeinish Hospitality</TriStateCheckBox>
 							<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="confusedOldMenCheckBox" bind-Value="@Flags.ConfusedOldMen">Confused Old Men</TriStateCheckBox>
 							<div class="checkbox-cell"></div>
-							<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="mapOpenProgressionCheckBox" bind-Value="@Flags.MapOpenProgression">Open Progression</TriStateCheckBox>
+							<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="mapOpenProgressionCheckBox" bind-Value="@Flags.MapOpenProgression">Open Progression (Southern Continent Edits)</TriStateCheckBox>
+							<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="mapOpenProgressionDocksCheckBox" bind-Value="@Flags.MapOpenProgressionDocks">Open Progression (Northern Docks)</TriStateCheckBox>
 							<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="mapOpenProgressionExtendedCheckBox" IsEnabled="@Flags.MapOpenProgression" bind-Value="@Flags.MapOpenProgressionExtended">Extended Open Progression</TriStateCheckBox>
 						</div>
 						<div class="col-md-4">

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -58,6 +58,7 @@ namespace FF1Lib
 		public bool? ConfusedOldMen { get; set; } = false;
 
 		public bool? MapOpenProgression { get; set; } = false;
+		public bool? MapOpenProgressionDocks { get; set; } = false;
 		public bool? Entrances { get; set; } = false;
 		public bool? Towns { get; set; } = false;
 		public bool? Floors { get; set; } = false;
@@ -240,8 +241,8 @@ namespace FF1Lib
 		public bool AllowStartAreaDanager { get; set; } = false;
 
 		public bool? MapCanalBridge => (NPCItems) | (NPCFetchItems) | MapOpenProgression | MapOpenProgressionExtended;
-		public bool? MapOnracDock => MapOpenProgression;
-		public bool? MapMirageDock => MapOpenProgression;
+		public bool? MapOnracDock => MapOpenProgressionDocks;
+		public bool? MapMirageDock => MapOpenProgressionDocks;
 		public bool? MapConeriaDwarves => MapOpenProgression;
 		public bool? MapVolcanoIceRiver => MapOpenProgression;
 		public bool? MapDwarvesNorthwest => MapOpenProgression & MapOpenProgressionExtended;
@@ -515,6 +516,7 @@ namespace FF1Lib
 			sum = AddTriState(sum, flags.LefeinShops);
 			sum = AddTriState(sum, flags.ConfusedOldMen);
 			sum = AddTriState(sum, flags.MapOpenProgression);
+			sum = AddTriState(sum, flags.MapOpenProgressionDocks);
 			sum = AddTriState(sum, flags.Entrances);
 			sum = AddTriState(sum, flags.Towns);
 			sum = AddTriState(sum, flags.Floors);
@@ -825,6 +827,7 @@ namespace FF1Lib
 				Floors = GetTriState(ref sum),
 				Towns = GetTriState(ref sum),
 				Entrances = GetTriState(ref sum),
+				MapOpenProgressionDocks = GetTriState(ref sum),
 				MapOpenProgression = GetTriState(ref sum),
 				ConfusedOldMen = GetTriState(ref sum),
 				LefeinShops = GetTriState(ref sum),

--- a/FF1Lib/FlagsViewModel.cs
+++ b/FF1Lib/FlagsViewModel.cs
@@ -515,6 +515,16 @@ namespace FF1Lib
 				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("MapOpenProgression"));
 			}
 		}
+
+		public bool? MapOpenProgressionDocks
+		{
+			get => Flags.MapOpenProgressionDocks;
+			set
+			{
+				Flags.MapOpenProgressionDocks = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("MapOpenProgressionDocks"));
+			}
+		}
 		public bool? MapOpenProgressionExtended
 		{
 			get => Flags.MapOpenProgressionExtended;


### PR DESCRIPTION
Turn open progression into two flags; Extended Open is dependent only on the Southern Continent Edits and not the Northern Docks