### PR TITLE
Pool Party + Random Class Change

### DIFF
--- a/FF1Blazorizer/Pages/Randomize.razor
+++ b/FF1Blazorizer/Pages/Randomize.razor
@@ -514,10 +514,10 @@
                         <TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="RandomArmorBonus" @bind-Value="Flags.RandomArmorBonus">Random Armor Bonus</TriStateCheckBox>
                         <CheckBox UpdateToolTip="@UpdateToolTipID" Id="fixMissingBattleRngEntry" @bind-Checked="Flags.FixMissingBattleRngEntry">Fix Missing Battle RNG Entry</CheckBox>
                         <TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="swolePiratesCheckBox" @bind-Value="Flags.SwolePirates">Buffed Pirates</TriStateCheckBox>
-                        <CheckBox UpdateToolTip="@UpdateToolTipID" Id="EnablePoolParty" @bind-Checked="Flags.EnablePoolParty">Select Party From Pool of Random Characters</CheckBox>
+                        <TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="EnablePoolParty" @bind-Value="Flags.EnablePoolParty">Select Party From Pool of Random Characters</TriStateCheckBox>
                         <EnumDropDown UpdateToolTip="@UpdateToolTipID" Indent IsEnabled="@Flags.EnablePoolParty" Id="PoolSizeDropDown" TItem="PoolSize" @bind-Value="Flags.PoolSize">Pool Size :</EnumDropDown>
                         <TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Indent IsEnabled="@Flags.EnablePoolParty" Id="PPIncludePromotedClasses" @bind-Value="Flags.IncludePromClasses">Include Promoted Classes</TriStateCheckBox>
-                        <CheckBox UpdateToolTip="@UpdateToolTipID" Id="EnableRandomPromotions" @bind-Checked="Flags.EnableRandomPromotions">Random Classes at Class Change</CheckBox>
+                        <TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="EnableRandomPromotions" @bind-Value="Flags.EnableRandomPromotions">Random Classes at Class Change</TriStateCheckBox>
                         <TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Indent IsEnabled="@Flags.EnableRandomPromotions" Id="RPIncludeBaseClasses" @bind-Value="Flags.IncludeBaseClasses">Include Base Classes</TriStateCheckBox>
                     </div>
                     <div class="col-md-12">

--- a/FF1Blazorizer/Pages/Randomize.razor
+++ b/FF1Blazorizer/Pages/Randomize.razor
@@ -514,6 +514,11 @@
                         <TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="RandomArmorBonus" @bind-Value="Flags.RandomArmorBonus">Random Armor Bonus</TriStateCheckBox>
                         <CheckBox UpdateToolTip="@UpdateToolTipID" Id="fixMissingBattleRngEntry" @bind-Checked="Flags.FixMissingBattleRngEntry">Fix Missing Battle RNG Entry</CheckBox>
                         <TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="swolePiratesCheckBox" @bind-Value="Flags.SwolePirates">Buffed Pirates</TriStateCheckBox>
+                        <CheckBox UpdateToolTip="@UpdateToolTipID" Id="EnablePoolParty" @bind-Checked="Flags.EnablePoolParty">Select Party From Pool of Random Characters</CheckBox>
+                        <EnumDropDown UpdateToolTip="@UpdateToolTipID" Indent IsEnabled="@Flags.EnablePoolParty" Id="PoolSizeDropDown" TItem="PoolSize" @bind-Value="Flags.PoolSize">Pool Size :</EnumDropDown>
+                        <TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Indent IsEnabled="@Flags.EnablePoolParty" Id="PPIncludePromotedClasses" @bind-Value="Flags.IncludePromClasses">Include Promoted Classes</TriStateCheckBox>
+                        <CheckBox UpdateToolTip="@UpdateToolTipID" Id="EnableRandomPromotions" @bind-Checked="Flags.EnableRandomPromotions">Random Classes at Class Change</CheckBox>
+                        <TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Indent IsEnabled="@Flags.EnableRandomPromotions" Id="RPIncludeBaseClasses" @bind-Value="Flags.IncludeBaseClasses">Include Base Classes</TriStateCheckBox>
                     </div>
                     <div class="col-md-12">
                     </div>

