### PR TITLE
Minor tweaks to Item Magic Shuffle, Enemizer, and Tiered Magic Shuffle

### DIFF
--- a/FF1Lib/Enemizer.cs
+++ b/FF1Lib/Enemizer.cs
@@ -2423,6 +2423,8 @@ namespace FF1Lib
 					int elemental = 9; // track elemental affinity for certain classes of monsters (elementals and dragons)
 					// generate monster's base elemental weakness/resist, type, and base name based on the monster image type
 					enemy[i].critrate = 1; // default crit rate of 1 for most enemies
+					// generate most enemy BASE stats
+					ENE_rollEnemyStats(rng, enemy[i]);
 					switch (newEnemyImageLUT[enemy[i].image])
 					{
 						case 0: // Imp
@@ -2566,7 +2568,7 @@ namespace FF1Lib
 							break;
 						case 23: // Tiger
 							enemyNames[i] = "TIGER";
-							enemy[i].critrate = rng.Between(20, 100);
+							enemy[i].critrate = rng.Between(20, 80);
 							enemy[i].monster_type = 0b00000000;
 							enemy[i].elem_resist = 0b00000000;
 							enemy[i].elem_weakness = 0b00000000;
@@ -2662,6 +2664,8 @@ namespace FF1Lib
 							enemy[i].monster_type = 0b00000001;
 							enemy[i].elem_weakness = (byte)(rng.Between(1, 6) << 4); // can be fire, ice, fire+ice, lit, fire+lit, or ice+lit weak
 							enemy[i].elem_resist = (byte)((0b11111111 ^ enemy[i].elem_weakness) & 0b11111011); // resist all other elements except time
+							if (rng.Between(0, 1) == 1)
+								enemy[i].absorb = 255; // 50% chance of max absorb for this enemy type
 							break;
 						case 29: // Manticore
 							enemyNames[i] = "MANT";
@@ -2701,7 +2705,7 @@ namespace FF1Lib
 							break;
 						case 35: // Steak
 							enemyNames[i] = "TYRO";
-							enemy[i].critrate = rng.Between(20, 100);
+							enemy[i].critrate = rng.Between(20, 80);
 							enemy[i].monster_type = 0b00000010;
 							enemy[i].elem_resist = 0b00000000;
 							enemy[i].elem_weakness = 0b00000000;
@@ -2890,8 +2894,6 @@ namespace FF1Lib
 					perks.Add(MonsterPerks.PERK_POISONTOUCH);
 					perks.Add(MonsterPerks.PERK_STUNSLEEPTOUCH);
 					perks.Add(MonsterPerks.PERK_MUTETOUCH);
-					// generate most enemy BASE stats
-					ENE_rollEnemyStats(rng, enemy[i]);
 					// set attack element and ailments to default value
 					enemy[i].atk_ailment = 0b00000000;
 					enemy[i].atk_elem = 0b00000000;

--- a/FF1Lib/ItemMagic.cs
+++ b/FF1Lib/ItemMagic.cs
@@ -26,7 +26,7 @@ namespace FF1Lib
 
 			// Remove out of battle only spells (spells where the effect is 0)
 			Spells.RemoveAll(spell => spell.Data[4] == 0);
-			if(balancedShuffle)
+			if (balancedShuffle)
 			{
 				// if balanced shuffle is on, remove spells which are too strong or too weak
 				// remove any spell which boosts attack power that isn't self-casting
@@ -58,7 +58,7 @@ namespace FF1Lib
 				Spells.RemoveAll(spell => spell.Data[4] == 0x09 && spell.Data[1] > 32);
 				// remove spells which resist all elements
 				Spells.RemoveAll(spell => spell.Data[4] == 0x0A && spell.Data[1] == 0xFF);
-1			}
+			}
 			Spells.Shuffle(rng); // Shuffle all spells remaining, then assign to each item that can cast a spell
 
 			foreach (var item in Spells.Zip(ItemLists.AllMagicItem, (s, i) => new { Spell = s, Item = i }))

--- a/FF1Lib/ItemMagic.cs
+++ b/FF1Lib/ItemMagic.cs
@@ -49,6 +49,13 @@ namespace FF1Lib
 				Spells.RemoveAll(spell => spell.Data[4] == 0x02 && spell.Data[1] > 120);
 				// remove non-elemental power word kill
 				Spells.RemoveAll(spell => spell.Data[4] == 0x12 && (spell.Data[1] & 0b00000011) != 0 && spell.Data[2] == 0b00000000);
+				// remove status spells which only cast darkness, sleep, or poison
+				Spells.RemoveAll(spell => spell.Data[4] == 0x03 && (spell.Data[1] & 0b11010011) == 0);
+				Spells.RemoveAll(spell => spell.Data[4] == 0x12 && (spell.Data[1] & 0b11010011) == 0);
+				// remove evasion up spells with effects greater than 80
+				Spells.RemoveAll(spell => spell.Data[4] == 0x10 && spell.Data[1] > 80);
+				// remove armor up spells with effects greater than 32
+				Spells.RemoveAll(spell => spell.Data[4] == 0x09 && spell.Data[1] > 32);
 			}
 			Spells.Shuffle(rng); // Shuffle all spells remaining, then assign to each item that can cast a spell
 

