### PR TITLE
ShuffleAstos and SaveWhenGameOver fix

### DIFF
--- a/FF1Blazorizer/Pages/Randomize.razor
+++ b/FF1Blazorizer/Pages/Randomize.razor
@@ -502,7 +502,8 @@
                         <div class="checkbox-cell"></div>
                         <CheckBox UpdateToolTip="@UpdateToolTipID" Id="disableTentSaving" @bind-Checked="Flags.DisableTentSaving">Disable Tent/Cabin/House Saving on Overworld</CheckBox>
                         <CheckBox UpdateToolTip="@UpdateToolTipID" Id="disableInnSaving" @bind-Checked="Flags.DisableInnSaving">Disable Inn Saving</CheckBox>
-                        <CheckBox UpdateToolTip="@UpdateToolTipID" Id="saveGameWhenGameOverCheckBox" @bind-Checked="Flags.SaveGameWhenGameOver">Save Game When Game Over</CheckBox>
+                        <CheckBox UpdateToolTip="@UpdateToolTipID" Id="saveGameWhenGameOverCheckBox" IsEnabled="@((Flags.NPCItems ?? true) || (Flags.NPCFetchItems ?? true))" @bind-Checked="Flags.SaveGameWhenGameOver">Save Game When Game Over</CheckBox>
+                        <CheckBox UpdateToolTip="@UpdateToolTipID" Id="shuffleAstosCheckBox" IsEnabled="@((Flags.NPCItems ?? true) || (Flags.NPCFetchItems ?? true))" @bind-Checked="Flags.ShuffleAstos">Shuffle Astos</CheckBox>
                         <TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="randomizeFormationEnemizer" @bind-Value="Flags.RandomizeFormationEnemizer">Generate New Formations (Enemizer)</TriStateCheckBox>
                         <TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="randomizeEnemizer" IsEnabled="@Flags.RandomizeFormationEnemizer" @bind-Value="Flags.RandomizeEnemizer">Generate New Enemies (Enemizer)</TriStateCheckBox>
                         <TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="generateNewSpellbook" @bind-Value="Flags.GenerateNewSpellbook">Generate New Spellbook (Spellcrafter)</TriStateCheckBox>

--- a/FF1Blazorizer/wwwroot/tooltips/tooltips.json
+++ b/FF1Blazorizer/wwwroot/tooltips/tooltips.json
@@ -882,7 +882,13 @@
 	{
 		"Id": "saveGameWhenGameOverCheckBox",
 		"title": "Save Game When Game Over",
-		"description": "When enabled, if your party perishes, you will respawn with all of your progression (items acquired, levels gained, etc.) intact.  Certain events (those that involve talking to NPCs that begin fights) will be reset based on the condition of other flags, for example you must acquire the item in the vanilla RUBY chest to ensure Vampire does not respawn.  If you have the SHIP (but not the airship), you will respawn where you last docked; if you have the AIRSHIP, you will respawn at the airship and the ship will be waiting for you at Coneria; if you have neither, you will respawn where you last saved."
+		"description": "When enabled, if your party perishes, you will respawn with all of your progression (items acquired, levels gained, etc.) intact. If you have the SHIP (but not the airship), you will respawn where you last docked; if you have the AIRSHIP, you will respawn at the airship and the ship will be waiting for you at Coneria; if you have neither, you will respawn where you last saved."
+	},
+	{
+		"Id": "shuffleAstosCheckBox",
+		"title": "Shuffle Astos",
+		"screenshot": "",
+		"description": "Astos disguises himself as another NPC: Bahamut, Canoe Sage, CubeBot, Elf Doctor, Elf Prince, Fairy, King, Lefein, Mayoya, Nerrick, Princess Sara, Sarda, Smith, Titan, Unne or the kindly old king from Northwest Castle."
 	},
 	{
 		"Id": "randomizeFormationEnemizer",

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -315,11 +315,11 @@ namespace FF1Lib
 			}
 			*/
 
-			NewAstosRoutine((bool)flags.NPCItems | (bool)flags.NPCFetchItems);  // moves Talk_Astos to a new location so we can play with it, and also makes it so Astos will only give his item after you have defeated him and speak to him again
+			NewAstosRoutine((bool)flags.NPCItems || (bool)flags.NPCFetchItems);  // moves Talk_Astos to a new location so we can play with it, and also makes it so Astos will only give his item after you have defeated him and speak to him again
 																				// we make this happen on all seeds for consistency with other features
