### PR TITLE
Versioned deploys

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -41,11 +41,11 @@ else
     --data-raw "{\"custom_domain\": \"${version}.finalfantasyrandomizer.com\", \"force_ssl\": \"true\"}")
     
     
-    errorsExist=$(echo "$deploy" | jq ".errors!=null")
-    if [ ! -z "$errorsExist" ]; then
-    	echo "errors encountered while creating site:"
-    	echo $(echo "$createdSite" | jq -r ".errors")
-    	exit 2
+    errorsExist=$(echo "$createdSite" | jq ".errors!=null")
+    if [ -n "$errorsExist" ]; then
+	    echo "errors encountered while creating site:"
+	    echo "$createdSite" | jq -r ".errors"
+	    exit 2
     fi
     
     id=$(echo "$createdSite" | jq -r ".site_id")

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -26,9 +26,9 @@ netlifyID=$(echo "$config" | jq -r ".netlifyID")
 #
 #else
     #version=$(grep " Version.*" /root/ff1randomizer/FF1Lib/FFRVersion.cs | grep -Eo "[0-9\.]+" | tr '.' '-')
-    version="fake-version"
+    version="fake-version2"
     siteExists=$(curl --location --request GET 'https://api.netlify.com/api/v1/dns_zones/finalfantasyrandomizer_com/dns_records' \
-    --header "Authorization: Bearer ${NETLIFY_TOKEN}" \
+    --header "Authorization: Bearer ${NETLIFY_AUTH_TOKEN}" \
     --header 'Content-Type: application/json' | jq -r ".[].hostname" | grep -q "${version}" && echo true || echo false
     )
     

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -26,11 +26,15 @@ set -x
 #
 #else
     #version=$(grep " Version.*" /root/ff1randomizer/FF1Lib/FFRVersion.cs | grep -Eo "[0-9\.]+" | tr '.' '-')
-    version="fake-version3"
+    version="fake-version6"
     siteExists=$(curl --location --request GET 'https://api.netlify.com/api/v1/dns_zones/finalfantasyrandomizer_com/dns_records' \
     --header "Authorization: Bearer ${NETLIFY_AUTH_TOKEN}" \
     --header 'Content-Type: application/json' | jq -r ".[].hostname" | grep -q "${version}" && echo true || echo false
     )
+    #siteExists=$(curl --location --request GET 'https://api.netlify.com/api/v1/dns_zones/stevenbir_com/dns_records' \
+    #--header "Authorization: Bearer ${NETLIFY_AUTH_TOKEN}" \
+    #--header 'Content-Type: application/json' | jq -r ".[].hostname" | grep -q "${version}" && echo true || echo false
+    #)
     
     
     if [ "${siteExists}" = true ]; then
@@ -38,16 +42,20 @@ set -x
     	exit 1
     fi
     
+    #createdSite=$(curl --location --request POST 'https://api.netlify.com/api/v1/sites' \
+    #--header "Authorization: Bearer ${NETLIFY_AUTH_TOKEN}" \
+    #--header 'Content-Type: application/json' \
+    #--data-raw "{\"custom_domain\": \"${version}.stevenbiro.com\", \"force_ssl\": \"true\"}")
     createdSite=$(curl --location --request POST 'https://api.netlify.com/api/v1/sites' \
     --header "Authorization: Bearer ${NETLIFY_AUTH_TOKEN}" \
     --header 'Content-Type: application/json' \
     --data-raw "{\"custom_domain\": \"${version}.finalfantasyrandomizer.com\", \"force_ssl\": \"true\"}")
     
     
-    errorsExist=$(echo "$createdSite" | jq ".errors!=null")
-    if [ "$errorsExist" ]; then
+    errors=$(echo "$createdSite" | jq ".errors")
+    if [ "$errors" -ne "null" ]; then
 	    echo "errors encountered while creating site:"
-	    echo "$createdSite" | jq -r ".errors"
+	    echo "$errors"
 	    exit 2
     fi
     

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -3,38 +3,33 @@ set -e
 set -x
 
 