--- a/FF1Blazorizer/wwwroot/tooltips/tooltips.json
+++ b/FF1Blazorizer/wwwroot/tooltips/tooltips.json
@@ -95,6 +95,31 @@
 		"description": "Unsafe Pirates: Allows Pirates to be shuffled skills and spells. Left unchecked, Pirates will always have a script that directs them to only attack."
 	},
 	{
+		"Id": "EnablePoolParty",
+		"title": "Select Party From Pool of Random Characters",
+		"description": "This fills a pool with random characters, allowing duplicates, from which to form your party. Once a character is selected, it's removed from the pool. Cancelling your choice puts back the character in the pool."
+	},
+	{
+		"Id": "PoolSizeDropDown",
+		"title": "Pool Size",
+		"description": "Number of characters in the pool."
+	},
+	{
+		"Id": "PPIncludePromotedClasses",
+		"title": "Include Promoted Classes",
+		"description": "Allow promoted classes to be added to the pool."
+	},
+	{
+		"Id": "EnableRandomPromotions",
+		"title": "Random Promotions",
+		"description": "When giving the TAIL to Bahamut, promote your party to random classes."
+	},
+	{
+		"Id": "RPIncludeBaseClasses",
+		"title": "Include Base Classes",
+		"description": "Allow base classes as possible promotions."
+	},
+	{
 		"Id": "enemySkillsSpellsCheckBox",
 		"title": "Enemy Skills/Spells",
 		"screenshot": "enemySkillsSpellsCheckBox.png",

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -658,6 +658,18 @@ namespace FF1Lib
 				PubReplaceClinic(rng, flags);
 			}
 
