### PR TITLE
ChanceToRun

### DIFF
--- a/FF1Blazorizer/Tabs/BugFixesTab.razor
+++ b/FF1Blazorizer/Tabs/BugFixesTab.razor
@@ -6,19 +6,19 @@
 
 	@if (IsOpen)
 	{
-		<div class="col1">
-			<h4>Bugs</h4>
-			<CheckBox UpdateToolTip="@UpdateToolTipID" Id="houseMPRestorationCheckBox" @bind-Value="Flags.HouseMPRestoration">House MP Restoration</CheckBox>
-			<CheckBox UpdateToolTip="@UpdateToolTipID" Id="weaponStatsCheckBox" @bind-Value="Flags.WeaponStats">Weapon Stats</CheckBox>
-			<CheckBox UpdateToolTip="@UpdateToolTipID" Id="chanceToRunCheckBox" @bind-Value="Flags.ChanceToRun">Chance to Run</CheckBox>
-			<CheckBox UpdateToolTip="@UpdateToolTipID" Id="spellBugsCheckBox" @bind-Value="Flags.SpellBugs">Spell Fixes</CheckBox>
-			<CheckBox UpdateToolTip="@UpdateToolTipID" Id="enemyStatusAttackBugCheckBox" @bind-Value="Flags.EnemyStatusAttackBug">Enemy Status Attacks</CheckBox>
-			<CheckBox UpdateToolTip="@UpdateToolTipID" Id="blackBeltAbsorbCheckBox" @bind-Value="Flags.BlackBeltAbsorb">Bl. Belt & Master Absorb Calculation</CheckBox>
-			<CheckBox UpdateToolTip="@UpdateToolTipID" Id="enemyElementalResistancesCheckBox" @bind-Value="Flags.EnemyElementalResistancesBug">Enemy Elemental Resistances</CheckBox>
-			<CheckBox UpdateToolTip="@UpdateToolTipID" Id="enemySpellsTargetingAlliesCheckBox" @bind-Value="Flags.EnemySpellsTargetingAllies">Enemy Spells Targeting Allies</CheckBox>
-			<CheckBox UpdateToolTip="@UpdateToolTipID" Id="improveTurnOrderRandomizationCheckBox" @bind-Value="Flags.ImproveTurnOrderRandomization">Improve Turn Order Randomization</CheckBox>
-			<div class="checkbox-cell"></div>
-		</div>
+<div class="col1">
+	<h4>Bugs</h4>
+	<CheckBox UpdateToolTip="@UpdateToolTipID" Id="houseMPRestorationCheckBox" @bind-Value="Flags.HouseMPRestoration">House MP Restoration</CheckBox>
+	<CheckBox UpdateToolTip="@UpdateToolTipID" Id="weaponStatsCheckBox" @bind-Value="Flags.WeaponStats">Weapon Stats</CheckBox>
+	<EnumDropDown UpdateToolTip="@UpdateToolTipID" Id="chanceToRunCheckBox" TItem="ChanceToRunMode" @bind-Value="Flags.ChanceToRun">Chance to Run:</EnumDropDown>
+	<CheckBox UpdateToolTip="@UpdateToolTipID" Id="spellBugsCheckBox" @bind-Value="Flags.SpellBugs">Spell Fixes</CheckBox>
+	<CheckBox UpdateToolTip="@UpdateToolTipID" Id="enemyStatusAttackBugCheckBox" @bind-Value="Flags.EnemyStatusAttackBug">Enemy Status Attacks</CheckBox>
+	<CheckBox UpdateToolTip="@UpdateToolTipID" Id="blackBeltAbsorbCheckBox" @bind-Value="Flags.BlackBeltAbsorb">Bl. Belt & Master Absorb Calculation</CheckBox>
+	<CheckBox UpdateToolTip="@UpdateToolTipID" Id="enemyElementalResistancesCheckBox" @bind-Value="Flags.EnemyElementalResistancesBug">Enemy Elemental Resistances</CheckBox>
+	<CheckBox UpdateToolTip="@UpdateToolTipID" Id="enemySpellsTargetingAlliesCheckBox" @bind-Value="Flags.EnemySpellsTargetingAllies">Enemy Spells Targeting Allies</CheckBox>
+	<CheckBox UpdateToolTip="@UpdateToolTipID" Id="improveTurnOrderRandomizationCheckBox" @bind-Value="Flags.ImproveTurnOrderRandomization">Improve Turn Order Randomization</CheckBox>
+	<div class="checkbox-cell"></div>
+</div>
 		<div class="col2">
 			<h4>Balance</h4>
 			<CheckBox UpdateToolTip="@UpdateToolTipID" Id="doubleBBCritCheckBox" @bind-Value="Flags.BBCritRate">Halve BB Crit Rate</CheckBox>

--- a/FF1Blazorizer/wwwroot/presets/Anti_Double_Bingo.json
+++ b/FF1Blazorizer/wwwroot/presets/Anti_Double_Bingo.json
@@ -125,7 +125,7 @@
     "BBCritRate": false,
     "WeaponCritRate": true,
     "WeaponBonuses": true,
-    "ChanceToRun": true,
+    "ChanceToRun": 1,
     "SpellBugs": true,
     "BlackBeltAbsorb": true,
     "NPCSwatter": true,

--- a/FF1Blazorizer/wwwroot/presets/Beginner.json
+++ b/FF1Blazorizer/wwwroot/presets/Beginner.json
@@ -129,7 +129,7 @@
     "WeaponCritRate": true,
     "WeaponBonuses": true,
     "WeaponTypeBonusValue": 10,
-    "ChanceToRun": true,
+    "ChanceToRun": 1,
     "SpellBugs": true,
     "BlackBeltAbsorb": true,
     "NPCSwatter": true,

--- a/FF1Blazorizer/wwwroot/presets/Chaos_Rampage.json
+++ b/FF1Blazorizer/wwwroot/presets/Chaos_Rampage.json
@@ -125,7 +125,7 @@
     "BBCritRate": true,
     "WeaponCritRate": true,
     "WeaponBonuses": true,
-    "ChanceToRun": true,
+    "ChanceToRun": 1,
     "SpellBugs": true,
     "BlackBeltAbsorb": true,
     "NPCSwatter": true,

--- a/FF1Blazorizer/wwwroot/presets/Chaos_Rush.json
+++ b/FF1Blazorizer/wwwroot/presets/Chaos_Rush.json
@@ -129,7 +129,7 @@
     "WeaponCritRate": true,
     "WeaponBonuses": true,
     "WeaponTypeBonusValue": 10,
-    "ChanceToRun": true,
+    "ChanceToRun": 1,
     "SpellBugs": true,
     "BlackBeltAbsorb": true,
     "NPCSwatter": true,

--- a/FF1Blazorizer/wwwroot/presets/Entrance_Floor_Shuffle.json
+++ b/FF1Blazorizer/wwwroot/presets/Entrance_Floor_Shuffle.json
@@ -129,7 +129,7 @@
     "WeaponCritRate": true,
     "WeaponBonuses": true,
     "WeaponTypeBonusValue": 10,
-    "ChanceToRun": true,
+    "ChanceToRun": 1,
     "SpellBugs": true,
     "BlackBeltAbsorb": true,
     "NPCSwatter": true,

--- a/FF1Blazorizer/wwwroot/presets/Improved_Vanilla.json
+++ b/FF1Blazorizer/wwwroot/presets/Improved_Vanilla.json
@@ -129,7 +129,7 @@
     "WeaponCritRate": true,
     "WeaponBonuses": true,
     "WeaponTypeBonusValue": 10,
-    "ChanceToRun": true,
+    "ChanceToRun": 1,
     "SpellBugs": true,
     "BlackBeltAbsorb": true,
     "NPCSwatter": false,

--- a/FF1Blazorizer/wwwroot/presets/Shard_Hunt.json
+++ b/FF1Blazorizer/wwwroot/presets/Shard_Hunt.json
@@ -129,7 +129,7 @@
     "WeaponCritRate": true,
     "WeaponBonuses": true,
     "WeaponTypeBonusValue": 10,
-    "ChanceToRun": true,
+    "ChanceToRun": 1,
     "SpellBugs": true,
     "BlackBeltAbsorb": true,
     "NPCSwatter": true,

--- a/FF1Blazorizer/wwwroot/presets/default.json
+++ b/FF1Blazorizer/wwwroot/presets/default.json
@@ -129,7 +129,7 @@
     "WeaponCritRate": true,
     "WeaponBonuses": true,
     "WeaponTypeBonusValue": 10,
-    "ChanceToRun": true,
+    "ChanceToRun": 1,
     "SpellBugs": true,
     "BlackBeltAbsorb": true,
     "NPCSwatter": true,

--- a/FF1Lib/BugFixes.cs
+++ b/FF1Lib/BugFixes.cs
@@ -73,11 +73,6 @@ namespace FF1Lib
 			Put(0x326F5, new byte[] { (byte) weaponBonusValue });
 		}
 
