### PR TITLE
Add "Y BURN" to Fun Enemy Names

### DIFF
--- a/FF1Lib/Fun.cs
+++ b/FF1Lib/Fun.cs
@@ -107,6 +107,7 @@ namespace FF1Lib
 			enemyText[56] = "EXPEDE"; // +2
 			enemyText[66] = "White D";
 			enemyText[72] = "MtlSLIME"; // +3
+			enemyText[83] = "Y BURN";
 			if (teamSteak)
 			{
 				enemyText[85] = "STEAK"; // +1


### PR DESCRIPTION
An ode to FF5's terrible PS1 translation, which conveniently uses the same number of letters as "WYVERN":
![image](https://user-images.githubusercontent.com/5532354/113942030-0f823b80-97b5-11eb-8981-49684d15fcaf.png)