+			if (flags.EnablePoolParty)
+			{
+				EnableTwelveClasses();
+				EnablePoolParty(flags, rng);
+			}
+
+			if (flags.EnableRandomPromotions)
+			{
+				EnableTwelveClasses();
+				EnableRandomPromotions(flags, rng);
+			}
+
 			if ((bool)flags.MapCanalBridge)
 			{
 				EnableCanalBridge();
@@ -963,10 +975,10 @@ namespace FF1Lib
 		public void WriteSeedAndFlags(string version, string seed, string flags)
 		{
 			// Replace most of the old copyright string printing with a JSR to a LongJump
-			Put(0x38486, Blob.FromHex("20FCFE60"));
+			Put(0x38486, Blob.FromHex("20B9FF60"));
 
 			// DrawSeedAndFlags LongJump
-			PutInBank(0x1F, 0xFEFC, CreateLongJumpTableEntry(0x0F, 0x8980));
+			PutInBank(0x1F, 0xFFB9, CreateLongJumpTableEntry(0x0F, 0x8980));
 
 			var sha = File.Exists("version.txt") ? File.ReadAllText("version.txt").Trim() : "development";
 			Blob hash;

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -252,6 +252,14 @@ namespace FF1Lib
 		public double EnemyHPScaleFactor { get; set; } = 1;
 		public double BossHPScaleFactor { get; set; } = 1;
 
+		public PoolSize PoolSize { get; set; } = PoolSize.Size6;
+		public bool EnablePoolParty { get; set; }= false;
+		public bool? IncludePromClasses { get; set; } = false;
+		public bool EnableRandomPromotions { get; set; } = false;
+		public bool? IncludeBaseClasses { get; set; } = false;
+
+
+
 		public MDEFGrowthMode MDefMode { get; set; } = MDEFGrowthMode.None;
 
 		public FormationShuffleMode FormationShuffleMode { get; set; } = FormationShuffleMode.None;
@@ -702,6 +710,11 @@ namespace FF1Lib
 			sum = AddTriState(sum, flags.ClampEnemyHpScaling);
 			sum = AddNumeric(sum, 41, (int)(10.0 * flags.EnemyHPScaleFactor) - 10);
 			sum = AddNumeric(sum, 41, (int)(10.0 * flags.BossHPScaleFactor) - 10);
+			sum = AddNumeric(sum, Enum.GetValues(typeof(PoolSize)).Cast<int>().Max() + 1, (int)flags.PoolSize);
+			sum = AddBoolean(sum, flags.EnablePoolParty);
+			sum = AddTriState(sum, flags.IncludePromClasses);
+			sum = AddBoolean(sum, flags.EnableRandomPromotions);
+			sum = AddTriState(sum, flags.IncludeBaseClasses);
 			sum = AddNumeric(sum, Enum.GetValues(typeof(FormationShuffleMode)).Cast<int>().Max() + 1, (int)flags.FormationShuffleMode);
 			sum = AddNumeric(sum, Enum.GetValues(typeof(MDEFGrowthMode)).Cast<int>().Max() + 1, (int)flags.MDefMode);
 			sum = AddNumeric(sum, Enum.GetValues(typeof(WorldWealthMode)).Cast<int>().Max() + 1, (int)flags.WorldWealth);
@@ -730,6 +743,11 @@ namespace FF1Lib
 				ClampBossHPScaling = GetTriState(ref sum),
 				SeparateEnemyHPScaling = GetTriState(ref sum),
 				SeparateBossHPScaling = GetTriState(ref sum),
+				PoolSize = (PoolSize)GetNumeric(ref sum, Enum.GetValues(typeof(PoolSize)).Cast<int>().Max() + 1),
+				EnablePoolParty = GetBoolean(ref sum),
+				IncludePromClasses = GetTriState(ref sum),
+				EnableRandomPromotions = GetBoolean(ref sum),
+				IncludeBaseClasses = GetTriState(ref sum),
 				BalancedItemMagicShuffle = GetTriState(ref sum),
 				RandomArmorBonus = GetTriState(ref sum),
 				RandomWeaponBonus = GetTriState(ref sum),

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -253,9 +253,9 @@ namespace FF1Lib
 		public double BossHPScaleFactor { get; set; } = 1;
 
 		public PoolSize PoolSize { get; set; } = PoolSize.Size6;
-		public bool EnablePoolParty { get; set; }= false;
+		public bool? EnablePoolParty { get; set; }= false;
 		public bool? IncludePromClasses { get; set; } = false;
-		public bool EnableRandomPromotions { get; set; } = false;
+		public bool? EnableRandomPromotions { get; set; } = false;
 		public bool? IncludeBaseClasses { get; set; } = false;
 
 
@@ -711,9 +711,9 @@ namespace FF1Lib
 			sum = AddNumeric(sum, 41, (int)(10.0 * flags.EnemyHPScaleFactor) - 10);
 			sum = AddNumeric(sum, 41, (int)(10.0 * flags.BossHPScaleFactor) - 10);
 			sum = AddNumeric(sum, Enum.GetValues(typeof(PoolSize)).Cast<int>().Max() + 1, (int)flags.PoolSize);
-			sum = AddBoolean(sum, flags.EnablePoolParty);
+			sum = AddTristate(sum, flags.EnablePoolParty);
 			sum = AddTriState(sum, flags.IncludePromClasses);
-			sum = AddBoolean(sum, flags.EnableRandomPromotions);
+			sum = AddTristate(sum, flags.EnableRandomPromotions);
 			sum = AddTriState(sum, flags.IncludeBaseClasses);
 			sum = AddNumeric(sum, Enum.GetValues(typeof(FormationShuffleMode)).Cast<int>().Max() + 1, (int)flags.FormationShuffleMode);
 			sum = AddNumeric(sum, Enum.GetValues(typeof(MDEFGrowthMode)).Cast<int>().Max() + 1, (int)flags.MDefMode);
@@ -737,17 +737,17 @@ namespace FF1Lib
 				WorldWealth = (WorldWealthMode)GetNumeric(ref sum, Enum.GetValues(typeof(WorldWealthMode)).Cast<int>().Max() + 1),
 				MDefMode = (MDEFGrowthMode)GetNumeric(ref sum, Enum.GetValues(typeof(MDEFGrowthMode)).Cast<int>().Max() + 1),
 				FormationShuffleMode = (FormationShuffleMode)GetNumeric(ref sum, Enum.GetValues(typeof(FormationShuffleMode)).Cast<int>().Max() + 1),
+				IncludeBaseClasses = GetTriState(ref sum),
+				EnableRandomPromotions = GetBoolean(ref sum),
+				IncludePromClasses = GetTriState(ref sum),
+				EnablePoolParty = GetBoolean(ref sum),
+				PoolSize = (PoolSize)GetNumeric(ref sum, Enum.GetValues(typeof(PoolSize)).Cast<int>().Max() + 1),
 				BossHPScaleFactor = (GetNumeric(ref sum, 41) + 10) / 10.0,
 				EnemyHPScaleFactor = (GetNumeric(ref sum, 41) + 10) / 10.0,
 				ClampEnemyHpScaling = GetTriState(ref sum),
 				ClampBossHPScaling = GetTriState(ref sum),
 				SeparateEnemyHPScaling = GetTriState(ref sum),
 				SeparateBossHPScaling = GetTriState(ref sum),
-				PoolSize = (PoolSize)GetNumeric(ref sum, Enum.GetValues(typeof(PoolSize)).Cast<int>().Max() + 1),
-				EnablePoolParty = GetBoolean(ref sum),
-				IncludePromClasses = GetTriState(ref sum),
-				EnableRandomPromotions = GetBoolean(ref sum),
-				IncludeBaseClasses = GetTriState(ref sum),
 				BalancedItemMagicShuffle = GetTriState(ref sum),
 				RandomArmorBonus = GetTriState(ref sum),
 				RandomWeaponBonus = GetTriState(ref sum),

--- a/FF1Lib/FlagsViewModel.cs
+++ b/FF1Lib/FlagsViewModel.cs
@@ -2140,7 +2140,7 @@ namespace FF1Lib
 				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("PoolSize"));
 			}
 		}
