### PR TITLE
Renaming "Randomize" button to "Generate ROM"

### DIFF
--- a/FF1Blazorizer/Pages/Randomize.cshtml
+++ b/FF1Blazorizer/Pages/Randomize.cshtml
@@ -58,7 +58,7 @@
 				</div>
 			</TabPane>
 			<br />
-			<button type="button" class="nes-btn is-primary" onclick="@OnRandomize">Randomize</button>
+			<button type="button" class="nes-btn is-primary" onclick="@OnRandomize">Generate ROM</button>
 			<TabPane IsOpen="@(StatusMessage.Length > 0)">
 				<div class="is-dark nes-container">
 					@StatusMessage
@@ -508,7 +508,7 @@
 				</div>
 			</TabPane>
 			<br />
-			<button type="button" class="nes-btn is-primary" onclick="@OnRandomize">Randomize</button>
+			<button type="button" class="nes-btn is-primary" onclick="@OnRandomize">Generate ROM</button>
 			<TabPane IsOpen="@(StatusMessage.Length > 0)">
 				<div class="is-dark nes-container">
 					@StatusMessage


### PR DESCRIPTION
There have been numerous comments on the discord that this button is ambiguous in meaning. It also confusingly matches the wording of the menu button which selects this page. Changing it to "Generate ROM" states the precise action it accomplishes.