### PR TITLE
Separate Gold Scaling

### DIFF
--- a/FF1Blazorizer/Tabs/ScaleTab.razor
+++ b/FF1Blazorizer/Tabs/ScaleTab.razor
@@ -6,65 +6,66 @@
 		<h3 class="@(IsOpen ? "" : "h3-collapsed")"><a class="@(noTabLayout ? "collapsible-header" : "")" @onclick="(() => IsOpen = (!noTabLayout || !IsOpen))">Scale</a></h3>
 		@if (IsOpen)
 		{ 
-		<div class="col1 full">
-			<DoubleSlider ShowMedian DoubleCol Id="clampMinimumPriceScaleLable" UpdateToolTip="@UpdateToolTipID" MinValue="20" MaxValue="500" @bind-ValueHigh="Flags.PriceScaleFactorHigh" @bind-ValueLow="Flags.PriceScaleFactorLow">Prices:</DoubleSlider>
-			<div class="row-seperator"></div>
-			<DoubleSlider ShowMedian DoubleCol Id="enemyStatsDoubleSlider" MinValue="20" MaxValue="500" @bind-ValueHigh="Flags.EnemyScaleStatsHigh" @bind-ValueLow="Flags.EnemyScaleStatsLow" DisableTooltip>Enemy Stats:</DoubleSlider>
-			<DoubleSlider ShowMedian DoubleCol Id="enemyHpDoubleSlider" Indent IsEnabled="Flags.SeparateEnemyHPScaling" MinValue="20" MaxValue="500" @bind-ValueHigh="Flags.EnemyScaleHpHigh" @bind-ValueLow="Flags.EnemyScaleHpLow" DisableTooltip>
-				<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="separateEnemyHPScalingCheckBox" @bind-Value="Flags.SeparateEnemyHPScaling">Separate HP Scaling:</TriStateCheckBox>
-			</DoubleSlider>
-			<div class="row-seperator"></div>
-			<DoubleSlider ShowMedian DoubleCol Id="bossStatsDoubleSlider" MinValue="20" MaxValue="500" @bind-ValueHigh="Flags.BossScaleStatsHigh" @bind-ValueLow="Flags.BossScaleStatsLow" DisableTooltip>Boss Stats:</DoubleSlider>
-			<DoubleSlider ShowMedian DoubleCol Id="bossHpDoubleSlider" Indent IsEnabled="Flags.SeparateBossHPScaling" MinValue="20" MaxValue="500" @bind-ValueHigh="Flags.BossScaleHpHigh" @bind-ValueLow="Flags.BossScaleHpLow" DisableTooltip>
-				<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="separateBossHPScalingCheckBox" @bind-Value="Flags.SeparateBossHPScaling">Separate HP Scaling:</TriStateCheckBox>
-			</DoubleSlider>
-			<div class="row-seperator"></div>
-			<EnumDropDown UpdateToolTip="@UpdateToolTipID" Id="evadeCapDropDown" TItem="EvadeCapValues" @bind-Value="Flags.EvadeCap">Evade Cap Value:</EnumDropDown>
-			<div class="row-seperator"></div>
-			<div class="row">
-				<div class="col-lg-4 noleftpadding">Exp. &amp; Gold Boost:</div>
-				<div class="col-lg-4">@Math.Round(Flags.ExpMultiplier, 1).ToString("F1")x + @Flags.ExpBonus</div>
-				<div class="col-slider">
-					<Slider @bind-Value="Flags.ExpMultiplier" Min="1" Max="5" Step="0.1"></Slider>
-					<Slider @bind-Value="Flags.ExpBonus" Min="0" Max="500" Step="10"></Slider>
-				</div>
+	<div class="col1 full">
+		<DoubleSlider ShowMedian DoubleCol Id="clampMinimumPriceScaleLable" UpdateToolTip="@UpdateToolTipID" MinValue="20" MaxValue="500" @bind-ValueHigh="Flags.PriceScaleFactorHigh" @bind-ValueLow="Flags.PriceScaleFactorLow">Prices:</DoubleSlider>
+		<div class="row-seperator"></div>
+		<DoubleSlider ShowMedian DoubleCol Id="enemyStatsDoubleSlider" MinValue="20" MaxValue="500" @bind-ValueHigh="Flags.EnemyScaleStatsHigh" @bind-ValueLow="Flags.EnemyScaleStatsLow" DisableTooltip>Enemy Stats:</DoubleSlider>
+		<DoubleSlider ShowMedian DoubleCol Id="enemyHpDoubleSlider" Indent IsEnabled="Flags.SeparateEnemyHPScaling" MinValue="20" MaxValue="500" @bind-ValueHigh="Flags.EnemyScaleHpHigh" @bind-ValueLow="Flags.EnemyScaleHpLow" DisableTooltip>
+			<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="separateEnemyHPScalingCheckBox" @bind-Value="Flags.SeparateEnemyHPScaling">Separate HP Scaling:</TriStateCheckBox>
+		</DoubleSlider>
+		<div class="row-seperator"></div>
+		<DoubleSlider ShowMedian DoubleCol Id="bossStatsDoubleSlider" MinValue="20" MaxValue="500" @bind-ValueHigh="Flags.BossScaleStatsHigh" @bind-ValueLow="Flags.BossScaleStatsLow" DisableTooltip>Boss Stats:</DoubleSlider>
+		<DoubleSlider ShowMedian DoubleCol Id="bossHpDoubleSlider" Indent IsEnabled="Flags.SeparateBossHPScaling" MinValue="20" MaxValue="500" @bind-ValueHigh="Flags.BossScaleHpHigh" @bind-ValueLow="Flags.BossScaleHpLow" DisableTooltip>
+			<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="separateBossHPScalingCheckBox" @bind-Value="Flags.SeparateBossHPScaling">Separate HP Scaling:</TriStateCheckBox>
+		</DoubleSlider>
+		<div class="row-seperator"></div>
+		<EnumDropDown UpdateToolTip="@UpdateToolTipID" Id="evadeCapDropDown" TItem="EvadeCapValues" @bind-Value="Flags.EvadeCap">Evade Cap Value:</EnumDropDown>
+		<div class="row-seperator"></div>
+		<div class="row">
+			<div class="col-lg-4 noleftpadding">Exp. &amp; Gold Boost:</div>
+			<div class="col-lg-4">@Math.Round(Flags.ExpMultiplier, 1).ToString("F1")x + @Flags.ExpBonus</div>
+			<div class="col-slider">
+				<Slider @bind-Value="Flags.ExpMultiplier" Min="1" Max="5" Step="0.1"></Slider>
+				<Slider @bind-Value="Flags.ExpBonus" Min="0" Max="500" Step="10"></Slider>
 			</div>
-			<div class="row-seperator"></div>
-			<EnumDropDown UpdateToolTip="@UpdateToolTipID" Id="progressiveScaleModeDropDown" TItem="ProgressiveScaleMode" @bind-Value="Flags.ProgressiveScaleMode">Exp. &amp; Gold Progressive Scaling:</EnumDropDown>
-			<div class="row-seperator"></div>
-			<div class="row">
-				<div class="col-lg-4 noleftpadding">Overworld Encounter Rate:</div>
-				<div class="col-lg-4">@Math.Round(Flags.EncounterRate / 30.0, 2).ToString("F2")x</div>
-				<div class="col-slider">
-					<Slider @bind-Value="Flags.EncounterRate" Min="0" Max="45" Step="1"></Slider>
-				</div>
-			</div>
-			<div class="row-seperator"></div>
-			<div class="row">
-				<div class="col-lg-4 noleftpadding">Dungeon Encounter Rate:</div>
-				<div class="col-lg-4">@Math.Round(Flags.DungeonEncounterRate / 30.0, 2).ToString("F2")x</div>
-				<div class="col-slider">
-					<Slider @bind-Value="Flags.DungeonEncounterRate" Min="0" Max="45" Step="1"></Slider>
-				</div>
-			</div>
-			<div class="row-seperator"></div>
-			<DoubleSlider DisableTooltip DoubleCol Id="RandomWeaponBonusSlider" IsEnabled="Flags.RandomWeaponBonus" MinValue="-9" MaxValue="9" Step="1" @bind-ValueHigh="Flags.RandomWeaponBonusHigh" @bind-ValueLow="Flags.RandomWeaponBonusLow">
-				<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="RandomWeaponBonus" @bind-Value="Flags.RandomWeaponBonus">Blursed Weapons:</TriStateCheckBox>
-			</DoubleSlider>
-			<TriStateCheckBox Indent UpdateToolTip="@UpdateToolTipID"  IsEnabled="Flags.RandomWeaponBonus" Id="RandomWeaponBonusExcludeMasa" @bind-Value="Flags.RandomWeaponBonusExcludeMasa">Exclude Masmune</TriStateCheckBox>
-			<div class="row-seperator"></div>
-			<DoubleSlider DisableTooltip DoubleCol Id="RandomArmorBonusSlider" IsEnabled="Flags.RandomArmorBonus" MinValue="-9" MaxValue="9" Step="1" @bind-ValueHigh="Flags.RandomArmorBonusHigh" @bind-ValueLow="Flags.RandomArmorBonusLow">
-				<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="RandomArmorBonus" @bind-Value="Flags.RandomArmorBonus">Blursed Armor:</TriStateCheckBox>
-			</DoubleSlider>
-			<div class="row-seperator"></div>
-			<CheckBox UpdateToolTip="@UpdateToolTipID" Id="wrapPriceOverflowCheckBox" @bind-Value="Flags.WrapPriceOverflow">Wrap Overflowing Prices</CheckBox>
-			<CheckBox UpdateToolTip="@UpdateToolTipID" Id="wrapStatOverflowCheckBox" @bind-Value="Flags.WrapStatOverflow">Wrap Overflowing Scaled Stats</CheckBox>
-			<CheckBox UpdateToolTip="@UpdateToolTipID" Id="includeMoraleCheckBox" @bind-Value="Flags.IncludeMorale">Scaled Stats Includes Morale</CheckBox>
-			<CheckBox UpdateToolTip="@UpdateToolTipID" Id="noDanModeCheckBox" @bind-Value="Flags.NoDanMode">Static EXP Distribution</CheckBox>
-			<CheckBox UpdateToolTip="@UpdateToolTipID" Id="startingGoldCheckBox" @bind-Value="Flags.StartingGold">Scale Starting Gold</CheckBox>
-			<CheckBox UpdateToolTip="@UpdateToolTipID" Id="easyModeCheckBox" @bind-Value="Flags.EasyMode">Easy Mode</CheckBox>			
-			<div class="clear-it"></div>
 		</div>
+		<div class="row-seperator"></div>
+		<EnumDropDown UpdateToolTip="@UpdateToolTipID" Id="progressiveScaleModeDropDown" TItem="ProgressiveScaleMode" @bind-Value="Flags.ProgressiveScaleMode">Exp. &amp; Gold Progressive Scaling:</EnumDropDown>
+		<div class="row-seperator"></div>
+		<div class="row">
+			<div class="col-lg-4 noleftpadding">Overworld Encounter Rate:</div>
+			<div class="col-lg-4">@Math.Round(Flags.EncounterRate / 30.0, 2).ToString("F2")x</div>
+			<div class="col-slider">
+				<Slider @bind-Value="Flags.EncounterRate" Min="0" Max="45" Step="1"></Slider>
+			</div>
+		</div>
+		<div class="row-seperator"></div>
+		<div class="row">
+			<div class="col-lg-4 noleftpadding">Dungeon Encounter Rate:</div>
+			<div class="col-lg-4">@Math.Round(Flags.DungeonEncounterRate / 30.0, 2).ToString("F2")x</div>
+			<div class="col-slider">
+				<Slider @bind-Value="Flags.DungeonEncounterRate" Min="0" Max="45" Step="1"></Slider>
+			</div>
+		</div>
+		<div class="row-seperator"></div>
+		<DoubleSlider DisableTooltip DoubleCol Id="RandomWeaponBonusSlider" IsEnabled="Flags.RandomWeaponBonus" MinValue="-9" MaxValue="9" Step="1" @bind-ValueHigh="Flags.RandomWeaponBonusHigh" @bind-ValueLow="Flags.RandomWeaponBonusLow">
+			<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="RandomWeaponBonus" @bind-Value="Flags.RandomWeaponBonus">Blursed Weapons:</TriStateCheckBox>
+		</DoubleSlider>
+		<TriStateCheckBox Indent UpdateToolTip="@UpdateToolTipID" IsEnabled="Flags.RandomWeaponBonus" Id="RandomWeaponBonusExcludeMasa" @bind-Value="Flags.RandomWeaponBonusExcludeMasa">Exclude Masmune</TriStateCheckBox>
+		<div class="row-seperator"></div>
+		<DoubleSlider DisableTooltip DoubleCol Id="RandomArmorBonusSlider" IsEnabled="Flags.RandomArmorBonus" MinValue="-9" MaxValue="9" Step="1" @bind-ValueHigh="Flags.RandomArmorBonusHigh" @bind-ValueLow="Flags.RandomArmorBonusLow">
+			<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="RandomArmorBonus" @bind-Value="Flags.RandomArmorBonus">Blursed Armor:</TriStateCheckBox>
+		</DoubleSlider>
+		<div class="row-seperator"></div>
+		<CheckBox UpdateToolTip="@UpdateToolTipID" Id="wrapPriceOverflowCheckBox" @bind-Value="Flags.WrapPriceOverflow">Wrap Overflowing Prices</CheckBox>
+		<CheckBox UpdateToolTip="@UpdateToolTipID" Id="wrapStatOverflowCheckBox" @bind-Value="Flags.WrapStatOverflow">Wrap Overflowing Scaled Stats</CheckBox>
+		<CheckBox UpdateToolTip="@UpdateToolTipID" Id="includeMoraleCheckBox" @bind-Value="Flags.IncludeMorale">Scaled Stats Includes Morale</CheckBox>
+		<CheckBox UpdateToolTip="@UpdateToolTipID" Id="noDanModeCheckBox" @bind-Value="Flags.NoDanMode">Static EXP Distribution</CheckBox>
+		<CheckBox UpdateToolTip="@UpdateToolTipID" Id="startingGoldCheckBox" @bind-Value="Flags.StartingGold">Scale Starting Gold</CheckBox>
+		<CheckBox UpdateToolTip="@UpdateToolTipID" Id="easyModeCheckBox" @bind-Value="Flags.EasyMode">Easy Mode</CheckBox>
+		<CheckBox UpdateToolTip="@UpdateToolTipID" Id="excludeGoldFromScalingCheckBox" @bind-Value="Flags.ExcludeGoldFromScaling">Exclude Gold Treasure from scaling</CheckBox>
+		<div class="clear-it"></div>
+	</div>
 		}
 	</div>
 