-		public bool EnablePoolParty
+		public bool? EnablePoolParty
 		{
 			get => Flags.EnablePoolParty;
 			set
@@ -2158,7 +2158,7 @@ namespace FF1Lib
 				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("IncludePromClasses"));
 			}
 		}
-		public bool EnableRandomPromotions
+		public bool? EnableRandomPromotions
 		{
 			get => Flags.EnableRandomPromotions;
 			set

--- a/FF1Lib/FlagsViewModel.cs
+++ b/FF1Lib/FlagsViewModel.cs
@@ -2131,7 +2131,51 @@ namespace FF1Lib
 				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("BossHPScaleFactor"));
 			}
 		}
-
+		public PoolSize PoolSize
+		{
+			get => Flags.PoolSize;
+			set
+			{
+				Flags.PoolSize = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("PoolSize"));
+			}
+		}
+		public bool EnablePoolParty
+		{
+			get => Flags.EnablePoolParty;
+			set
+			{
+				Flags.EnablePoolParty = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("EnablePoolParty"));
+			}
+		}
+		public bool? IncludePromClasses
+		{
+			get => Flags.IncludePromClasses;
+			set
+			{
+				Flags.IncludePromClasses = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("IncludePromClasses"));
+			}
+		}
+		public bool EnableRandomPromotions
+		{
+			get => Flags.EnableRandomPromotions;
+			set
+			{
+				Flags.EnableRandomPromotions = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("EnableRandomPromotions"));
+			}
+		}
+		public bool? IncludeBaseClasses
+		{
+			get => Flags.IncludeBaseClasses;
+			set
+			{
+				Flags.IncludeBaseClasses = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("IncludeBaseClasses"));
+			}
+		}
 		public bool? SwolePirates
 		{
 			get => Flags.SwolePirates;

--- a/FF1Lib/Hacks.cs
+++ b/FF1Lib/Hacks.cs
@@ -2,9 +2,23 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.ComponentModel;
 
 namespace FF1Lib
 {
+	public enum PoolSize
+	{
+		[Description("4 characters")]
+		Size4,
+		[Description("5 characters")]
+		Size5,
+		[Description("6 characters")]
+		Size6,
+		[Description("7 characters")]
+		Size7,
+		[Description("8 characters")]
+		Size8,
+	}
 	public partial class FF1Rom : NesRom
 	{
 		public const int Nop = 0xEA;
@@ -745,5 +759,112 @@ namespace FF1Lib
 			// Hacks the game so that Inns do not save the game
 			Put(0x3A53D, Blob.FromHex("EAEAEA"));
 		}
+		public void EnableTwelveClasses()
+		{
+			// Expand characters shown in party creation screen; set to 0C for all promoted classes
+			PutInBank(0x1E, 0x80F5, Blob.FromHex("06"));
+			// Add the classes to authorized classes lut
+			PutInBank(0x1E, 0x811B, Blob.FromHex("804020100804"));
+			// Reduce count to $10 in PtyGen_DrawChars because we only loaded one row of sprites
+			PutInBank(0x1E, 0x8373, Blob.FromHex("EA"));
+
+			// New CHRLoad routine so we can load promoted classes' sprites in memory by only loading one row of sprites instead of two
+			var newfCHRLoad = Blob.FromHex("A000B1108D0720C8D0F8E611E611CAD0F160");
+
+			// Put new CHRLoad routine
+			PutInBank(0x1F, 0xEAD5, Blob.FromHex("20EBFE"));
+			PutInBank(0x1F, 0xFEEB, newfCHRLoad);
+
+			// Starting stats for promoted classes, same as base classes
+			Put(0x30A0, Get(0x3040, 0x0A));
+			Put(0x30B0, Get(0x3050, 0x0A));
+			Put(0x30C0, Get(0x3060, 0x0A));
+			Put(0x30D0, Get(0x3070, 0x0A));
+			Put(0x30E0, Get(0x3080, 0x0A));
+			Put(0x30F0, Get(0x3090, 0x0A));
+
+			// Starting magic for promoted classes. Instead of checking for the class ID of the characters, we compare with the unused class ID in the starting stats array.
+			PutInBank(0x1F, 0xC7CA, Blob.FromHex("B940B0"));
+
+			// New promotion routine to not bug out with already promoted classes and allow random promotion; works with Nones; see 0E_95AE_DoClassChange-2.asm
+			PutInBank(0x0E, 0x95AE, Blob.FromHex("A20020C595A24020C595A28020C595A2C020C595E65660BC00613006B9809C9D006160"));
+			// lut for standard promotion, can be modified or randomized
+			PutInBank(0x0E, 0x9C80, Blob.FromHex("060708090A0B060708090A0B"));
+		}
+
+		public void EnableRandomPromotions(Flags flags, MT19337 rng)
+		{
+			// Need EnableTwelveClasses()
+			// Promotions list
+			List<sbyte> promotions = new List<sbyte> { 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B };
+
+			// Include base classes
+			if (flags.IncludeBaseClasses ?? false)
+			{
+				promotions.AddRange(new List<sbyte> { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05 });
+				promotions.Shuffle(rng);
+			}
+			else
+			{
+				// If not shuffle list first then add promoted classes so that already promoted classes don't bug
+				promotions.Shuffle(rng);
+				promotions.AddRange(new List<sbyte> { 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B });
+			}
+
+			// Insert randomized promotions
+			PutInBank(0x0E, 0x9C80, Blob.FromSBytes(promotions.ToArray()));
+		}
+
+		public void EnablePoolParty(Flags flags, MT19337 rng)
+		{
+			// Need EnableTwelveClasses()
+			// New DoPartyGen_OnCharacter and update references; see 1E_85B0_DoPartyGen_OnCharacter.asm
+			PutInBank(0x1E, 0x85B0, Blob.FromHex("A667BD01030D41038D410320A480200F82A667AC4003A524F016BD0003C9FFF00CB926869D01034D41038D41034C2C81A525F0118AC900F00AA9009D0103A9FF9D00033860A520290FC561F0C18561C900F0BBC898C9099002A0008C4003B926862C4103F0EDB942039D0003A901853720B0824CBE858040201008040201"));
+			PutInBank(0x1E, 0x8032, Blob.FromHex("B085"));
+			PutInBank(0x1E, 0x803B, Blob.FromHex("B085"));
+			PutInBank(0x1E, 0x8044, Blob.FromHex("B085"));
+			PutInBank(0x1E, 0x804D, Blob.FromHex("B085"));
+
+			// Routine to load the random pool in memory
+			PutInBank(0x1E, 0x80C1, Blob.FromHex("A23FBDAA849D0003CA10F7A209BD30869D4003CA10F760"));
+
+			// Zero out free space
+			sbyte[] zerofill = new sbyte[0x54];
+			PutInBank(0x1E, 0x80D8, Blob.FromSBytes(zerofill));
+
+			// Change reference in NewGamePartyGeneration
+			PutInBank(0x1E, 0x801E, Blob.FromHex("20C180EAEAEAEAEAEAEAEA"));
+
+			// Standard party pool lut, byte1 = selection; byte2 = availability mask; byte3-10: characters pool
+			PutInBank(0x1E, 0x8630, Blob.FromHex("00FC0001020304050607"));
+
+			int size = 6;
+			Blob sizebyte = Blob.FromHex("");
+
+			switch (flags.PoolSize)
+			{
+				case PoolSize.Size4: size = 4; sizebyte = Blob.FromHex("F0"); break;
+				case PoolSize.Size5: size = 5; sizebyte = Blob.FromHex("F8"); break;
+				case PoolSize.Size6: size = 6; sizebyte = Blob.FromHex("FC"); break;
+				case PoolSize.Size7: size = 7; sizebyte = Blob.FromHex("FE"); break;
+				case PoolSize.Size8: size = 8; sizebyte = Blob.FromHex("FF"); break;
+			}
+
+			int class_span = 5;
+			if (flags.IncludePromClasses ?? false) class_span = 11;
+			Blob pool = Blob.FromHex("");
+			for (int i = 0; i < size; i++)
+				pool += Blob.FromSBytes(new List<sbyte> { (sbyte)Rng.Between(rng, 0, class_span) }.ToArray());
+
+			// Pool size : 4 0xF0; 5 0xF8; 6 0xFC; 7 0xFE; 8 0xFF)
+			PutInBank(0x1E, 0x8630, Blob.FromHex("00") + sizebyte + pool);
+
+			// Starting party composition
+			PutInBank(0x1E, 0x84AA, pool.SubBlob(0, 1));
+			PutInBank(0x1E, 0x84BA, Blob.FromHex("FF"));
+			PutInBank(0x1E, 0x84CA, Blob.FromHex("FF"));
+			PutInBank(0x1E, 0x84DA, Blob.FromHex("FF"));
+		}
+
 	}
 }