-		public void FixChanceToRun()
-		{
-			Put(0x323EF, new byte[] { 0x82 });
-		}
-
 		public void FixWarpBug()
 		{
 			Put(0x3AEF3, Blob.FromHex("187D0063")); // Allows last slot in a spell level to be used outside of battle

--- a/FF1Lib/ChanceToRun.cs
+++ b/FF1Lib/ChanceToRun.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FF1Lib
+{
+	public enum ChanceToRunMode
+	{
+		[Description("Vanilla")]
+		Vanilla,
+
+		[Description("Fixed")]
+		Fixed,
+
+		[Description("25%")]
+		Fix25,
+
+		[Description("40%")]
+		Fix40,
+
+		[Description("55%")]
+		Fix55,
+
+		[Description("70%")]
+		Fix70,
+
+		[Description("85%")]
+		Fix85,
+
+		[Description("100%")]
+		Fix100
+	}
+
+	public class ChanceToRun
+	{
+		FF1Rom rom;
+		Flags flags;
+
+		public ChanceToRun(FF1Rom _rom, Flags _flags)
+		{
+			rom = _rom;
+			flags = _flags;
+		}
+
+		public void FixChanceToRun()
+		{
+			switch (flags.ChanceToRun)
+			{
+				case ChanceToRunMode.Vanilla:
+					break;
+				case ChanceToRunMode.Fixed:
+					//Load Level instead of whatever the vanilla game loads
+					rom.Put(0x323EF, new byte[] { 0x82 });
+					break;
+				case ChanceToRunMode.Fix25:
+					//Load 100 instead of level, the CLC can stay, remove Add 16
+					rom.Put(0x323EE, new byte[] { 0xA9, 0x63, 0x18, 0xEA, 0xEA });
+					//Load 25 instead of Luck
+					rom.Put(0x323FF, new byte[] { 0xA9, 0x19});
+					break;
+				case ChanceToRunMode.Fix40:
+					rom.Put(0x323EE, new byte[] { 0xA9, 0x63, 0x18, 0xEA, 0xEA });
+					rom.Put(0x323FF, new byte[] { 0xA9, 0x28 });
+					break;
+				case ChanceToRunMode.Fix55:
+					rom.Put(0x323EE, new byte[] { 0xA9, 0x63, 0x18, 0xEA, 0xEA });
+					rom.Put(0x323FF, new byte[] { 0xA9, 0x37 });
+					break;
+				case ChanceToRunMode.Fix70:
+					rom.Put(0x323EE, new byte[] { 0xA9, 0x63, 0x18, 0xEA, 0xEA });
+					rom.Put(0x323FF, new byte[] { 0xA9, 0x46 });
+					break;
+				case ChanceToRunMode.Fix85:
+					rom.Put(0x323EE, new byte[] { 0xA9, 0x63, 0x18, 0xEA, 0xEA });
+					rom.Put(0x323FF, new byte[] { 0xA9, 0x55 });
+					break;
+				case ChanceToRunMode.Fix100:
+					rom.Put(0x323EE, new byte[] { 0xA9, 0x63, 0x18, 0xEA, 0xEA });
+					rom.Put(0x323FF, new byte[] { 0xA9, 0x64 });
+					break;
+
+			}
+
+		}
+	}
+}

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -703,10 +703,7 @@ namespace FF1Lib
 				FixWeaponStats();
 			}
 
