### PR TITLE
Minor Enemizer fix

### DIFF
--- a/FF1Lib/Enemizer.cs
+++ b/FF1Lib/Enemizer.cs
@@ -3458,13 +3458,21 @@ namespace FF1Lib
 				enemy[i].tier = enemyTierList[i];
 			}
 
-			int medusaScriptTier = 10;
+			bool[] scriptRepeat = new bool[ScriptCount];
+			int[] scriptLowestTier = new int[ScriptCount];
+			for(int i = 0; i < ScriptCount; ++i)
+			{
+				scriptRepeat[i] = false;
+				scriptLowestTier[i] = 10;
+			}
 			for(int i = 0; i < EnemyCount - 10; ++i)
 			{
 				if (enemy[i].AIscript == 0xFF)
 					continue; // skip any enemy without a script
-				if (enemy[i].AIscript == 0x02 && enemy[i].tier >= medusaScriptTier)
+				if (scriptRepeat[enemy[i].AIscript] && enemy[i].tier >= scriptLowestTier[enemy[i].AIscript])
 					continue; // skip medusa script if this enemy is stronger than another monster with the medusa script
+				scriptRepeat[enemy[i].AIscript] = true;
+				scriptLowestTier[enemy[i].AIscript] = enemy[i].tier;
 				int[] tierchance = new int[5];
 				int[] skilltierchance = new int[4];
 				tierchance[0] = 0; tierchance[1] = 0; tierchance[2] = 0; tierchance[3] = 0; tierchance[4] = 0;

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -170,7 +170,7 @@ namespace FF1Lib
 
 			if ((bool)flags.RandomizeFormationEnemizer)
 			{
-				DoEnemizer(rng, (bool)flags.RandomizeEnemizer, (bool)flags.RandomizeFormationEnemizer, (bool)flags.EnemySkillsSpells);
+				DoEnemizer(rng, (bool)flags.RandomizeEnemizer, (bool)flags.RandomizeFormationEnemizer, flags.EnemizerDontMakeNewScripts);
 			}
 
 			if (preferences.ModernBattlefield)
@@ -681,7 +681,7 @@ namespace FF1Lib
 				PaletteSwap(rng);
 			}
 
-			if (preferences.TeamSteak)
+			if (preferences.TeamSteak && !(bool)flags.RandomizeEnemizer)
 			{
 				TeamSteak();
 			}
@@ -699,7 +699,7 @@ namespace FF1Lib
 		{
 			// Talk_norm is overwritten with unconditional jump to Talk_CoOGuy (say whatever then disappear)
 			PutInBank(0x0E, 0x9492, Blob.FromHex("4CA294"));
-			Put(MapObjJumpTableOffset + 0x16 * JumpTablePointerSize, Blob.FromHex("B894B894")); // overwrite mab object jump table so that it calls "Talk_iftem"
+			Put(MapObjJumpTableOffset + 0x16 * JumpTablePointerSize, Blob.FromHex("B894B894")); // overwrite map object jump table so that it calls "Talk_iftem"
 			Put(MapObjOffset + 0x16 * MapObjSize, Blob.FromHex("01FFFF0001FFFF00")); // and overwrite the data so that it prints message 0xFF regardless of whether you have the item or not
 		}
 

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -489,7 +489,7 @@ namespace FF1Lib
 		public bool? DeepTownsPossible => Towns & Entrances & Floors & EntrancesMixedWithTowns;
 
 		public bool EnemizerEnabled => (bool)RandomizeFormationEnemizer | (bool)RandomizeEnemizer;
-		public bool EnemizerDontMakeNewScripts => (bool)EnemySkillsSpells & ((bool)BossSkillsOnly | (bool)EnemySkillsSpellsTiered);
+		public bool EnemizerDontMakeNewScripts => (bool)EnemySkillsSpells & !((bool)BossSkillsOnly | (bool)EnemySkillsSpellsTiered);
 
 		public static string EncodeFlagsText(Flags flags)
 		{

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -489,6 +489,7 @@ namespace FF1Lib
 		public bool? DeepTownsPossible => Towns & Entrances & Floors & EntrancesMixedWithTowns;
 
 		public bool EnemizerEnabled => (bool)RandomizeFormationEnemizer | (bool)RandomizeEnemizer;
+		public bool EnemizerDontMakeNewScripts => (bool)EnemySkillsSpells & ((bool)BossSkillsOnly | (bool)EnemySkillsSpellsTiered);
 
 		public static string EncodeFlagsText(Flags flags)
 		{


### PR DESCRIPTION
If "Only Shuffle Bosses" or "Generated New and Balanced Scripts" are turned on, Enemizer will know that it is allowed to create new scripts for spellcasting monsters ("Wz" type monsters and status-elemental enemies).

Team Steak is disabled when generating new enemies (Enemizer), since the Tyro image in pattern tables is moved around.

Generate New and Balanced Scripts now no longer only checks the Medusa script for repeats, so it can be used with Enemizer without producing wonky results.