### PR TITLE
Balanced Item Magic Shuffle

### DIFF
--- a/FF1Blazorizer/Pages/Randomize.cshtml
+++ b/FF1Blazorizer/Pages/Randomize.cshtml
@@ -80,6 +80,7 @@
 							<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Indent IsEnabled="@Flags.MagicLevels" Id="magicLevelsMixed" bind-Value="@Flags.MagicLevelsMixed">Mix Spellbooks</TriStateCheckBox>
 							<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Indent IsEnabled="@Flags.MagicLevels" Id="magicPermissionsCheckBox" bind-Value="@Flags.MagicPermissions">Keep Permissions</TriStateCheckBox>
 							<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="itemMagicCheckBox" bind-Value="@Flags.ItemMagic">Item Magic</TriStateCheckBox>
+							<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Indent IsEnabled="@Flags.ItemMagic" Id="balancedItemMagicCheckBox" bind-Value="@Flags.BalancedItemMagicShuffle">Balanced Shuffle</TriStateCheckBox>
 							<div class="checkbox-cell"></div>
 							<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="rngCheckBox" bind-Value="@Flags.Rng">RNG Table</TriStateCheckBox>
 						</div>

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -220,7 +220,7 @@ namespace FF1Lib
 
 			if ((bool)flags.ItemMagic)
 			{
-				ShuffleItemMagic(rng);
+				ShuffleItemMagic(rng, (bool)flags.BalancedItemMagicShuffle);
 			}
 
 			if ((bool)flags.ShortToFR)

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -241,6 +241,7 @@ namespace FF1Lib
 		public bool? SpellcrafterRetainPermissions { get; set; } = false;
 		public bool? RandomWeaponBonus { get; set; } = false;
 		public bool? RandomArmorBonus { get; set; } = false;
+		public bool? BalancedItemMagicShuffle { get; set; } = false;
 		public bool? SeparateBossHPScaling { get; set; } = false;
 		public bool? SeparateEnemyHPScaling { get; set; } = false;
 		public bool? ClampBossHPScaling { get; set; } = false;
@@ -687,6 +688,7 @@ namespace FF1Lib
 			sum = AddTriState(sum, flags.SpellcrafterRetainPermissions);
 			sum = AddTriState(sum, flags.RandomWeaponBonus);
 			sum = AddTriState(sum, flags.RandomArmorBonus);
+			sum = AddTriState(sum, flags.BalancedItemMagicShuffle);
 			sum = AddTriState(sum, flags.SeparateBossHPScaling);
 			sum = AddTriState(sum, flags.SeparateEnemyHPScaling);
 			sum = AddTriState(sum, flags.ClampBossHPScaling);
@@ -721,6 +723,7 @@ namespace FF1Lib
 				ClampBossHPScaling = GetTriState(ref sum),
 				SeparateEnemyHPScaling = GetTriState(ref sum),
 				SeparateBossHPScaling = GetTriState(ref sum),
+				BalancedItemMagicShuffle = GetTriState(ref sum),
 				RandomArmorBonus = GetTriState(ref sum),
 				RandomWeaponBonus = GetTriState(ref sum),
 				SpellcrafterRetainPermissions = GetTriState(ref sum),

--- a/FF1Lib/FlagsViewModel.cs
+++ b/FF1Lib/FlagsViewModel.cs
@@ -2034,6 +2034,16 @@ namespace FF1Lib
 			}
 		}
 
+		public bool? BalancedItemMagicShuffle
+		{
+			get => Flags.BalancedItemMagicShuffle;
+			set
+			{
+				Flags.BalancedItemMagicShuffle = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("BalancedItemMagicShuffle"));
+			}
+		}
+
 		public bool ?SeparateBossHPScaling
 		{
 			get => Flags.SeparateBossHPScaling;

--- a/FF1Lib/ItemMagic.cs
+++ b/FF1Lib/ItemMagic.cs
@@ -20,12 +20,36 @@ namespace FF1Lib
 		private int WeaponStart = (byte)ItemLists.AllWeapons.ElementAt(0);
 		private int ArmorStart = (byte)ItemLists.AllArmor.ElementAt(0);
 
-		public void ShuffleItemMagic(MT19337 rng)
+		public void ShuffleItemMagic(MT19337 rng, bool balancedShuffle)
 		{
 			var Spells = GetSpells();
 
 			// Remove out of battle only spells (spells where the effect is 0)
 			Spells.RemoveAll(spell => spell.Data[4] == 0);
+			if(balancedShuffle)
+			{
+				// if balanced shuffle is on, remove spells which are too strong or too weak
+				// remove any spell which boosts attack power that isn't self-casting
+				Spells.RemoveAll(spell => spell.Data[4] == 0x0D && spell.Data[3] != 0x04);
+				// remove any spell that doubles hit rate
+				Spells.RemoveAll(spell => spell.Data[4] == 0x0C);
+				// remove any non-elemental damage spell with >55 effectivity
+				Spells.RemoveAll(spell => spell.Data[4] == 0x01 && spell.Data[1] > 55 && spell.Data[2] == 0b0000000);
+				// remove any multitarget elemental damage spell with > 70 effectivity
+				Spells.RemoveAll(spell => spell.Data[4] == 0x01 && spell.Data[1] > 70 && spell.Data[3] == 0x01);
+				// remove any singletarget elemental damage spell with > 100 effectivity
+				Spells.RemoveAll(spell => spell.Data[4] == 0x01 && spell.Data[1] > 100);
+				// remove any damage spell with <20 effectivity
+				Spells.RemoveAll(spell => spell.Data[4] == 0x01 && spell.Data[1] < 20);
+				// remove status recovery spells which don't heal paralysis or mute
+				Spells.RemoveAll(spell => spell.Data[4] == 0x08 && (spell.Data[1] & 0b01010000) == 0);
+				// remove HP Max
+				Spells.RemoveAll(spell => spell.Data[4] == 0x0F);
+				// remove HARM spells with > 120 effectivity
+				Spells.RemoveAll(spell => spell.Data[4] == 0x02 && spell.Data[1] > 120);
+				// remove non-elemental power word kill
+				Spells.RemoveAll(spell => spell.Data[4] == 0x12 && (spell.Data[1] & 0b00000011) != 0);
+			}
 			Spells.Shuffle(rng); // Shuffle all spells remaining, then assign to each item that can cast a spell
 
 			foreach (var item in Spells.Zip(ItemLists.AllMagicItem, (s, i) => new { Spell = s, Item = i }))

--- a/FF1Lib/ItemMagic.cs
+++ b/FF1Lib/ItemMagic.cs
@@ -48,7 +48,7 @@ namespace FF1Lib
 				// remove HARM spells with > 120 effectivity
 				Spells.RemoveAll(spell => spell.Data[4] == 0x02 && spell.Data[1] > 120);
 				// remove non-elemental power word kill
-				Spells.RemoveAll(spell => spell.Data[4] == 0x12 && (spell.Data[1] & 0b00000011) != 0);
+				Spells.RemoveAll(spell => spell.Data[4] == 0x12 && (spell.Data[1] & 0b00000011) != 0 && spell.Data[2] == 0b00000000);
 			}
 			Spells.Shuffle(rng); // Shuffle all spells remaining, then assign to each item that can cast a spell
 


### PR DESCRIPTION
Balanced Item Magic Shuffle is implemented.  Rather than use the Spellcrafter methods and structures, we simply remove spells which fit particular criteria as being too strong or too weak.  Any item can carry any spell, and there are no guarantees of certain magics appearing, unlike in Spellcrafter.  This feature is compatible with Spellcrafter as well.