### PR TITLE
Minor fix to Spellcrafter

### DIFF
--- a/FF1Lib/Spellcrafter.cs
+++ b/FF1Lib/Spellcrafter.cs
@@ -2132,10 +2132,5 @@ namespace FF1Lib
 			}
 			return returnValue;
 		}
-
-		public void BalancedItemMagic(MT19337 rng)
-		{
-
-		}
 	}
 }

--- a/FF1Lib/Spellcrafter.cs
+++ b/FF1Lib/Spellcrafter.cs
@@ -853,7 +853,7 @@ namespace FF1Lib
 										spell[index].elem = 0b00000001;
 										break;
 									case 6:
-										spell[index].effect = 0b10010000;
+										spell[index].effect = 0b10000000;
 										spell[index].targeting = 0x01;
 										spell[index].routine = routine;
 										spell[index].elem = 0b00000001;
@@ -2131,6 +2131,11 @@ namespace FF1Lib
 					returnValue++;
 			}
 			return returnValue;
+		}
+
+		public void BalancedItemMagic(MT19337 rng)
+		{
+
 		}
 	}
 }


### PR DESCRIPTION
Tier 6 MUDL no longer paralyzes.  It is simply confusion (and thus, enemies will no longer castt it).