### PR TITLE
Add handler to checkbox labels to make clickable again

### DIFF
--- a/FF1Blazorizer/Shared/CheckBox.razor
+++ b/FF1Blazorizer/Shared/CheckBox.razor
@@ -1,7 +1,7 @@
 <div class="checkbox-cell">
 	<div class="btn-group-toggle @IndentClass @ValueClass @DisabledClass" data-toggle="buttons">
 		<input type="radio" name="@Name" value="0" checked="@checked0" hidden>
-		<input type="image" src="@image" id="@Id" class="tri-state" disabled="@(!IsEnabled)" @onmouseup="@onClick" @oncontextmenu:preventDefault @oncontextmenu="@onContext" /> <label for="@Id" hidden="@(ChildContent is null)">@ChildContent</label>
+		<input type="image" src="@image" id="@Id" class="tri-state" disabled="@(!IsEnabled)" @onmouseup="@onClick" @oncontextmenu:preventDefault @oncontextmenu="@onContext" /> <label for="@Id" @onmouseup="@onClick" @oncontextmenu:preventDefault hidden="@(ChildContent is null)">@ChildContent</label>
 	@if (!DisableTooltip)
 	{
 		<input type="image" src="/images/help.png" class="btn-group-help" title="Show Help" @onclick="@ShowToolTip" id="@Id" />

--- a/FF1Blazorizer/Shared/TriStateCheckBox.razor
+++ b/FF1Blazorizer/Shared/TriStateCheckBox.razor
@@ -3,7 +3,7 @@
 		<input type="radio" name="@Name" value="2" checked="@checked2" hidden>
 		<input type="radio" name="@Name" value="1" checked="@checked1" hidden>
 		<input type="radio" name="@Name" value="0" checked="@checked0" hidden>
-		<input type="image" src="@image" id="@Id" class="tri-state" disabled="@(!IsEnabled)" @oncontextmenu="@onContext" @oncontextmenu:preventDefault @onmouseup="@onClick" /> <label for="@Id" hidden="@(ChildContent is null)">@ChildContent</label> 
+		<input type="image" src="@image" id="@Id" class="tri-state" disabled="@(!IsEnabled)" @oncontextmenu="@onContext" @oncontextmenu:preventDefault @onmouseup="@onClick" /> <label for="@Id" @onmouseup="@onClick" @oncontextmenu:preventDefault hidden="@(ChildContent is null)">@ChildContent</label> 
 	@if (!DisableTooltip)
 	{
 		<input type="image" src="/images/help.png" class="btn-group-help" title="Show Help" @onclick="@ShowToolTip" id="@Id" />


### PR DESCRIPTION
Adds click event handlers to the labels for the checkboxes so that they can interpret left and right mouse button clicks after my change to make the tristate boxes multidirectional.