### PR TITLE
Swole Pirates Fun Hack

### DIFF
--- a/FF1Blazorizer/Pages/Randomize.cshtml
+++ b/FF1Blazorizer/Pages/Randomize.cshtml
@@ -487,6 +487,7 @@
 							<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="RandomWeaponBonus" bind-Value="@Flags.RandomWeaponBonus">Random Weapon Bonus</TriStateCheckBox>
 							<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="RandomArmorBonus" bind-Value="@Flags.RandomArmorBonus">Random Armor Bonus</TriStateCheckBox>
 							<CheckBox UpdateToolTip="@UpdateToolTipID" Id="fixMissingBattleRngEntry" bind-Value="@Flags.FixMissingBattleRngEntry">Fix Missing Battle RNG Entry</CheckBox>
+							<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="swolePiratesCheckBox" bind-Value="@Flags.SwolePirates">Buffed Pirates</TriStateCheckBox>
 						</div>
 						<div class="col-md-12">
 						</div>

--- a/FF1Blazorizer/wwwroot/tooltips/tooltips.json
+++ b/FF1Blazorizer/wwwroot/tooltips/tooltips.json
@@ -904,5 +904,10 @@
 		"Id": "AllSpellLevelsForKnightNinja",
 		"title": "Knight and Ninja Gain Charges In All Levels",
 		"description": "Sets the Knight and Ninja magic charge growth to give a charge in all levels whenever those classes gain a charge in any level, giving Knight and Ninja tier 4-8 charges.  This alleviates an issue with Keep Permissions where the Knight and Ninja could never cast spells they could learn, but is useless otherwise."
+	},
+	{
+		"Id": "swolePiratesCheckBox",
+		"title": "Buff the Pirates",
+		"description": "Increases the stats of Bikke's pirates considerably, roughly to the equivalent of a level 6 Fighter with a cheap but decent sword and iron armor, and increases the XP and gold yield from them by a factor of 20.  This is done before stat scaling, and also increases the level of script they can carry when generating balanced scripts (if Allow Unsafe Pirates is on)."
 	}
 ]

--- a/FF1Lib/Enemizer.cs
+++ b/FF1Lib/Enemizer.cs
@@ -3414,7 +3414,7 @@ namespace FF1Lib
 			}
 		}
 
