### PR TITLE
Mix Spellbooks fix

### DIFF
--- a/FF1Lib/Magic.cs
+++ b/FF1Lib/Magic.cs
@@ -343,9 +343,10 @@ namespace FF1Lib
 			{
 				if(mixSpellbooks)
 				{
-					magicSpells.Shuffle(rng);
-					whiteSpells = magicSpells.Where((spell, i) => (i / 4) % 2 == 0).ToList();
-					blackSpells = magicSpells.Where((spell, i) => (i / 4) % 2 == 1).ToList();
+					var mergedList = magicSpells.ToList();
+					mergedList.Shuffle(rng);
+					whiteSpells = mergedList.Where((spell, i) => (i / 4) % 2 == 0).ToList();
+					blackSpells = mergedList.Where((spell, i) => (i / 4) % 2 == 1).ToList();
 				}
 				else
 				{


### PR DESCRIPTION
Mixed spellbooks (vanilla) no longer shuffles the original magic list, instead shuffling a temp list.  This should fix an issue with confuse not working properly.