-			if (flags.ChanceToRun)
-			{
-				FixChanceToRun();
-			}
+			new ChanceToRun(this, flags).FixChanceToRun();
 
 			if (flags.EnemyStatusAttackBug)
 			{

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -230,7 +230,9 @@ namespace FF1Lib
 
 		[IntegerFlag(0, 50)]
 		public int WeaponTypeBonusValue { get; set; } = 10;
-		public bool ChanceToRun { get; set; } = false;
+
+		public ChanceToRunMode ChanceToRun { get; set; } = ChanceToRunMode.Vanilla;
+
 		public bool SpellBugs { get; set; } = false;
 		public bool BlackBeltAbsorb { get; set; } = false;
 		public bool NPCSwatter { get; set; } = false;

--- a/FF1Lib/FlagsViewModel.cs
+++ b/FF1Lib/FlagsViewModel.cs
@@ -1862,13 +1862,13 @@ namespace FF1Lib
 			}
 		}
 
-		public bool ChanceToRun
+		public ChanceToRunMode ChanceToRun
 		{
 			get => Flags.ChanceToRun;
 			set
 			{
 				Flags.ChanceToRun = value;
-				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("ChanceToRun"));
+				RaisePropertyChanged();
 			}
 		}
 		public bool SpellBugs

--- a/FF1Lib/presets/beginner.json
+++ b/FF1Lib/presets/beginner.json
@@ -117,7 +117,7 @@
 		"BBCritRate": true,
 		"WeaponCritRate": true,
 		"WeaponBonuses": true,