--- a/FF1Blazorizer/Tabs/ScaleTab.razor
+++ b/FF1Blazorizer/Tabs/ScaleTab.razor
@@ -8,6 +8,11 @@
 		{ 
 	<div class="col1 full">
 		<DoubleSlider ShowMedian DoubleCol Id="clampMinimumPriceScaleLable" UpdateToolTip="@UpdateToolTipID" MinValue="20" MaxValue="500" @bind-ValueHigh="Flags.PriceScaleFactorHigh" @bind-ValueLow="Flags.PriceScaleFactorLow">Prices:</DoubleSlider>
+
+		<DoubleSlider ShowMedian DoubleCol Id="separategoldScalingDoubleSlider" Indent IsEnabled="Flags.SeparateBossHPScaling" MinValue="10" MaxValue="500" @bind-ValueHigh="Flags.SeparateGoldScalingFactorMax" @bind-ValueLow="Flags.SeparateGoldScalingFactorMin" DisableTooltip>
+			<CheckBox UpdateToolTip="@UpdateToolTipID" Id="separateGoldScalingCheckBox" @bind-Value="Flags.SeparateGoldScaling">Separate Gold Scaling:</CheckBox>
+		</DoubleSlider>
+
 		<div class="row-seperator"></div>
 		<DoubleSlider ShowMedian DoubleCol Id="enemyStatsDoubleSlider" MinValue="20" MaxValue="500" @bind-ValueHigh="Flags.EnemyScaleStatsHigh" @bind-ValueLow="Flags.EnemyScaleStatsLow" DisableTooltip>Enemy Stats:</DoubleSlider>
 		<DoubleSlider ShowMedian DoubleCol Id="enemyHpDoubleSlider" Indent IsEnabled="Flags.SeparateEnemyHPScaling" MinValue="20" MaxValue="500" @bind-ValueHigh="Flags.EnemyScaleHpHigh" @bind-ValueLow="Flags.EnemyScaleHpLow" DisableTooltip>
@@ -63,7 +68,6 @@
 		<CheckBox UpdateToolTip="@UpdateToolTipID" Id="noDanModeCheckBox" @bind-Value="Flags.NoDanMode">Static EXP Distribution</CheckBox>
 		<CheckBox UpdateToolTip="@UpdateToolTipID" Id="startingGoldCheckBox" @bind-Value="Flags.StartingGold">Scale Starting Gold</CheckBox>
 		<CheckBox UpdateToolTip="@UpdateToolTipID" Id="easyModeCheckBox" @bind-Value="Flags.EasyMode">Easy Mode</CheckBox>
-		<CheckBox UpdateToolTip="@UpdateToolTipID" Id="excludeGoldFromScalingCheckBox" @bind-Value="Flags.ExcludeGoldFromScaling">Exclude Gold Treasure from scaling</CheckBox>
 		<div class="clear-it"></div>
 	</div>
 		}

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -742,9 +742,10 @@ namespace FF1Lib
 
 				NPCHints(rng, npcdata, flags, overworldMap);
 			}