--- a/FF1Lib/asm/0E_95AE_DoClassChange-2.asm
+++ b/FF1Lib/asm/0E_95AE_DoClassChange-2.asm
@@ -1,0 +1,32 @@
+﻿; New DoClassChange routine to prevent any bugs with promoting already promoted classes
+:  and allow randomizing promotions
+
+define ch_class $6100
+define lut_promote $9C80
+define dlgflg_reentermap $56
+
+ .ORG $95AE
+
+DoClassChange:
+  LDX #$00				; Revert somewhat to classic class change routine
+  JSR @DoClass			;  where we cycle manually through each class
+  LDX #$40				
+  JSR @DoClass			
+  LDX #$80				
+  JSR @DoClass			
+  LDX #$C0				
+  JSR @DoClass			
+  INC dlgflg_reentermap	; Set bit to reload map and show promoted class
+  RTS					
+
+@DoClass:
+  LDY ch_class, X		; Get current class 
+  BMI @Skip			    ; Skip Nones
+  LDA lut_promote, Y	; Find to which class it promote in the table
+  STA ch_class, X		; Change class
+@Skip:
+  RTS				; 60
+
+ .ORG $9C80
+; Standard LUT at lut_promote for normal class change
+ .BYTE $06, $07, $08, $09, $0A, $0B, $06, $07, $08, $09, $0A, $0B