-#config=$(jq -r ".branchConfig | map(select(if .branch == \"default\" then true elif .branch == \"${CIRCLE_BRANCH}\" then true else false end)) | .[0]" .circleci/configs/config.json)
-#netlifyID=$(echo "$config" | jq -r ".netlifyID")
-#deployPreview=$(echo "$config" | jq -r ".deployPreview")
+config=$(jq -r ".branchConfig | map(select(if .branch == \"default\" then true elif .branch == \"${CIRCLE_BRANCH}\" then true else false end)) | .[0]" .circleci/configs/config.json)
+netlifyID=$(echo "$config" | jq -r ".netlifyID")
+deployPreview=$(echo "$config" | jq -r ".deployPreview")
 
 
-#if "$deployPreview"; then
-#    deploy_response=$(netlify deploy --json --dir=/root/ff1randomizer/FF1Blazorizer/output/wwwroot --site="$netlifyID")
-#    url=$(echo "$deploy_response" | jq -r ".deploy_url")
-#
-#    GH_USER=FFR_Build_And_Deploy
-#    pr_response=$(curl --location --request GET "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls?head=$CIRCLE_PROJECT_USERNAME:$CIRCLE_BRANCH&state=open" -u $GH_USER:"$GH_API")
-#
-#    if [ "$(echo "$pr_response" | jq length)" -eq 0 ]; then
-#        echo "No PR found to update"
-#        exit 0
-#    else
-#        pr_comment_url=$(echo "$pr_response" | jq -r ".[]._links.comments.href")
-#    fi
-#    post_data='{"body": "Automatic deployment: '$url'"}'
-#    curl -X POST -H "Accept: application/vnd.github.v3+json" -H "Content-Type:application/json" "$pr_comment_url" -u $GH_USER:"$GH_API" -d "$post_data"
-#
-#else
-    #version=$(grep " Version.*" /root/ff1randomizer/FF1Lib/FFRVersion.cs | grep -Eo "[0-9\.]+" | tr '.' '-')
-    version="fake-version6"
+if "$deployPreview"; then
+    deploy_response=$(netlify deploy --json --dir=/root/ff1randomizer/FF1Blazorizer/output/wwwroot --site="$netlifyID")
+    url=$(echo "$deploy_response" | jq -r ".deploy_url")
+
+    GH_USER=FFR_Build_And_Deploy
+    pr_response=$(curl --location --request GET "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls?head=$CIRCLE_PROJECT_USERNAME:$CIRCLE_BRANCH&state=open" -u $GH_USER:"$GH_API")
+
+    if [ "$(echo "$pr_response" | jq length)" -eq 0 ]; then
+        echo "No PR found to update"
+        exit 0
+    else
+        pr_comment_url=$(echo "$pr_response" | jq -r ".[]._links.comments.href")
+    fi
+    post_data='{"body": "Automatic deployment: '$url'"}'
+    curl -X POST -H "Accept: application/vnd.github.v3+json" -H "Content-Type:application/json" "$pr_comment_url" -u $GH_USER:"$GH_API" -d "$post_data"
+
+else
+    version=$(grep " Version.*" /root/ff1randomizer/FF1Lib/FFRVersion.cs | grep -Eo "[0-9\.]+" | tr '.' '-')
     siteExists=$(curl --location --request GET 'https://api.netlify.com/api/v1/dns_zones/finalfantasyrandomizer_com/dns_records' \
     --header "Authorization: Bearer ${NETLIFY_AUTH_TOKEN}" \
     --header 'Content-Type: application/json' | jq -r ".[].hostname" | grep -q "${version}" && echo true || echo false
     )
-    #siteExists=$(curl --location --request GET 'https://api.netlify.com/api/v1/dns_zones/stevenbir_com/dns_records' \
-    #--header "Authorization: Bearer ${NETLIFY_AUTH_TOKEN}" \
-    #--header 'Content-Type: application/json' | jq -r ".[].hostname" | grep -q "${version}" && echo true || echo false
-    #)
     
     
     if [ "${siteExists}" = true ]; then
@@ -42,10 +37,6 @@ set -x
     	exit 1
     fi
     
