### PR TITLE
Moved weapon bonuses to before weapon crit doubling

### DIFF
--- a/FF1Blazorizer/Pages/Randomize.cshtml
+++ b/FF1Blazorizer/Pages/Randomize.cshtml
@@ -239,7 +239,13 @@
 				<div class="is-dark nes-container">
 					<ClampedSlider Min="1" Max="5" Step="0.1" UpdateToolTip="@UpdateToolTipID" Id="clampMinimumPriceScaleLable" bind-Clamp="@Flags.ClampMinimumPriceScale" bind-Scale="@Flags.PriceScaleFactor">Prices:</ClampedSlider>
 					<ClampedSlider Min="1" Max="5" Step="0.1" UpdateToolTip="@UpdateToolTipID" Id="clampMinimumStatScaleLable" bind-Clamp="@Flags.ClampMinimumStatScale" bind-Scale="@Flags.EnemyScaleFactor">Enemy Stats:</ClampedSlider>
+					<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Indent Id="separateEnemyHPScalingCheckBox" bind-Value="@Flags.SeparateEnemyHPScaling">Separate Enemy HP Scaling</TriStateCheckBox>
+					<ClampedSlider Min="1" Max="5" Step="0.1" Indent IsEnabled="@Flags.SeparateEnemyHPScaling" UpdateToolTip="@UpdateToolTipID" Id="clampEnemyHpScaleLable" bind-Clamp="@Flags.ClampEnemyHpScaling" bind-Scale="@Flags.EnemyHPScaleFactor">Enemy HP:</ClampedSlider>
+
 					<ClampedSlider Min="1" Max="5" Step="0.1" UpdateToolTip="@UpdateToolTipID" Id="clampMinimumBossScaleLable" bind-Clamp="@Flags.ClampMinimumBossStatScale" bind-Scale="@Flags.BossScaleFactor">Boss Stats:</ClampedSlider>
+					<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Indent Id="separateBossHPScalingCheckBox" bind-Value="@Flags.SeparateBossHPScaling">Separate Boss HP Scaling</TriStateCheckBox>
+					<ClampedSlider Min="1" Max="5" Step="0.1" Indent IsEnabled="@Flags.SeparateBossHPScaling" UpdateToolTip="@UpdateToolTipID" Id="clampBossHpScaleLable" bind-Clamp="@Flags.ClampBossHPScaling" bind-Scale="@Flags.BossHPScaleFactor">Boss HP:</ClampedSlider>
+
 					<div class="slider-cell"></div>
 					<div class="row">
 						<div class="col-md-5">

--- a/FF1Blazorizer/Shared/ClampedSlider.cshtml
+++ b/FF1Blazorizer/Shared/ClampedSlider.cshtml
@@ -1,6 +1,6 @@
 <div class="row">
 	<div class="col-md-5">
-		<p class="@DisabledClass">@ChildContent</p>
+		<p class="@DisabledClass @IndentClass">@ChildContent</p>
 	</div>
 	<div class="col-xs-6 col-md-3">
 		<div class="checkbox-cell">
@@ -35,68 +35,73 @@
 	[CascadingParameter]
 	protected string ToolTipId { get; set; }
 	[Parameter]
-	protected Action<string, UIMouseEventArgs> UpdateToolTip { get; set; }
+	protected Action<string, UIMouseEventArgs>
+	UpdateToolTip { get; set; }
 
 
 	[Parameter]
 	private bool Indent { get; set; }
+	private string IndentClass => Indent ? "indent" : "";
 
 	[Parameter]
-	private bool IsEnabled { get; set; } = true;
-	private string DisabledClass => IsEnabled ? "" : "disabled";
+	private bool? IsEnabled { get; set; } = true;
+	private bool Disabled => !(IsEnabled ?? true);
+	private string DisabledClass => (IsEnabled ?? true) ? "" : "disabled";
 
 	[Parameter]
 	private string Id { get; set; }
 
 	private string image => checked0 ? "/images/true.png" : (checked1 ? "/images/false.png" : "/images/random.gif");
 	private string DisplayText => (Clamp != null ?
-		Math.Round(100.0 / (Clamp ?? true ? 1.0 : Scale)).ToString() :
-		Math.Round(100.0 / Scale).ToString() + "% OR " + Math.Round(100.0 / 1.0).ToString()
-		) + "% - " + Math.Round(100.0 * Scale).ToString() + "%";
+	Math.Round(100.0 / (Clamp ?? true ? 1.0 : Scale)).ToString() :
+	Math.Round(100.0 / Scale).ToString() + "% OR " + Math.Round(100.0 / 1.0).ToString()
+	) + "% - " + Math.Round(100.0 * Scale).ToString() + "%";
 
 	[Parameter]
 	private bool? Clamp { get; set; } = false;
 	[Parameter]