--- a/FF1Lib/asm/0E_95AE_DoClassChange.asm
+++ b/FF1Lib/asm/0E_95AE_DoClassChange.asm
@@ -1,4 +1,6 @@
-﻿define ch_class $6100
+;; Superseded for Hacks.cs/EnableTwelveClasses() - see "0E_95AE_DoClassChange-2.asm"
+
+define ch_class $6100
 define lut_ptr $95D0
 define dlgflg_reentermap $56
 

--- a/FF1Lib/asm/1E.asm
+++ b/FF1Lib/asm/1E.asm
@@ -143,6 +143,7 @@ PtyGen_DrawScreen:
 ;;
 ;;  DoPartyGen_OnCharacter  [around $80C1 :: 0x780D1]
 ;;    modified
+;;    modified further for Hacks.cs/EnablePoolParty() - see "1E_85B0_DoPartyGen_OnCharacter.asm"
 ;;
 ;;    Does character selection and name input for one character.
 ;;

--- a/FF1Lib/asm/1E_85B0_DoPartyGen_OnCharacter.asm
+++ b/FF1Lib/asm/1E_85B0_DoPartyGen_OnCharacter.asm
@@ -1,0 +1,77 @@
+﻿ .ORG $85B0
+
+define ptygen_class $0300
+define ptygen_empty $0301
+
+define lut_PtyGenBuf $84AA
+
+; The pool is stored right after ptygen in memory
+define pool_maxchar $09
+define pool_select $0340     ; Current character selected
+define pool_taken $0341      ; Taken mask so you can't take the same character twice
+define pool_char $0342       ; Characters pool, 8 bytes
+
+DoPartyGen_OnCharacter:
+    LDX char_index           ; Start by restoring last char if B button was pressed
+    LDA ptygen_empty,X       ; char availability mask was stored in empty ptygen byte
+    ORA pool_taken
+    STA pool_taken  
+    JSR PtyGen_DrawScreen    ; Normal draw screen
+
+  @MainLoop:
+    JSR PtyGen_Frame
+    LDX char_index
+    LDY pool_select          ; Get the current char selected
+      
+    LDA joy_a                ; Pressing A button
+    BEQ @SkipA
+      LDA ptygen_class,X     ; Check if None was choosen
+      CMP #$FF
+      BEQ :+                 ; If it's not, update availability mask
+        LDA lut_CharMask,Y
+        STA ptygen_empty,X
+        EOR pool_taken
+        STA pool_taken      
+    : JMP DoNameInput        ; and go to name input
+  @SkipA:
+    LDA joy_b                ; Pressing B button
+    BEQ @SkipB
+      TXA                    ; Check if the current slot is the first
+      CMP #$00               ;  we don't want to allow 4 nones
+      BEQ :+                 ; If it's not, put None before freeing character 
+        LDA #$00
+        STA ptygen_empty,X     
+        LDA #$FF
+        STA ptygen_class,X  
+    : SEC
+      RTS
+  @SkipB:
+    LDA joy                  ; Check directional input
+    AND #$0F
+    CMP joy_prevdir
+    BEQ @MainLoop
+
+    STA joy_prevdir    
+    CMP #$00                 ; if directional input released (rather than pressed)
+    BEQ @MainLoop            ;  loop to another frame.
+  @retry:
+    INY                      ; Cycle available characters
+    TYA
+    CMP #pool_maxchar
+    BCC :+                   ; Loop back if we go over the max
+      LDY #$00
+  : STY pool_select          
+    LDA lut_CharMask,Y      ; Check if the char is still available
+    BIT pool_taken
+    BEQ @retry               ; If not loop, else load it in memory
+    LDA pool_char,Y
+    STA ptygen_class,X
+     
+    LDA #$01
+    STA menustall
+
+    JSR PtyGen_DrawOneText  
+    JMP @MainLoop
+
+lut_CharMask:
+  .BYTE $80, $40, $20, $10, $08, $04, $02, $01      


### PR DESCRIPTION
**Pool Party**
Change party creation at the start of the game. It fills a pool with random characters, allowing duplicates, from which to form the party. Once a character is selected, it's removed from the pool. Cancelling your choice puts back the character in the pool.
Key points:
 - Modify extensively DoPartyGen_OnCharacter
 - Use an array of 10 bytes in memory which isn't used at party creation, tests didn't bring up any problems
 - Ignore Party Composition flags for now, but it's possible to take them into accounts down the road. Works fine with Tavern Recruitment.

**Random Class Change**
Promote party to random classes.
Key points:
- Modify extensively DoClassChange, doesn't break "Nones"

Flags are in experimental section