### PR TITLE
Add experimental flag to patch the missing hex value in the Battle RNG table

### DIFF
--- a/FF1Blazorizer/Pages/Randomize.cshtml
+++ b/FF1Blazorizer/Pages/Randomize.cshtml
@@ -478,6 +478,7 @@
 							<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="spellcrafterMixSpells" IsEnabled="@Flags.GenerateNewSpellbook" bind-Value="@Flags.SpellcrafterMixSpells">Mix spellbooks (Spellcrafter)</TriStateCheckbox>
 							<CheckBox UpdateToolTip="@UpdateToolTipID" Id="AllSpellLevelsForKnightNinja" bind-Value="@Flags.AllSpellLevelsForKnightNinja">Knight and Ninja Gain Charges in All Levels</CheckBox>
 							<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="FreeTail" bind-Value="@Flags.FreeTail">Free Tail</TriStateCheckBox>
+							<CheckBox UpdateToolTip="@UpdateToolTipID" Id="fixMissingBattleRngEntry" bind-Value="@Flags.FixMissingBattleRngEntry">Fix Missing Battle RNG Entry</CheckBox>
 						</div>
 						<div class="col-md-12">
 						</div>

--- a/FF1Blazorizer/wwwroot/presets/beginner.json
+++ b/FF1Blazorizer/wwwroot/presets/beginner.json
@@ -28,6 +28,7 @@
 		"ItemMagic": false,
 
 		"Rng": true,
+		"FixMissingBattleRngEntry": false,
 		"FormationShuffleMode": 0,
 		"EnemyFormationsUnrunnable": false,
 		"EnemyFormationsSurprise": false,

--- a/FF1Blazorizer/wwwroot/presets/chaos-rush.json
+++ b/FF1Blazorizer/wwwroot/presets/chaos-rush.json
@@ -28,6 +28,7 @@
 		"ItemMagic": false,
 
 		"Rng": false,
+		"FixMissingBattleRngEntry": false,
 		"FormationShuffleMode": 3,
 		"EnemyFormationsUnrunnable": true,
 		"EnemyFormationsSurprise": true,

--- a/FF1Blazorizer/wwwroot/presets/debug.json
+++ b/FF1Blazorizer/wwwroot/presets/debug.json
@@ -28,6 +28,7 @@
 		"ItemMagic": true,
 
 		"Rng": true,
+		"FixMissingBattleRngEntry": true,
 		"FormationShuffleMode": 1,
 		"EnemyFormationsUnrunnable": true,
 		"EnemyFormationsSurprise": true,

--- a/FF1Blazorizer/wwwroot/presets/default.json
+++ b/FF1Blazorizer/wwwroot/presets/default.json
@@ -26,6 +26,7 @@
 		"RebalanceSpells": false,
 
 		"Rng": true,
+		"FixMissingBattleRngEntry": false,
 		"EverythingUnrunnable": false,
 		"EnemyFormationsUnrunnable": false,
 		"EnemyFormationsSurprise": false,

--- a/FF1Blazorizer/wwwroot/presets/full-npc.json
+++ b/FF1Blazorizer/wwwroot/presets/full-npc.json
@@ -28,6 +28,7 @@
 		"ItemMagic": false,
 
 		"Rng": true,
+		"FixMissingBattleRngEntry": false,
 		"FormationShuffleMode": 0,
 		"EnemyFormationsUnrunnable": false,
 		"EnemyFormationsSurprise": false,

--- a/FF1Blazorizer/wwwroot/presets/improved-vanilla.json
+++ b/FF1Blazorizer/wwwroot/presets/improved-vanilla.json
@@ -28,6 +28,7 @@
 		"ItemMagic": false,
 
 		"Rng": false,
+		"FixMissingBattleRngEntry": false,
 		"FormationShuffleMode": 0,
 		"EnemyFormationsUnrunnable": false,
 		"EnemyFormationsSurprise": false,

--- a/FF1Blazorizer/wwwroot/tooltips/tooltips.json
+++ b/FF1Blazorizer/wwwroot/tooltips/tooltips.json
@@ -75,6 +75,11 @@
 		"description": "RNG Table: Shuffles the RNG Table and the Battle RNG, changing encounters and the distance between encounters while leaving overall probabilites unchanged."
 	},
 	{
+		"Id": "fixMissingBattleRngEntry",
+		"title": "Fix Missing Battle RNG Entry",
+		"description": "Fix Missing Battle RNG Entry: The vanilla Battle RNG table has two 00s out of 256 hex values. If checked, this flag replaces one of them with 95, the missing hex value."
+	},
+	{
 		"Id": "enemyScriptsCheckBox",
 		"title": "Enemy Scripts",
 		"screenshot": "enemyScriptsCheckBox.png",

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -936,6 +936,13 @@ namespace FF1Lib
 				hash));
 		}
 