-			
-			ExpGoldBoost(flags.ExpBonus, flags.ExpMultiplier);
-			ScalePrices(flags, itemText, rng, ((bool)flags.ClampMinimumPriceScale), shopItemLocation);
+
+			double separateGoldScalingFactor = rng.Between(flags.SeparateGoldScalingFactorMin, flags.SeparateGoldScalingFactorMax) / 100.0;			
+			ExpGoldBoost(flags.ExpBonus, flags.ExpMultiplier, flags.SeparateGoldScaling, separateGoldScalingFactor, rng);
+			ScalePrices(flags, itemText, rng, ((bool)flags.ClampMinimumPriceScale), shopItemLocation, flags.SeparateGoldScaling, separateGoldScalingFactor);
 			ScaleEncounterRate(flags.EncounterRate / 30.0, flags.DungeonEncounterRate / 30.0);
 
 			overworldMap.ApplyMapEdits();

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -65,7 +65,7 @@ namespace FF1Lib
 
 		#endregion
 
-		public bool ExcludeGoldFromScaling { get; set; } = true;
+		public bool ExcludeGoldFromScaling { get; set; } = false;
 		public bool Spoilers { get; set; } = false;
 		public bool TournamentSafe { get; set; } = false;
 		public bool BlindSeed { get; set; } = false;

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -63,8 +63,9 @@ namespace FF1Lib
 
 		public HintPlacementStrategy ExtensiveHints_EquipmentNamePlacement { get; set; } = HintPlacementStrategy.ConeriaToCrescent;
 
