### PR TITLE
Added a fun% flag for removing the spell cast flash from casting spells.

### DIFF
--- a/FF1Blazorizer/Pages/Randomize.cshtml
+++ b/FF1Blazorizer/Pages/Randomize.cshtml
@@ -510,6 +510,7 @@
 							<EnumDropDown UpdateToolTip="@UpdateToolTipID" Id="partyMapmanSlot" TItem="MapmanSlot" bind-Value="@Flags.MapmanSlot">Mapman Slot</EnumDropDown>
 							<EnumDropDown UpdateToolTip="@UpdateToolTipID" Id="musicDropDown" TItem="MusicShuffle" bind-Value="@Flags.Music"></EnumDropDown>
 							<CheckBox UpdateToolTip="@UpdateToolTipID" Id="disableDamageTileFlickerCheckBox" bind-Value="@Flags.DisableDamageTileFlicker">Disable Damage Tile Flicker</CheckBox>
+							<CheckBox UpdateToolTip="@UpdateToolTipID" Id="disableSpellCastFlashCheckBox" bind-Value="@Flags.DisableSpellCastFlash">Disable Spell Cast Flash</CheckBox>
 							<EnumDropDown UpdateToolTip="@UpdateToolTipID" Id="menuColorDropDown" TItem="MenuColor" bind-Value="@Flags.MenuColor">Menu Color</EnumDropDown>
 						</div>
 					</div>

--- a/FF1Blazorizer/wwwroot/tooltips/tooltips.json
+++ b/FF1Blazorizer/wwwroot/tooltips/tooltips.json
@@ -403,6 +403,11 @@
 		"description": "Disables screen flashing when stepping over lava tiles."
 	},
 	{
+		"Id": "disableSpellCastFlashCheckBox",
+		"title": "Disable Spell Cast Flash",
+		"description": "Removes the full screen color flash when casting spells."
+	},
+	{
 		"Id": "menuColorDropDown",
 		"title": "Menu Color",
 		"screenshot": "MenuColor.gif",

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -701,6 +701,11 @@ namespace FF1Lib
 				ShuffleMusic(preferences.Music, rng);
 			}
 
+			if (preferences.DisableSpellCastFlash)
+			{
+				DisableSpellCastScreenFlash();
+			}
+
 			WriteSeedAndFlags(Version, seed.ToHex(), Flags.EncodeFlagsText(flags));
 			ExtraTrackingAndInitCode(flags);
 		}

--- a/FF1Lib/FlagsViewModel.cs
+++ b/FF1Lib/FlagsViewModel.cs
@@ -1439,6 +1439,15 @@ namespace FF1Lib
 				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("MapmanSlot"));
 			}
 		}
+		public bool DisableSpellCastFlash
+		{
+			get => Preferences.DisableSpellCastFlash;
+			set
+			{
+				Preferences.DisableSpellCastFlash = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("DisableSpellCastFlash"));
+			}
+		}
 
 		public bool? RecruitmentMode
 		{

--- a/FF1Lib/Fun.cs
+++ b/FF1Lib/Fun.cs
@@ -123,6 +123,12 @@ namespace FF1Lib
 				"00000000000000000000000000000000" + "01010101010000000000000000000000" + "fb9b9b9b98ff7f006767676767000000" + "6060606060c080008080808080000000" + "00000000000000000000000000000000" + "00000000000000000000000000000000"));
 		}
 
+		public void DisableSpellCastScreenFlash()
+		{
+			//just load the original battleground background in place of the flash color, it will still use the same number of frames
+			Put(0x32051, Blob.FromHex("AD446D"));
+		}
+
 		public void ShuffleLeader(MT19337 rng)
 		{
 			byte leader = (byte)(rng.Between(0, 3) << 6);

--- a/FF1Lib/Preferences.cs
+++ b/FF1Lib/Preferences.cs
@@ -15,5 +15,6 @@ namespace FF1Lib
 		public bool DisableDamageTileFlicker { get; set; }
 		public MenuColor MenuColor { get; set; } = MenuColor.Blue;
 		public MapmanSlot MapmanSlot { get; set; } = MapmanSlot.Leader;
+		public bool DisableSpellCastFlash { get; set; } = false;
 	}
 }


### PR DESCRIPTION
The DoMagicFlash function it works by setting the palette for the background to the palette of the spell being cast on alternating frames.

Removing this is done by changing the swap color of the spell to the current background itself. It should take up the same number of frames as the original, when it goes to swap it'll just swap to itself.