-	Action<bool?> ClampChanged { get; set; }
+	Action<bool?>
+		ClampChanged { get; set; }
 
-	[Parameter]
-	private double Scale { get; set; }
-	[Parameter]
-	Action<double> ScaleChanged { get; set; }
+		[Parameter]
+		private double Scale { get; set; }
+		[Parameter]
+		Action<double>
+			ScaleChanged { get; set; }
 
-	[Parameter]
-	private double Min { get; set; }
-	[Parameter]
-	private double Max { get; set; }
-	[Parameter]
-	private double Step { get; set; }
+			[Parameter]
+			private double Min { get; set; }
+			[Parameter]
+			private double Max { get; set; }
+			[Parameter]
+			private double Step { get; set; }
 
-	[Parameter]
-	private RenderFragment ChildContent { get; set; }
+			[Parameter]
+			private RenderFragment ChildContent { get; set; }
 
-	private bool checked0 => Clamp ?? false;
-	private bool checked1 => !Clamp ?? false;
-	private bool checked2 => Clamp == null;
+			private bool checked0 => Clamp ?? false;
+			private bool checked1 => !Clamp ?? false;
+			private bool checked2 => Clamp == null;
 
-	[Parameter]
-	private bool Name { get; set; }
+			[Parameter]
+			private bool Name { get; set; }
 
-	void onclick()
-	{
-		if (Clamp == false)
-		{
+			void onclick()
+			{
+			if (Clamp == false)
+			{
 			Clamp = true;
-		}
-		else if (Clamp == true)
-		{
+			}
+			else if (Clamp == true)
+			{
 			Clamp = null;
-		}
-		else
-		{
+			}
+			else
+			{
 			Clamp = false;
-		}
-		ClampChanged(Clamp);
+			}
+			ClampChanged(Clamp);
 
-	}
+			}
 
-}
+			}

--- a/FF1Blazorizer/wwwroot/tooltips/tooltips.json
+++ b/FF1Blazorizer/wwwroot/tooltips/tooltips.json
@@ -255,6 +255,16 @@
 		"description": "Gives each armor a random bonus of +5 to -5. This will increase or decrease its absorb by 1 per bonus (2 for body armor) and reduce its weight penalty by 1 per bonus (2 for body armor)."
 	},
 	{
+		"Id": "separateBossHPScalingCheckBox",
+		"title": "Separate Boss HP Scaling",
+		"description": "Uses a second scaling for boss hp independant of other stats."
+	},
+	{
+		"Id": "separateEnemyHPScalingCheckBox",
+		"title": "Separate Enemy HP Scaling",
+		"description": "Uses a second scaling for enemy hp independant of other stats."
+	},
+	{
 		"Id": "incentivizeFreeNPCsCheckBox",
 		"title": "Free NPCs",
 		"screenshot": "incentivizeFreeNPCsCheckBox.png",

--- a/FF1Lib/EnemyFormations.cs
+++ b/FF1Lib/EnemyFormations.cs
@@ -156,8 +156,8 @@ namespace FF1Lib
 					finalBattle[PaletteAsignmentOffset] = 0x41; // Palette Assignment in top nibble, 1 in bottom for unrunnable.
 
 					// Scale up the Fundead enemies if we end up with them. They're too weak otherwise.
-					ScaleSingleEnemyStats(0x78, 1.4, false, false, null, false);
-					ScaleSingleEnemyStats(0x33, 1.2, false, false, null, false);
+					ScaleSingleEnemyStats(0x78, 1.4, false, false, null, false, false, 1.0, false);
+					ScaleSingleEnemyStats(0x33, 1.2, false, false, null, false, false, 1.0, false);
 					break;
 				case FinalFormation.TimeLoop:
 					finalBattle[TypeOffset] = 0x0B;         // 9Small + Garland pattern

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -614,12 +614,12 @@ namespace FF1Lib
 
 			if (flags.EnemyScaleFactor > 1)
 			{
-				ScaleEnemyStats(flags.EnemyScaleFactor, flags.WrapStatOverflow, flags.IncludeMorale, rng, ((bool)flags.ClampMinimumStatScale));
+				ScaleEnemyStats(flags.EnemyScaleFactor, flags.WrapStatOverflow, flags.IncludeMorale, rng, (bool)flags.ClampMinimumStatScale, (bool)flags.SeparateEnemyHPScaling, flags.EnemyHPScaleFactor, (bool)flags.ClampEnemyHpScaling);
 			}
 
 			if (flags.BossScaleFactor > 1)
 			{
-				ScaleBossStats(flags.BossScaleFactor, flags.WrapStatOverflow, flags.IncludeMorale, rng, ((bool)flags.ClampMinimumBossStatScale));
+				ScaleBossStats(flags.BossScaleFactor, flags.WrapStatOverflow, flags.IncludeMorale, rng, (bool)flags.ClampMinimumBossStatScale, (bool)flags.SeparateBossHPScaling, flags.BossHPScaleFactor, (bool)flags.ClampBossHPScaling);
 			}
 
 			PartyComposition(rng, flags, preferences);

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -529,6 +529,17 @@ namespace FF1Lib
 				DontDoubleBBCritRates();
 			}
 