-    #endregion
-		
+		#endregion
+
+		public bool ExcludeGoldFromScaling { get; set; } = true;
 		public bool Spoilers { get; set; } = false;
 		public bool TournamentSafe { get; set; } = false;
 		public bool BlindSeed { get; set; } = false;

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -68,10 +68,10 @@ namespace FF1Lib
 		public bool SeparateGoldScaling { get; set; } = false;
 
 		[IntegerFlag(10, 500, 10)]
-		public int SeparateGoldScalingFactorMin { get; set; } = 10;
+		public int SeparateGoldScalingFactorMin { get; set; } = 50;
 
 		[IntegerFlag(10, 500, 10)]
-		public int SeparateGoldScalingFactorMax { get; set; } = 500;
+		public int SeparateGoldScalingFactorMax { get; set; } = 200;
 
 		public bool Spoilers { get; set; } = false;
 		public bool TournamentSafe { get; set; } = false;

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -65,7 +65,14 @@ namespace FF1Lib
 
 		#endregion
 
-		public bool ExcludeGoldFromScaling { get; set; } = false;
+		public bool SeparateGoldScaling { get; set; } = false;
+
+		[IntegerFlag(10, 500, 10)]
+		public int SeparateGoldScalingFactorMin { get; set; } = 50;
+
+		[IntegerFlag(10, 500, 10)]
+		public int SeparateGoldScalingFactorMax { get; set; } = 200;
+
 		public bool Spoilers { get; set; } = false;
 		public bool TournamentSafe { get; set; } = false;
 		public bool BlindSeed { get; set; } = false;

