### PR TITLE
[Bugfix] Set default SpoilerCache value and check for empty string

### DIFF
--- a/FF1Blazorizer/Tabs/FileTab.razor
+++ b/FF1Blazorizer/Tabs/FileTab.razor
@@ -266,16 +266,20 @@
 
 				SetStatusMessage(StatusMessage + "SUCCESS!");
 
-				if (Flags.Spoilers)
+				if (Flags.Spoilers && Utilities.SpoilerCache.Length > 0)
 				{
-					SetStatusMessage(StatusMessage + " Downloading spoiler log after the ROM");
+					SetStatusMessage(StatusMessage + " Downloading ROM and spoiler log.");
+				}
+				else if (Flags.Spoilers && Utilities.SpoilerCache.Length == 0)
+				{
+					SetStatusMessage(StatusMessage + " No spoilers have been generated to download.");
 				}
 
 				StateHasChanged();
 
 				await JSRuntime.InvokeAsync<object>("downloadFile", $"FFR_{_seed}_{Flags.Encoded}.nes", encoded);
 
-				if (Flags.Spoilers)
+				if (Flags.Spoilers && Utilities.SpoilerCache.Length > 0)
 				{
 					var encodedSpoiler = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(Utilities.SpoilerCache));
 					await JSRuntime.InvokeVoidAsync("downloadFile", $"Spoiler_{_seed}_{Flags.Encoded}.txt", encodedSpoiler);

--- a/FF1Lib/Helpers/Utilities.cs
+++ b/FF1Lib/Helpers/Utilities.cs
@@ -4,7 +4,7 @@ namespace FF1Lib
 {
 	public static class Utilities
 	{
-		public static string SpoilerCache { get; set; }
+		public static string SpoilerCache { get; set; } = "";
 
 		/// <summary>
 		/// Outputs the spoiler log entry to a text file or to the console


### PR DESCRIPTION
I found a bug in my handling of downloading spoiler logs when attempting to get a spoiler log that is empty (i.e. not using the Treasures flag). This PR fixes that by ensuring the `SpoilerCache` is initialized with an empty string. Additionally, I added logic to the File Tab to not download a spoiler log if the `SpoilerCache` is empty and display a message stating as much to the user.

![image](https://user-images.githubusercontent.com/5532354/114479100-9ddf2e80-9bb4-11eb-942d-60614c6bb7b8.png)