+			//needs to go after item magic, goes before weapon crit doubling now to actually change 1% per bonus
+			if ((bool)flags.RandomWeaponBonus)
+			{
+				RandomWeaponBonus(rng);
+			}
+
+			if ((bool)flags.RandomArmorBonus)
+			{
+				RandomArmorBonus(rng);
+			}
+
 			if (flags.WeaponCritRate)
 			{
 				DoubleWeaponCritRates();
@@ -542,17 +553,6 @@ namespace FF1Lib
 			if (flags.WeaponStats)
 			{
 				FixWeaponStats();
-			}
-
-			//needs to go after item magic
-			if ((bool)flags.RandomWeaponBonus)
-			{
-				RandomWeaponBonus(rng);
-			}
-
-			if ((bool)flags.RandomArmorBonus)
-			{
-				RandomArmorBonus(rng);
 			}
 
 			if (flags.ChanceToRun)

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -237,6 +237,12 @@ namespace FF1Lib
 		public bool? SpellcrafterRetainPermissions { get; set; } = false;
 		public bool? RandomWeaponBonus { get; set; } = false;
 		public bool? RandomArmorBonus { get; set; } = false;
+		public bool? SeparateBossHPScaling { get; set; } = false;
+		public bool? SeparateEnemyHPScaling { get; set; } = false;
+		public bool? ClampBossHPScaling { get; set; } = false;
+		public bool? ClampEnemyHpScaling { get; set; } = false;
+		public double EnemyHPScaleFactor { get; set; } = 1;
+		public double BossHPScaleFactor { get; set; } = 1;
 
 		public MDEFGrowthMode MDefMode { get; set; } = MDEFGrowthMode.None;
 
@@ -673,6 +679,12 @@ namespace FF1Lib
 			sum = AddTriState(sum, flags.SpellcrafterRetainPermissions);
 			sum = AddTriState(sum, flags.RandomWeaponBonus);
 			sum = AddTriState(sum, flags.RandomArmorBonus);
+			sum = AddTriState(sum, flags.SeparateBossHPScaling);
+			sum = AddTriState(sum, flags.SeparateEnemyHPScaling);
+			sum = AddTriState(sum, flags.ClampBossHPScaling);
+			sum = AddTriState(sum, flags.ClampEnemyHpScaling);
+			sum = AddNumeric(sum, 41, (int)(10.0 * flags.EnemyHPScaleFactor) - 10);
+			sum = AddNumeric(sum, 41, (int)(10.0 * flags.BossHPScaleFactor) - 10);
 			sum = AddNumeric(sum, Enum.GetValues(typeof(FormationShuffleMode)).Cast<int>().Max() + 1, (int)flags.FormationShuffleMode);
 			sum = AddNumeric(sum, Enum.GetValues(typeof(MDEFGrowthMode)).Cast<int>().Max() + 1, (int)flags.MDefMode);
 			sum = AddNumeric(sum, Enum.GetValues(typeof(WorldWealthMode)).Cast<int>().Max() + 1, (int)flags.WorldWealth);
@@ -695,6 +707,12 @@ namespace FF1Lib
 				WorldWealth = (WorldWealthMode)GetNumeric(ref sum, Enum.GetValues(typeof(WorldWealthMode)).Cast<int>().Max() + 1),
 				MDefMode = (MDEFGrowthMode)GetNumeric(ref sum, Enum.GetValues(typeof(MDEFGrowthMode)).Cast<int>().Max() + 1),
 				FormationShuffleMode = (FormationShuffleMode)GetNumeric(ref sum, Enum.GetValues(typeof(FormationShuffleMode)).Cast<int>().Max() + 1),
+				BossHPScaleFactor = (GetNumeric(ref sum, 41) + 10) / 10.0,
+				EnemyHPScaleFactor = (GetNumeric(ref sum, 41) + 10) / 10.0,
+				ClampEnemyHpScaling = GetTriState(ref sum),
+				ClampBossHPScaling = GetTriState(ref sum),
+				SeparateEnemyHPScaling = GetTriState(ref sum),
+				SeparateBossHPScaling = GetTriState(ref sum),
 				RandomArmorBonus = GetTriState(ref sum),
 				RandomWeaponBonus = GetTriState(ref sum),
 				SpellcrafterRetainPermissions = GetTriState(ref sum),

--- a/FF1Lib/FlagsViewModel.cs
+++ b/FF1Lib/FlagsViewModel.cs
@@ -1997,5 +1997,65 @@ namespace FF1Lib
 				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("RandomArmorBonus"));
 			}
 		}