--- a/FF1Lib/FlagsViewModel.cs
+++ b/FF1Lib/FlagsViewModel.cs
@@ -3760,12 +3760,32 @@ namespace FF1Lib
 			}
 		}
 
-		public bool ExcludeGoldFromScaling
+		public bool SeparateGoldScaling
 		{
-			get => Flags.ExcludeGoldFromScaling;
+			get => Flags.SeparateGoldScaling;
 			set
 			{
-				Flags.ExcludeGoldFromScaling = value;
+				Flags.SeparateGoldScaling = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		public int SeparateGoldScalingFactorMin
+		{
+			get => Flags.SeparateGoldScalingFactorMin;
+			set
+			{
+				Flags.SeparateGoldScalingFactorMin = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		public int SeparateGoldScalingFactorMax
+		{
+			get => Flags.SeparateGoldScalingFactorMax;
+			set
+			{
+				Flags.SeparateGoldScalingFactorMax = value;
 				RaisePropertyChanged();
 			}
 		}

--- a/FF1Lib/FlagsViewModel.cs
+++ b/FF1Lib/FlagsViewModel.cs
@@ -3759,6 +3759,16 @@ namespace FF1Lib
 				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Etherizer"));
 			}
 		}
+
+		public bool ExcludeGoldFromScaling
+		{
+			get => Flags.ExcludeGoldFromScaling;
+			set
+			{
+				Flags.ExcludeGoldFromScaling = value;
+				RaisePropertyChanged();
+			}
+		}
 	}
 }
 