-		"ChanceToRun": true,
+		"ChanceToRun": 1,
 		"SpellBugs": true,
 		"BlackBeltAbsorb": true,
 		"BlackBeltMDEF": true,

--- a/FF1Lib/presets/debug.json
+++ b/FF1Lib/presets/debug.json
@@ -117,7 +117,7 @@
 		"BBCritRate": true,
 		"WeaponCritRate": true,
 		"WeaponBonuses": true,
-		"ChanceToRun": true,
+		"ChanceToRun": 1,
 		"SpellBugs": true,
 		"BlackBeltAbsorb": true,
 		"BlackBeltMDEF": true,

--- a/FF1Lib/presets/default.json
+++ b/FF1Lib/presets/default.json
@@ -117,7 +117,7 @@
 		"BBCritRate": true,
 		"WeaponCritRate": true,
 		"WeaponBonuses": true,
-		"ChanceToRun": true,
+		"ChanceToRun": 1,
 		"SpellBugs": true,
 		"BlackBeltAbsorb": true,
 		"BlackBeltMDEF": true,

--- a/FF1Lib/presets/full-npc.json
+++ b/FF1Lib/presets/full-npc.json
@@ -117,7 +117,7 @@
 		"BBCritRate": true,
 		"WeaponCritRate": true,
 		"WeaponBonuses": true,
-		"ChanceToRun": true,
+		"ChanceToRun": 1,
 		"SpellBugs": true,
 		"BlackBeltAbsorb": true,
 		"BlackBeltMDEF": true,

--- a/FF1Lib/presets/improved-vanilla.json
+++ b/FF1Lib/presets/improved-vanilla.json
@@ -117,7 +117,7 @@
 		"BBCritRate": true,
 		"WeaponCritRate": true,
 		"WeaponBonuses": true,
-		"ChanceToRun": true,
+		"ChanceToRun": 1,
 		"SpellBugs": true,
 		"BlackBeltAbsorb": true,
 		"BlackBeltMDEF": true,

--- a/Sandbox/TreasureDistribution.cs
+++ b/Sandbox/TreasureDistribution.cs
@@ -37,7 +37,7 @@ namespace Sandbox
 
 			    HouseMPRestoration = false,
 			    WeaponStats = false,
-			    ChanceToRun = false,
+			    ChanceToRun = ChanceToRunMode.Vanilla,
 			    SpellBugs = false,
 			    EnemyStatusAttackBug = false,
 


### PR DESCRIPTION
A niche flag for challenge flagsets where you don't get to choose your classes. It overrides the class specific run chances with a fixed one.

Done to make things like Solo WM more bearable.