-    #createdSite=$(curl --location --request POST 'https://api.netlify.com/api/v1/sites' \
-    #--header "Authorization: Bearer ${NETLIFY_AUTH_TOKEN}" \
-    #--header 'Content-Type: application/json' \
-    #--data-raw "{\"custom_domain\": \"${version}.stevenbiro.com\", \"force_ssl\": \"true\"}")
     createdSite=$(curl --location --request POST 'https://api.netlify.com/api/v1/sites' \
     --header "Authorization: Bearer ${NETLIFY_AUTH_TOKEN}" \
     --header 'Content-Type: application/json' \
@@ -63,6 +54,6 @@ set -x
     echo "$id"
     
     netlify deploy --dir=/root/ff1randomizer/FF1Blazorizer/output/wwwroot --prod --site="$id"
-    #netlify deploy --dir=/root/ff1randomizer/FF1Blazorizer/output/wwwroot --prod --site="$netlifyID"
+    netlify deploy --dir=/root/ff1randomizer/FF1Blazorizer/output/wwwroot --prod --site="$netlifyID"
 
-#fi
+fi

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -36,7 +36,7 @@ else
     fi
     
     createdSite=$(curl --location --request POST 'https://api.netlify.com/api/v1/sites' \
-    --header "Authorization: Bearer ${NETLIFY_TOKEN}" \
+    --header "Authorization: Bearer ${NETLIFY_AUTH_TOKEN}" \
     --header 'Content-Type: application/json' \
     --data-raw "{\"custom_domain\": \"${version}.finalfantasyrandomizer.com\", \"force_ssl\": \"true\"}")
     

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
-set -x
 set -e
+set -x
 
 
-config=$(jq -r ".branchConfig | map(select(if .branch == \"default\" then true elif .branch == \"${CIRCLE_BRANCH}\" then true else false end)) | .[0]" .circleci/configs/config.json)
-netlifyID=$(echo "$config" | jq -r ".netlifyID")
+#config=$(jq -r ".branchConfig | map(select(if .branch == \"default\" then true elif .branch == \"${CIRCLE_BRANCH}\" then true else false end)) | .[0]" .circleci/configs/config.json)
+#netlifyID=$(echo "$config" | jq -r ".netlifyID")
 #deployPreview=$(echo "$config" | jq -r ".deployPreview")
 
 
@@ -26,7 +26,7 @@ netlifyID=$(echo "$config" | jq -r ".netlifyID")
 #
 #else
     #version=$(grep " Version.*" /root/ff1randomizer/FF1Lib/FFRVersion.cs | grep -Eo "[0-9\.]+" | tr '.' '-')
-    version="fake-version2"
+    version="fake-version3"
     siteExists=$(curl --location --request GET 'https://api.netlify.com/api/v1/dns_zones/finalfantasyrandomizer_com/dns_records' \
     --header "Authorization: Bearer ${NETLIFY_AUTH_TOKEN}" \
     --header 'Content-Type: application/json' | jq -r ".[].hostname" | grep -q "${version}" && echo true || echo false
@@ -45,7 +45,7 @@ netlifyID=$(echo "$config" | jq -r ".netlifyID")
     
     
     errorsExist=$(echo "$createdSite" | jq ".errors!=null")
-    if [ -n "$errorsExist" ]; then
+    if [ "$errorsExist" ]; then
 	    echo "errors encountered while creating site:"
 	    echo "$createdSite" | jq -r ".errors"
 	    exit 2
@@ -55,6 +55,6 @@ netlifyID=$(echo "$config" | jq -r ".netlifyID")
     echo "$id"
     
     netlify deploy --dir=/root/ff1randomizer/FF1Blazorizer/output/wwwroot --prod --site="$id"
-    netlify deploy --dir=/root/ff1randomizer/FF1Blazorizer/output/wwwroot --prod --site="$netlifyID"
+    #netlify deploy --dir=/root/ff1randomizer/FF1Blazorizer/output/wwwroot --prod --site="$netlifyID"
 
 #fi

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
-set -o errexit
-set -x
+
 
 config=$(jq -r ".branchConfig | map(select(if .branch == \"default\" then true elif .branch == \"${CIRCLE_BRANCH}\" then true else false end)) | .[0]" .circleci/configs/config.json)
 netlifyID=$(echo "$config" | jq -r ".netlifyID")
 deployPreview=$(echo "$config" | jq -r ".deployPreview")
+
+
 if "$deployPreview"; then
     deploy_response=$(netlify deploy --json --dir=/root/ff1randomizer/FF1Blazorizer/output/wwwroot --site="$netlifyID")
     url=$(echo "$deploy_response" | jq -r ".deploy_url")
@@ -22,5 +23,34 @@ if "$deployPreview"; then
     curl -X POST -H "Accept: application/vnd.github.v3+json" -H "Content-Type:application/json" "$pr_comment_url" -u $GH_USER:"$GH_API" -d "$post_data"
 
 else
+    version=$(grep " Version.*" /root/ff1randomizer/FF1Lib/FFRVersion.cs | grep -Eo "[0-9\.]+")
+    siteExists=$(curl --location --request GET 'https://api.netlify.com/api/v1/dns_zones/finalfantasyrandomizer_com/dns_records' \
+    --header "Authorization: Bearer ${NETLIFY_TOKEN}" \
+    --header 'Content-Type: application/json' | jq -r ".[].hostname" | grep -q "${version}" && echo true || echo false
+    )
+    
+    
+    if [ "${siteExists}" = true ]; then
+    	echo "The version ${version} was found in the dns entries, make sure you increment the version in FF1Lib/FFRVersion.cs"
+    	exit 1
+    fi
+    
+    createdSite=$(curl --location --request POST 'https://api.netlify.com/api/v1/sites' \
+    --header "Authorization: Bearer ${NETLIFY_TOKEN}" \
+    --header 'Content-Type: application/json' \
+    --data-raw "{\"custom_domain\": \"${version}.finalfantasyrandomizer.com\", \"force_ssl\": \"true\"}")
+    
+    
+    errorsExist=$(echo "$deploy" | jq ".errors!=null")
+    if [ ! -z "$errorsExist" ]; then
+    	echo "errors encountered while creating site:"
+    	echo $(echo "$createdSite" | jq -r ".errors")
+    	exit 2
+    fi
+    
+    id=$(echo "$createdSite" | jq -r ".site_id")
+    
+    netlify deploy --dir=/root/ff1randomizer/FF1Blazorizer/output/wwwroot --prod --site="$id"
     netlify deploy --dir=/root/ff1randomizer/FF1Blazorizer/output/wwwroot --prod --site="$netlifyID"
+
 fi

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -3,27 +3,28 @@
 
 config=$(jq -r ".branchConfig | map(select(if .branch == \"default\" then true elif .branch == \"${CIRCLE_BRANCH}\" then true else false end)) | .[0]" .circleci/configs/config.json)
 netlifyID=$(echo "$config" | jq -r ".netlifyID")
-deployPreview=$(echo "$config" | jq -r ".deployPreview")
+#deployPreview=$(echo "$config" | jq -r ".deployPreview")
 
 
-if "$deployPreview"; then
-    deploy_response=$(netlify deploy --json --dir=/root/ff1randomizer/FF1Blazorizer/output/wwwroot --site="$netlifyID")
-    url=$(echo "$deploy_response" | jq -r ".deploy_url")
-
-    GH_USER=FFR_Build_And_Deploy
-    pr_response=$(curl --location --request GET "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls?head=$CIRCLE_PROJECT_USERNAME:$CIRCLE_BRANCH&state=open" -u $GH_USER:"$GH_API")
-
-    if [ "$(echo "$pr_response" | jq length)" -eq 0 ]; then
-        echo "No PR found to update"
-        exit 0
-    else
-        pr_comment_url=$(echo "$pr_response" | jq -r ".[]._links.comments.href")
-    fi
-    post_data='{"body": "Automatic deployment: '$url'"}'
-    curl -X POST -H "Accept: application/vnd.github.v3+json" -H "Content-Type:application/json" "$pr_comment_url" -u $GH_USER:"$GH_API" -d "$post_data"
-
-else
-    version=$(grep " Version.*" /root/ff1randomizer/FF1Lib/FFRVersion.cs | grep -Eo "[0-9\.]+" | tr '.' '-')
+#if "$deployPreview"; then
+#    deploy_response=$(netlify deploy --json --dir=/root/ff1randomizer/FF1Blazorizer/output/wwwroot --site="$netlifyID")
+#    url=$(echo "$deploy_response" | jq -r ".deploy_url")
+#
+#    GH_USER=FFR_Build_And_Deploy
+#    pr_response=$(curl --location --request GET "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls?head=$CIRCLE_PROJECT_USERNAME:$CIRCLE_BRANCH&state=open" -u $GH_USER:"$GH_API")
+#
+#    if [ "$(echo "$pr_response" | jq length)" -eq 0 ]; then
+#        echo "No PR found to update"
+#        exit 0
+#    else
+#        pr_comment_url=$(echo "$pr_response" | jq -r ".[]._links.comments.href")
+#    fi
+#    post_data='{"body": "Automatic deployment: '$url'"}'
+#    curl -X POST -H "Accept: application/vnd.github.v3+json" -H "Content-Type:application/json" "$pr_comment_url" -u $GH_USER:"$GH_API" -d "$post_data"
+#
+#else
+    #version=$(grep " Version.*" /root/ff1randomizer/FF1Lib/FFRVersion.cs | grep -Eo "[0-9\.]+" | tr '.' '-')
+    version="fake-version"
     siteExists=$(curl --location --request GET 'https://api.netlify.com/api/v1/dns_zones/finalfantasyrandomizer_com/dns_records' \
     --header "Authorization: Bearer ${NETLIFY_TOKEN}" \
     --header 'Content-Type: application/json' | jq -r ".[].hostname" | grep -q "${version}" && echo true || echo false
@@ -49,8 +50,9 @@ else
     fi
     
     id=$(echo "$createdSite" | jq -r ".site_id")
+    echo "$id"
     
     netlify deploy --dir=/root/ff1randomizer/FF1Blazorizer/output/wwwroot --prod --site="$id"
     netlify deploy --dir=/root/ff1randomizer/FF1Blazorizer/output/wwwroot --prod --site="$netlifyID"
 
-fi
+#fi

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -23,7 +23,7 @@ if "$deployPreview"; then
     curl -X POST -H "Accept: application/vnd.github.v3+json" -H "Content-Type:application/json" "$pr_comment_url" -u $GH_USER:"$GH_API" -d "$post_data"
 
 else
-    version=$(grep " Version.*" /root/ff1randomizer/FF1Lib/FFRVersion.cs | grep -Eo "[0-9\.]+")
+    version=$(grep " Version.*" /root/ff1randomizer/FF1Lib/FFRVersion.cs | grep -Eo "[0-9\.]+" | tr '.' '-')
     siteExists=$(curl --location --request GET 'https://api.netlify.com/api/v1/dns_zones/finalfantasyrandomizer_com/dns_records' \
     --header "Authorization: Bearer ${NETLIFY_TOKEN}" \
     --header 'Content-Type: application/json' | jq -r ".[].hostname" | grep -q "${version}" && echo true || echo false

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -x
+set -e
 
 
 config=$(jq -r ".branchConfig | map(select(if .branch == \"default\" then true elif .branch == \"${CIRCLE_BRANCH}\" then true else false end)) | .[0]" .circleci/configs/config.json)


### PR DESCRIPTION
This is up for feedback right now only, and to see what netlify does with this as a PR, it should just deploy the standard thing with nothing changing.

The intent of this change is to create new sites each time we deploy the main site.

So when www.finalfantasyrandomizer.com updates to version 5.23.1, we create 5-23-1.finalfantasyrandomizer.com and deploy the exact same build there. A possible additional change that I am thinking about including is the flag decoding, it should check the version only for the versioned and live site, but the sha for alpha and beta sites. This would allow for minor updates that do not affect flags or rng to each version after it is deployed.