-		public void GenerateBalancedEnemyScripts(MT19337 rng)
+		public void GenerateBalancedEnemyScripts(MT19337 rng, bool swolePirates)
 		{
 			SpellInfo[] spell = new SpellInfo[MagicCount]; // list of spells and their appropriate tiers
 			EnemySkillInfo[] skill = new EnemySkillInfo[EnemySkillCount]; // list of enemy skills and their appropriate tiers
@@ -3453,6 +3453,8 @@ namespace FF1Lib
 												  3, 2, 2, 3, 3, 4, 5, 1, 2, 2, 3, 2, 4, 2, 2, 3,
 												  4, 3, 3, 3, 4, 3, 4, 1, 3, 1, 4, 4, 3, 3, 5, 3,
 												  4, 3, 3, 4, 1, 3, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
+			if (swolePirates)
+				enemyTierList[Enemy.Pirate] = 3;
 			for (int i = 0; i < EnemyCount; ++i)
 			{
 				enemy[i] = new EnemyInfo();

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -335,7 +335,7 @@ namespace FF1Lib
 			{
 				if((bool)flags.EnemySkillsSpellsTiered && (bool)!flags.BossSkillsOnly)
 				{
-					GenerateBalancedEnemyScripts(rng);
+					GenerateBalancedEnemyScripts(rng, (bool)flags.SwolePirates);
 					ShuffleEnemySkillsSpells(rng, false);
 				}
 				else
@@ -628,6 +628,11 @@ namespace FF1Lib
 			WriteMaps(maps);
 
 			WriteText(itemText, ItemTextPointerOffset, ItemTextPointerBase, ItemTextOffset, UnusedGoldItems);
+
+			if ((bool)flags.SwolePirates)
+			{
+				EnableSwolePirates();
+			}
 
 			if (flags.EnemyScaleFactor > 1)
 			{

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -46,6 +46,7 @@ namespace FF1Lib
 		public bool? EnemyTrapTiles { get; set; } = false;
 		public bool? RandomTrapFormations { get; set; } = false;
 
+		public bool? SwolePirates { get; set; } = false;
 		public bool? EnemyScripts { get; set; } = false;
 		public bool? BossScriptsOnly { get; set; } = false;
 		public bool? EnemySkillsSpells { get; set; } = false;
@@ -525,6 +526,7 @@ namespace FF1Lib
 			sum = AddTriState(sum, flags.UnrunnablesStrikeFirstAndSurprise);
 			sum = AddTriState(sum, flags.EnemyTrapTiles);
 			sum = AddTriState(sum, flags.RandomTrapFormations);
+			sum = AddTriState(sum, flags.SwolePirates);
 			sum = AddTriState(sum, flags.EnemyScripts);
 			sum = AddTriState(sum, flags.BossScriptsOnly);
 			sum = AddTriState(sum, flags.EnemySkillsSpells);
@@ -893,6 +895,7 @@ namespace FF1Lib
 				EnemySkillsSpells = GetTriState(ref sum),
 				BossScriptsOnly = GetTriState(ref sum),
 				EnemyScripts = GetTriState(ref sum),
+				SwolePirates = GetTriState(ref sum),
 				RandomTrapFormations = GetTriState(ref sum),
 				EnemyTrapTiles = GetTriState(ref sum),
 				UnrunnablesStrikeFirstAndSurprise = GetTriState(ref sum),

--- a/FF1Lib/FlagsViewModel.cs
+++ b/FF1Lib/FlagsViewModel.cs
@@ -2112,5 +2112,15 @@ namespace FF1Lib
 				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("BossHPScaleFactor"));
 			}
 		}
+
+		public bool? SwolePirates
+		{
+			get => Flags.SwolePirates;
+			set
+			{
+				Flags.SwolePirates = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("SwolePirates"));
+			}
+		}
 	}
 }

--- a/FF1Lib/Scale.cs
+++ b/FF1Lib/Scale.cs
@@ -39,7 +39,7 @@ namespace FF1Lib
 
 	public partial class FF1Rom : NesRom
 	{
-		public static readonly List<int> Bosses = new List<int> { Enemy.Garland, Enemy.Astos, Enemy.WarMech,
+		public static readonly List<int> Bosses = new List<int> { Enemy.Garland, Enemy.Astos, Enemy.Pirate, Enemy.WarMech,
 			Enemy.Lich, Enemy.Lich2, Enemy.Kary, Enemy.Kary2, Enemy.Kraken, Enemy.Kraken2, Enemy.Tiamat, Enemy.Tiamat2, Enemy.Chaos };
 
 		public static readonly List<int> NonBossEnemies = Enumerable.Range(0, EnemyCount).Where(x => !Bosses.Contains(x)).ToList();
@@ -292,6 +292,23 @@ namespace FF1Lib
 			byte firstLevelRequirement = Data[0x7C04B];
 			firstLevelRequirement = (byte)(firstLevelRequirement / multiplier);
 			Data[0x7C04B] = firstLevelRequirement;
+		}
+
+		public void EnableSwolePirates()
+		{
+			EnemyInfo newPirate = new EnemyInfo();
+			newPirate.decompressData(Get(EnemyOffset + EnemySize * Enemy.Pirate, EnemySize));
+			newPirate.exp = 800;
+			newPirate.gp = 800;
+			newPirate.hp = 160;
+			newPirate.num_hits = 2;
+			newPirate.damage = 32;
+			newPirate.absorb = 32;
+			newPirate.mdef = 30;
+			newPirate.accuracy = 35;
+			newPirate.critrate = 5;
+			newPirate.agility = 24;
+			Put(EnemyOffset + EnemySize * Enemy.Pirate, newPirate.compressData());
 		}
 	}
 }


### PR DESCRIPTION
Included an option to make the Pirates much more buff - each pirate's stats are around those of a level 6 Fighter, and the xp/gold reward is increased by a factor of 20 (800 gold/xp per pirate).