+
+		public bool ?SeparateBossHPScaling
+		{
+			get => Flags.SeparateBossHPScaling;
+			set
+			{
+				Flags.SeparateBossHPScaling = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("SeparateBossHPScaling"));
+			}
+		}
+
+		public bool ?SeparateEnemyHPScaling
+		{
+			get => Flags.SeparateEnemyHPScaling;
+			set
+			{
+				Flags.SeparateEnemyHPScaling = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("SeparateEnemyHPScaling"));
+			}
+		}
+
+		public bool ?ClampBossHPScaling
+		{
+			get => Flags.ClampBossHPScaling;
+			set
+			{
+				Flags.ClampBossHPScaling = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("ClampBossHPScaling"));
+			}
+		}
+
+		public bool ?ClampEnemyHpScaling
+		{
+			get => Flags.ClampEnemyHpScaling;
+			set
+			{
+				Flags.ClampEnemyHpScaling = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("ClampEnemyHpScaling"));
+			}
+		}
+
+		public double EnemyHPScaleFactor
+		{
+			get => Flags.EnemyHPScaleFactor;
+			set
+			{
+				Flags.EnemyHPScaleFactor = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("EnemyHPScaleFactor"));
+			}
+		}
+
+		public double BossHPScaleFactor
+		{
+			get => Flags.BossHPScaleFactor;
+			set
+			{
+				Flags.BossHPScaleFactor = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("BossHPScaleFactor"));
+			}
+		}
 	}
 }

--- a/FF1Lib/Scale.cs
+++ b/FF1Lib/Scale.cs
@@ -116,22 +116,22 @@ namespace FF1Lib
 
 		}
 
-		public void ScaleEnemyStats(double scale, bool wrapOverflow, bool includeMorale, MT19337 rng, bool increaseOnly)
+		public void ScaleEnemyStats(double scale, bool wrapOverflow, bool includeMorale, MT19337 rng, bool increaseOnly, bool separateHPScale, double hpScale, bool hpIncreaseOnly)
 		{
-			NonBossEnemies.ForEach(index => ScaleSingleEnemyStats(index, scale, wrapOverflow, includeMorale, rng, increaseOnly));
+			NonBossEnemies.ForEach(index => ScaleSingleEnemyStats(index, scale, wrapOverflow, includeMorale, rng, increaseOnly, separateHPScale, hpScale, hpIncreaseOnly));
 		}
 
-		public void ScaleBossStats(double scale, bool wrapOverflow, bool includeMorale, MT19337 rng, bool increaseOnly)
+		public void ScaleBossStats(double scale, bool wrapOverflow, bool includeMorale, MT19337 rng, bool increaseOnly, bool separateHPScale, double hpScale, bool hpIncreaseOnly)
 		{
-			Bosses.ForEach(index => ScaleSingleEnemyStats(index, scale, wrapOverflow, includeMorale, rng, increaseOnly));
+			Bosses.ForEach(index => ScaleSingleEnemyStats(index, scale, wrapOverflow, includeMorale, rng, increaseOnly, separateHPScale, hpScale, hpIncreaseOnly));
 		}
 
-		public void ScaleSingleEnemyStats(int index, double scale, bool wrapOverflow, bool includeMorale, MT19337 rng, bool increaseOnly)
+		public void ScaleSingleEnemyStats(int index, double scale, bool wrapOverflow, bool includeMorale, MT19337 rng, bool increaseOnly, bool separateHPScale, double hpScale, bool hpIncreaseOnly)
 		{
 			var enemy = Get(EnemyOffset + index * EnemySize, EnemySize);
 
 			var hp = BitConverter.ToUInt16(enemy, 4);
-			hp = (ushort)Min(Scale(hp, scale, 1.0, rng, increaseOnly), 0x7FFF);
+			hp = (ushort)Min(Scale(hp, separateHPScale ? hpScale : scale, 1.0, rng, separateHPScale ? hpIncreaseOnly : increaseOnly), 0x7FFF);
 			var hpBytes = BitConverter.GetBytes(hp);
 			Array.Copy(hpBytes, 0, enemy, 4, 2);
 


### PR DESCRIPTION
Moved weapon bonuses to before weapon doubling. This should cause weapons to receive 1 full crit% per bonus instead of .5