### PR TITLE
Random Weapon Bonus Balance Changes

### DIFF
--- a/FF1Blazorizer/wwwroot/tooltips/tooltips.json
+++ b/FF1Blazorizer/wwwroot/tooltips/tooltips.json
@@ -247,7 +247,7 @@
 	{
 		"Id": "RandomWeaponBonus",
 		"title": "Random Weapon Bonus",
-		"description": "Gives each weapon a random bonus of +5 to -5. This will increase or decrease its damage by 2 per bonus, hit by 3 per bonus, crit by 1 per bonus."
+		"description": "Gives each weapon a random bonus of +5 to -5. This will increase or decrease its damage by 2 per bonus, hit by 3(max 50%) per bonus, crit by 3(1.5%) per bonus. All values cannot go below zero hit or 1 crit/damage."
 	},
 	{
 		"Id": "RandomArmorBonus",

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -546,7 +546,12 @@ namespace FF1Lib
 				DontDoubleBBCritRates();
 			}
 
-			//needs to go after item magic, goes before weapon crit doubling now to actually change 1% per bonus
+			if (flags.WeaponCritRate)
+			{
+				DoubleWeaponCritRates();
+			}
+
+			//needs to go after item magic, moved after double weapon crit to have more control over the actual number of crit gained.
 			if ((bool)flags.RandomWeaponBonus)
 			{
 				RandomWeaponBonus(rng);
@@ -555,11 +560,6 @@ namespace FF1Lib
 			if ((bool)flags.RandomArmorBonus)
 			{
 				RandomArmorBonus(rng);
-			}
-
-			if (flags.WeaponCritRate)
-			{
-				DoubleWeaponCritRates();
 			}
 
 			if (flags.WeaponBonuses)

--- a/FF1Lib/Weapon.cs
+++ b/FF1Lib/Weapon.cs
@@ -110,7 +110,7 @@ namespace FF1Lib
 					currentWeapon.HitBonus = (byte)Math.Max(0, (int)(currentWeapon.HitBonus + (3 * bonus)));
 					currentWeapon.HitBonus = (byte)Math.Min(50, (int)(currentWeapon.HitBonus));
 					currentWeapon.Damage = (byte)Math.Max(1, (int)currentWeapon.Damage + (2 * bonus));
-					currentWeapon.Crit = (byte)Math.Max(1, (int)currentWeapon.Crit + bonus);
+					currentWeapon.Crit = (byte)Math.Max(1, (int)currentWeapon.Crit + (3 * bonus));
 
 					//change last two non icon characters to -/+bonus
 					string bonusString = bonus.ToString();


### PR DESCRIPTION
Updated random weapon bonuses to be 3 crit per bonus instead of two. Updated the tooltip to reflect this change.

This should make weapons a bit more effective as end game options, as well as making a -5 masmune a less appealing.