### PR TITLE
Weapon Blurse fix

### DIFF
--- a/FF1Lib/Weapon.cs
+++ b/FF1Lib/Weapon.cs
@@ -106,8 +106,9 @@ namespace FF1Lib
 				if (bonus != 0)
 				{
 					//adjust stats
-					//clamp to 1 dmg min, 0 hit min
+					//clamp to 1 dmg min, 0 hit min, 50 hit maximum
 					currentWeapon.HitBonus = (byte)Math.Max(0, (int)(currentWeapon.HitBonus + (3 * bonus)));
+					currentWeapon.HitBonus = (byte)Math.Min(50, (int)(currentWeapon.HitBonus));
 					currentWeapon.Damage = (byte)Math.Max(1, (int)currentWeapon.Damage + (2 * bonus));
 					currentWeapon.Crit = (byte)Math.Max(1, (int)currentWeapon.Crit + bonus);
 


### PR DESCRIPTION
No weapon will possess more than 50 hit rate (fixes an overflow issue with very high level Ninjas).
A better fix would have to reinstate the cap or change the way weapons add to hitrate.