--- a/FF1Lib/Interfaces.cs
+++ b/FF1Lib/Interfaces.cs
@@ -110,6 +110,7 @@
 		double ExpMultiplier { get; }
 		int PriceScaleFactorLow { get; }
 		int PriceScaleFactorHigh { get; }
+		bool ExcludeGoldFromScaling { get; }
 	}
 	public interface IFloorShuffleFlags
 	{

--- a/FF1Lib/Interfaces.cs
+++ b/FF1Lib/Interfaces.cs
@@ -110,7 +110,6 @@
 		double ExpMultiplier { get; }
 		int PriceScaleFactorLow { get; }
 		int PriceScaleFactorHigh { get; }
-		bool ExcludeGoldFromScaling { get; }
 	}
 	public interface IFloorShuffleFlags
 	{

--- a/FF1Lib/Scale.cs
+++ b/FF1Lib/Scale.cs
@@ -87,7 +87,7 @@ namespace FF1Lib
 			var prices = Get(PriceOffset, PriceSize * PriceCount).ToUShorts();
 			for (int i = 0; i < prices.Length; i++)
 			{
-				if (flags.ExcludeGoldFromScaling)
+				if (flags.ExcludeGoldFromScaling && ItemLists.AllGoldTreasure.Contains((Item)i))
 				{
 					var price = (int)prices[i];
 					var newPrice = price + rng.Between(-price / 10, price / 10);

--- a/FF1Lib/Scale.cs
+++ b/FF1Lib/Scale.cs
@@ -87,8 +87,17 @@ namespace FF1Lib
 			var prices = Get(PriceOffset, PriceSize * PriceCount).ToUShorts();
 			for (int i = 0; i < prices.Length; i++)
 			{
-				var newPrice = RangeScale(prices[i] / multiplier, scaleLow, scaleHigh, 1, rng);
-				prices[i] = (ushort)(flags.WrapPriceOverflow ? ((newPrice - 1) % 0xFFFF) + 1 : Min(newPrice, 0xFFFF));
+				if (flags.ExcludeGoldFromScaling)
+				{
+					var price = (int)prices[i];
+					var newPrice = price + rng.Between(-price / 10, price / 10);
+					prices[i] = (ushort)Math.Min(Math.Max(newPrice, 1), 65535);
+				}
+				else
+				{
+					var newPrice = RangeScale(prices[i] / multiplier, scaleLow, scaleHigh, 1, rng);
+					prices[i] = (ushort)(flags.WrapPriceOverflow ? ((newPrice - 1) % 0xFFFF) + 1 : Min(newPrice, 0xFFFF));
+				}
 			}
 			var questItemPrice = prices[(int)Item.Bottle];
 			// If we don't do this before checking for the item shop location factor, Ribbons and Shirts will end up being really cheap


### PR DESCRIPTION
The new flag allows a separate scaling for all Gold Rewards(treasure and enemy drops).

If enabled it rolls a global factor between the selected min and max. This factor is applied to all gold rewards. Then it applies +-10% random value to each of them.

EXP/Gold Boost is ignored. Progressive Scaling will still be applied.