### PR TITLE
More OFD Stuff

### DIFF
--- a/FF1Lib/Enemies.cs
+++ b/FF1Lib/Enemies.cs
@@ -44,6 +44,7 @@ namespace FF1Lib
 			public const int Crawl = 24;
 			public const int Phantom = 51;
 			public const int Mancat = 55;
+			public const int Vampire = 60;
 			public const int Coctrice = 81;
 			public const int Sorceror = 104;
 			public const int Garland = 105;


### PR DESCRIPTION
Enemizer Changes:
- Pattern tables are now shuffled, which means that monster types that couldn't appear together in vanilla can appear together in Enemizer.
- Garland, Astos, and Pirates are all locked to their vanilla appearances.
- Vampire encounter is now drawn like other boss battles, except with the enemy replacing Vampire being drawn (instead of a random enemy with the Vampire graphic).