-			if (flags.SaveGameWhenGameOver)
+			if (flags.SaveGameWhenGameOver && ((bool)flags.NPCItems || (bool)flags.NPCFetchItems))
 			{
-				EnableSaveOnDeath((bool)flags.NPCItems | (bool)flags.NPCFetchItems);
+				EnableSaveOnDeath();
 			}
 
 			// Ordered before RNG shuffle. In the event that both flags are on, RNG shuffle depends on this.
@@ -656,6 +656,11 @@ namespace FF1Lib
 			if (((bool)flags.RecruitmentMode))
 			{
 				PubReplaceClinic(rng, flags);
+			}
+
+			if ((bool)flags.ShuffleAstos && ((bool)flags.NPCItems || (bool)flags.NPCFetchItems))
+			{
+				ShuffleAstos(flags, rng);
 			}
 
 			if ((bool)flags.MapCanalBridge)

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -686,8 +686,8 @@ namespace FF1Lib
 			sum = AddBoolean(sum, flags.FiendShuffle);
 			sum = AddBoolean(sum, flags.DisableTentSaving);
 			sum = AddBoolean(sum, flags.DisableInnSaving);
-			sum = AddBoolean(sum, flags.SaveGameWhenGameOver);
 			sum = AddBoolean(sum, flags.ShuffleAstos);
+			sum = AddBoolean(sum, flags.SaveGameWhenGameOver);
 			sum = AddTriState(sum, flags.RandomizeEnemizer);
 			sum = AddTriState(sum, flags.RandomizeFormationEnemizer);
 			sum = AddTriState(sum, flags.GenerateNewSpellbook);

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -233,6 +233,7 @@ namespace FF1Lib
 		public bool DisableTentSaving { get; set; } = false;
 		public bool DisableInnSaving { get; set; } = false;
 		public bool SaveGameWhenGameOver { get; set; } = false;
+		public bool ShuffleAstos { get; set; } = false;
 		public bool? RandomizeEnemizer { get; set; } = false;
 		public bool? RandomizeFormationEnemizer { get; set; } = false;
 		public bool? GenerateNewSpellbook { get; set; } = false;
@@ -251,6 +252,8 @@ namespace FF1Lib
 		public bool? ClampEnemyHpScaling { get; set; } = false;
 		public double EnemyHPScaleFactor { get; set; } = 1;
 		public double BossHPScaleFactor { get; set; } = 1;
+		public bool EnablePoolParty { get; set; } = false;
+		public bool EnableRandomPromotions { get; set; } = false;
 
 		public MDEFGrowthMode MDefMode { get; set; } = MDEFGrowthMode.None;
 
@@ -684,6 +687,7 @@ namespace FF1Lib
 			sum = AddBoolean(sum, flags.DisableTentSaving);
 			sum = AddBoolean(sum, flags.DisableInnSaving);
 			sum = AddBoolean(sum, flags.SaveGameWhenGameOver);
+			sum = AddBoolean(sum, flags.ShuffleAstos);
 			sum = AddTriState(sum, flags.RandomizeEnemizer);
 			sum = AddTriState(sum, flags.RandomizeFormationEnemizer);
 			sum = AddTriState(sum, flags.GenerateNewSpellbook);
@@ -743,6 +747,7 @@ namespace FF1Lib
 				RandomizeFormationEnemizer = GetTriState(ref sum),
 				RandomizeEnemizer = GetTriState(ref sum),
 				SaveGameWhenGameOver = GetBoolean(ref sum),
+				ShuffleAstos = GetBoolean(ref sum),
 				DisableInnSaving = GetBoolean(ref sum),
 				DisableTentSaving = GetBoolean(ref sum),
 				FiendShuffle = GetBoolean(ref sum),

--- a/FF1Lib/FlagsViewModel.cs
+++ b/FF1Lib/FlagsViewModel.cs
@@ -1960,6 +1960,15 @@ namespace FF1Lib
 				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("SaveGameWhenGameOver"));
 			}
 		}
+		public bool ShuffleAstos
+		{
+			get => Flags.ShuffleAstos;
+			set
+			{
+				Flags.ShuffleAstos = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("ShuffleAstos"));
+			}
+		}
 		public bool? RandomizeEnemizer
 		{
 			get => Flags.RandomizeEnemizer;


### PR DESCRIPTION
SaveWhenGameOver fixes
Fix a bug with SaveWhenGameOver that would revives Nones when reloading a game; also change the main routine so has to not fiddle with NPC flags as much.
Key points:
- Change from checking various NPC flags to checking which battle killed the party.
- Restore Astos to normal behaviour without allowing to cheat his item.

SuffleAstos
Shuffle Astos script to a random key NPC, as is he's hiding as this new NPC.
Key points:
- Compatible with SaveWhenGameOver
- If Astos is Bahamut, there's substantial change to Astos's routine and SaveWhenGameOver