--- a/FF1Lib/ItemMagic.cs
+++ b/FF1Lib/ItemMagic.cs
@@ -56,7 +56,9 @@ namespace FF1Lib
 				Spells.RemoveAll(spell => spell.Data[4] == 0x10 && spell.Data[1] > 80);
 				// remove armor up spells with effects greater than 32
 				Spells.RemoveAll(spell => spell.Data[4] == 0x09 && spell.Data[1] > 32);
-			}
+				// remove spells which resist all elements
+				Spells.RemoveAll(spell => spell.Data[4] == 0x0A && spell.Data[1] == 0xFF);
+1			}
 			Spells.Shuffle(rng); // Shuffle all spells remaining, then assign to each item that can cast a spell
 
 			foreach (var item in Spells.Zip(ItemLists.AllMagicItem, (s, i) => new { Spell = s, Item = i }))

--- a/FF1Lib/Magic.cs
+++ b/FF1Lib/Magic.cs
@@ -115,13 +115,13 @@ namespace FF1Lib
 				blackSpells.Clear();
 				foreach (MagicSpell spell in whiteSpellList[2])
 				{
-					// 60% chance of tier 7-8, 30% chance of tier 4-6, 10% chance of tier 1-3
-					int diceRoll = rng.Between(0, 9);
-					if(diceRoll < 6)
+					// 70% chance of tier 7-8, 25% chance of tier 4-6, 5% chance of tier 1-3
+					int diceRoll = rng.Between(0, 19);
+					if(diceRoll < 14)
 					{
 						whiteSpellFinalList[2].Add(spell);
 					}
-					else if (diceRoll < 9)
+					else if (diceRoll < 19)
 					{
 						whiteSpellFinalList[1].Add(spell);
 					}
@@ -132,10 +132,10 @@ namespace FF1Lib
 				}
 				foreach (MagicSpell spell in whiteSpellList[1])
 				{
-					// 60% chance of tier 4-6, 20% chance of tier 1-3, 20% chance of tier 7-8
+					// 60% chance of tier 4-6, 25% chance of tier 1-3, 15% chance of tier 7-8
 					// if a section of the final list is full, move to another section
-					int diceRoll = rng.Between(0, 9);
-					if(diceRoll < 6)
+					int diceRoll = rng.Between(0, 19);
+					if(diceRoll < 12)
 					{
 						if(whiteSpellFinalList[1].Count >= 12 * mergedSpellDoubler)
 						{
@@ -153,7 +153,7 @@ namespace FF1Lib
 							whiteSpellFinalList[1].Add(spell);
 						}
 					}
-					else if (diceRoll < 8)
+					else if (diceRoll < 17)
 					{
 						if(whiteSpellFinalList[0].Count >= 12 * mergedSpellDoubler)
 						{
@@ -224,13 +224,13 @@ namespace FF1Lib
 				{
 					foreach (MagicSpell spell in blackSpellList[2])
 					{
-						// 60% chance of tier 7-8, 30% chance of tier 4-6, 10% chance of tier 1-3
-						int diceRoll = rng.Between(0, 9);
-						if (diceRoll < 6)
+						// 70% chance of tier 7-8, 25% chance of tier 4-6, 5% chance of tier 1-3
+						int diceRoll = rng.Between(0, 19);
+						if (diceRoll < 14)
 						{
 							blackSpellFinalList[2].Add(spell);
 						}
-						else if (diceRoll < 9)
+						else if (diceRoll < 19)
 						{
 							blackSpellFinalList[1].Add(spell);
 						}
@@ -241,10 +241,10 @@ namespace FF1Lib
 					}
 					foreach (MagicSpell spell in blackSpellList[1])
 					{
-						// 60% chance of tier 4-6, 20% chance of tier 1-3, 20% chance of tier 7-8
+						// 60% chance of tier 4-6, 25% chance of tier 1-3, 15% chance of tier 7-8
 						// if a section of the final list is full, move to another section
-						int diceRoll = rng.Between(0, 9);
-						if (diceRoll < 6)
+						int diceRoll = rng.Between(0, 19);
+						if (diceRoll < 12)
 						{
 							if (blackSpellFinalList[1].Count >= 12)
 							{
@@ -262,7 +262,7 @@ namespace FF1Lib
 								blackSpellFinalList[1].Add(spell);
 							}
 						}
-						else if (diceRoll < 8)
+						else if (diceRoll < 17)
 						{
 							if (blackSpellFinalList[0].Count >= 12)
 							{


### PR DESCRIPTION
- Balanced Item Magic Shuffle no longer includes evasion spells with more than 80 effectivity, or armor spells with more than 32 effectivity.  Balanced Item Magic Shuffle no longer includes resistance spells which resist all elements.  This removes WALL from the vanilla spell pool, and INV8/FOG8/WAL8 from the Spellcrafter spell pool plus some other spells.

- Tiered Magic Shuffle is less likely to land tier 7-8 spells in the first 6 slots (chance reduced to 5% for 1-3 and 15% for 4-6) and more likely to land tier 4-6 spells in the first 3 slots (chance increased from 20 to 25%, with 15% likelihood of landing in 7-8).

- Flans in Enemizer have a 50% chance of rolling 255 absorb.  This is one of the few enemy class specific rules I want to bring back, the other being class specific crit rates (already in effect for Asps, Tigers, and Tyros).

- Tigers and Tyros' Enemizer maximum critrate is reduced to 80 (was 100).