+		public void FixMissingBattleRngEntry(List<Blob> battleRng)
+		{
+			// of the 256 entries in the battle RNG table, the 98th entry (index 97) is a duplicate '00' where '95' hex / 149 int is absent.
+			// you could arbitrarily choose the other '00', the 111th entry (index 110), to replace instead
+			battleRng[97] = Blob.FromHex("95")
+		}
+
 		public void ShuffleRng(MT19337 rng)
 		{
 			var rngTable = Get(RngOffset, RngSize).Chunk(1).ToList();
@@ -944,6 +951,12 @@ namespace FF1Lib
 			Put(RngOffset, rngTable.SelectMany(blob => blob.ToBytes()).ToArray());
 
 			var battleRng = Get(BattleRngOffset, RngSize).Chunk(1).ToList();
+
+			if (flags.FixMissingBattleRngEntry)
+			{
+				FixMissingBattleRngEntry(battleRng)
+			}
+
 			battleRng.Shuffle(rng);
 
 			Put(BattleRngOffset, battleRng.SelectMany(blob => blob.ToBytes()).ToArray());

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -940,7 +940,7 @@ namespace FF1Lib
 		{
 			// of the 256 entries in the battle RNG table, the 98th entry (index 97) is a duplicate '00' where '95' hex / 149 int is absent.
 			// you could arbitrarily choose the other '00', the 111th entry (index 110), to replace instead
-			battleRng[97] = Blob.FromHex("95")
+			battleRng[97] = Blob.FromHex("95");
 		}
 
 		public void ShuffleRng(MT19337 rng)
@@ -954,7 +954,7 @@ namespace FF1Lib
 
 			if (flags.FixMissingBattleRngEntry)
 			{
-				FixMissingBattleRngEntry(battleRng)
+				FixMissingBattleRngEntry(battleRng);
 			}
 
 			battleRng.Shuffle(rng);

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -36,6 +36,7 @@ namespace FF1Lib
 		public bool RebalanceSpells { get; set; } = false;
 
 		public bool? Rng { get; set; } = false;
+		public bool FixMissingBattleRngEntry { get; set; } = false;
 		public bool? EverythingUnrunnable { get; set; } = false;
 		public bool? EnemyFormationsUnrunnable { get; set; } = false;
 		public bool? EnemyFormationsSurprise { get; set; } = false;
@@ -499,6 +500,7 @@ namespace FF1Lib
 			sum = AddTriState(sum, flags.ItemMagic);
 			sum = AddBoolean(sum, flags.RebalanceSpells);
 			sum = AddTriState(sum, flags.Rng);
+			sum = AddBoolean(sum, flags.FixMissingBattleRngEntry);
 			sum = AddTriState(sum, flags.EverythingUnrunnable);
 			sum = AddTriState(sum, flags.EnemyFormationsUnrunnable);
 			sum = AddTriState(sum, flags.EnemyFormationsSurprise);
@@ -854,6 +856,7 @@ namespace FF1Lib
 				EnemyFormationsUnrunnable = GetTriState(ref sum),
 				EverythingUnrunnable = GetTriState(ref sum),
 				Rng = GetTriState(ref sum),
+				FixMissingBattleRngEntry = GetBoolean(ref sum),
 				RebalanceSpells = GetBoolean(ref sum),
 				ItemMagic = GetTriState(ref sum),
 				MagicPermissions = GetTriState(ref sum),

--- a/FF1Lib/FlagsViewModel.cs
+++ b/FF1Lib/FlagsViewModel.cs
@@ -268,6 +268,15 @@ namespace FF1Lib
 				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Rng"));
 			}
 		}
+		public bool FixMissingBattleRngEntry
+		{
+			get => Flags.FixMissingBattleRngEntry;
+			set
+			{
+				Flags.FixMissingBattleRngEntry = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("FixMissingBattleRngEntry"));
+			}
+		}
 		public bool? EnemyFormationsUnrunnable
 		{
 			get => Flags.EnemyFormationsUnrunnable;


### PR DESCRIPTION
- Adds a new flag, 'FixMissingBattleRngEntry', a boolean which defaults to false, under the Experimental randomizer section.
- New code in FF1Rom.cs attempts to insert the hex value '95' into the battleRng list
- For all boilerplate code, I attempted to copy formatting exactly.
- Only added to the Blazorizer app. MainWindow.xaml and all old-site preset files have been ignored.

Reviewer recommendations:
1. Check syntax for correctness and functionality, especially `FF1Rom.cs`, which was something of a stab in the dark. Submit review with corrections.
2. Once corrected syntax is in this PR, test both viewing the Blazorizer app and generating a ROM from this branch.
3. If those look OK, push to Alpha and I will test out that playing through various generated ROMs with the flag on show no bugs.