### PR TITLE
All backward cycling through tristate checkboxes

### DIFF
--- a/FF1Blazorizer/Shared/CheckBox.razor
+++ b/FF1Blazorizer/Shared/CheckBox.razor
@@ -1,7 +1,7 @@
 <div class="checkbox-cell">
 	<div class="btn-group-toggle @IndentClass @ValueClass @DisabledClass" data-toggle="buttons">
 		<input type="radio" name="@Name" value="0" checked="@checked0" hidden>
-		<input type="image" src="@image" id="@Id" class="tri-state" disabled="@(!IsEnabled)" @onclick="@onclick" /> <label for="@Id" hidden="@(ChildContent is null)">@ChildContent</label>
+		<input type="image" src="@image" id="@Id" class="tri-state" disabled="@(!IsEnabled)" @onmouseup="@onClick" @oncontextmenu:preventDefault @oncontextmenu="@onContext" /> <label for="@Id" hidden="@(ChildContent is null)">@ChildContent</label>
 	@if (!DisableTooltip)
 	{
 		<input type="image" src="/images/help.png" class="btn-group-help" title="Show Help" @onclick="@ShowToolTip" id="@Id" />
@@ -24,7 +24,7 @@
 	[Parameter]
 	public bool Name { get; set; }
 
-	Task onclick()
+	Task onClick()
 	{
 		if (Disabled)
 		{
@@ -40,7 +40,13 @@
 			Value = false;
 		}
 		return ValueChanged.InvokeAsync(Value);
+	}
 
+	// For some reason, using just `@oncontextmenu:preventDefault` or just handling `oncontextmenu` events did nothing to prevent the context menu from appearing!
+	// I needed both `preventDefault` AND this handler to prevent the context menu from showing up. Ugh...
+	Task onContext()
+	{
+		return Task.CompletedTask;
 	}
 
 	private void ShowToolTip(MouseEventArgs e)

--- a/FF1Blazorizer/Shared/TriStateCheckBox.razor
+++ b/FF1Blazorizer/Shared/TriStateCheckBox.razor
@@ -3,7 +3,7 @@
 		<input type="radio" name="@Name" value="2" checked="@checked2" hidden>
 		<input type="radio" name="@Name" value="1" checked="@checked1" hidden>
 		<input type="radio" name="@Name" value="0" checked="@checked0" hidden>
-		<input type="image" src="@image" id="@Id" class="tri-state" disabled="@(!IsEnabled)" @oncontextmenu="onContext" @oncontextmenu:preventDefault @onmouseup="onClick" /> <label for="@Id" hidden="@(ChildContent is null)">@ChildContent</label> 
+		<input type="image" src="@image" id="@Id" class="tri-state" disabled="@(!IsEnabled)" @oncontextmenu="@onContext" @oncontextmenu:preventDefault @onmouseup="@onClick" /> <label for="@Id" hidden="@(ChildContent is null)">@ChildContent</label> 
 	@if (!DisableTooltip)
 	{
 		<input type="image" src="/images/help.png" class="btn-group-help" title="Show Help" @onclick="@ShowToolTip" id="@Id" />

--- a/FF1Blazorizer/Shared/TriStateCheckBox.razor
+++ b/FF1Blazorizer/Shared/TriStateCheckBox.razor
@@ -3,7 +3,7 @@
 		<input type="radio" name="@Name" value="2" checked="@checked2" hidden>
 		<input type="radio" name="@Name" value="1" checked="@checked1" hidden>
 		<input type="radio" name="@Name" value="0" checked="@checked0" hidden>
-		<input type="image" src="@image" id="@Id" class="tri-state" disabled="@(!IsEnabled)" @onclick="@onclick" /> <label for="@Id" hidden="@(ChildContent is null)">@ChildContent</label> 
+		<input type="image" src="@image" id="@Id" class="tri-state" disabled="@(!IsEnabled)" @oncontextmenu="onContext" @oncontextmenu:preventDefault @onmouseup="onClick" /> <label for="@Id" hidden="@(ChildContent is null)">@ChildContent</label> 
 	@if (!DisableTooltip)
 	{
 		<input type="image" src="/images/help.png" class="btn-group-help" title="Show Help" @onclick="@ShowToolTip" id="@Id" />
@@ -28,27 +28,52 @@
 	[Parameter]
 	public bool Name { get; set; }
 
-	Task onclick()
+	Task onClick(MouseEventArgs args)
 	{
 		if (Disabled)
 		{
 			return Task.CompletedTask;
 		}
 
-		if (Value == false)
+		// Which button was pressed?
+		if (args.Button == 0)
 		{
-			Value = true;
+			if (Value == false)
+			{
+				Value = true;
+			}
+			else if (Value == true)
+			{
+				Value = null;
+			}
+			else
+			{
+				Value = false;
+			}
 		}
-		else if (Value == true)
+		else if (args.Button == 2)
 		{
-			Value = null;
+			// Go the opposite direction in the cycle
+			if (Value == false)
+			{
+				Value = null;
+			}
+			else if (Value == true)
+			{
+				Value = false;
+			}
+			else
+			{
+				Value = true;
+			}
 		}
-		else
-		{
-			Value = false;
-		}
-		return ValueChanged.InvokeAsync(Value);
 
+		return ValueChanged.InvokeAsync(Value);
+	}
+
+	Task onContext()
+	{
+		return Task.CompletedTask;
 	}
 
 	private void ShowToolTip(MouseEventArgs e)

--- a/FF1Blazorizer/Shared/TriStateCheckBox.razor
+++ b/FF1Blazorizer/Shared/TriStateCheckBox.razor
@@ -71,6 +71,8 @@
 		return ValueChanged.InvokeAsync(Value);
 	}
 
+	// For some reason, using just `@oncontextmenu:preventDefault` or just handling `oncontextmenu` events did nothing to prevent the context menu from appearing!
+	// I needed both `preventDefault` AND this handler to prevent the context menu from showing up. Ugh...
 	Task onContext()
 	{
 		return Task.CompletedTask;


### PR DESCRIPTION
This will allow users to right-click on a tristate checkbox to cycle the opposite direction. If a tristate is checked and the user wants to clear it, rather than click it twice, they only need to right-click once.

- Adds a `preventDefault` flag for the `oncontextmenu` event AND an event handler that does nothing as well, as both are required to prevent the context menu from appearing. I don't know why `preventDefault` didn't work on it's own, but Today I Learned... 🤷‍♂️
- Changed from `onclick` to `onmouseup` because blazor also doesn't seem to care about `MouseEventArgs` when provided, despite the docs saying that it does... 🤷‍♂️
- Did the same thing with regular checkboxes so that people can't inadvertently attempt to back cycle on them and then have a context menu appear and the box not toggle it's state, for consistency's sake. 😄