### PR TITLE
Tetron/nofloater entrance shuffle

### DIFF
--- a/FF1Lib/Dialogs.cs
+++ b/FF1Lib/Dialogs.cs
@@ -1292,7 +1292,7 @@ namespace FF1Lib
 				}
 			}
 
-			if ((flags.IsAirshipFree ?? false) || (flags.IsFloaterRemoved ?? false)) incentivePool.Remove(Item.Floater);
+			if (flags.IsFloaterRemoved ?? false) incentivePool.Remove(Item.Floater);
 			if (flags.FreeCanoe ?? false) incentivePool.Remove(Item.Canoe);
 			if (flags.FreeBridge ?? false) incentivePool.Remove(Item.Bridge);
 			if (flags.IsCanalFree ?? false) incentivePool.Remove(Item.Canal);

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -620,7 +620,7 @@ namespace FF1Lib
 		public bool? IsShipFree => FreeShip | NoOverworld;
 		public bool? IsAirshipFree => FreeAirship & !NoOverworld;
 		public bool? IsCanalFree => FreeCanal & !NoOverworld;
-		public bool? IsFloaterRemoved => NoFloater & !NoOverworld;
+		public bool? IsFloaterRemoved => (NoFloater|IsAirshipFree) & !NoOverworld;
 		public bool IncentivizeBridge => false;
 		public bool? IncentivizeCanoe => NPCItems & IncentivizeCanoeItem & !FreeCanoe;
 		public bool? IncentivizeLute => NPCItems & !FreeLute & IncentivizeMainItems;

--- a/FF1Lib/Interfaces.cs
+++ b/FF1Lib/Interfaces.cs
@@ -150,6 +150,7 @@
 		bool? AllowDeepTowns { get; }
 		bool? AllowUnsafeStartArea { get; }
 		bool? IsFloaterRemoved { get; }
+	        bool? IsAirshipFree { get; }
 		bool? MapBahamutCardiaDock { get; }
 	}
 	public interface IVictoryConditionFlags

--- a/FF1Lib/ItemPlacement.cs
+++ b/FF1Lib/ItemPlacement.cs
@@ -131,7 +131,7 @@ namespace FF1Lib
 			{
 				placedItems = placedItems.Select(x => x.Item != Item.Bridge ? x : NewItemPlacement(x, ReplacementItem)).ToList();
 			}
-			if (((bool)_flags.IsAirshipFree || (bool)_flags.IsFloaterRemoved))
+			if ((bool)_flags.IsFloaterRemoved)
 			{
 				placedItems = placedItems.Select(x => x.Item != Item.Floater ? x : NewItemPlacement(x, ReplacementItem)).ToList();
 			}

--- a/FF1Lib/OverworldMap.cs
+++ b/FF1Lib/OverworldMap.cs
@@ -653,20 +653,6 @@ namespace FF1Lib
 			// Titan's Tunnel adjustments. The Titan Fed requirement implies access to one side of the tunnel,
 			// so it is sufficient to say feeding the titan will grant access to all walkable and canoeable nodes
 			// from either entrance.
-
-			//if ((bool)flags.IsFloaterRemoved && !(bool)flags.IsAirshipFree) {
-			    // Floater is removed.  The west end of
-			    // Titan's tunnel is pinned, so the Titan
-			    // has to be fed to access these
-			    // locations.
-			//MapLocationRequirements[MapLocation.SardasCave] = new List<MapChange> { MapChange.TitanFed };
-			//MapLocationRequirements[MapLocation.TitansTunnelWest] = new List<MapChange> { MapChange.TitanFed };
-
-			    /*MapLocationRequirements[MapLocation.TitansTunnelWest].Clear();
-			    foreach (var loc in defaultRequirements[ItemLocations.OverworldToMapLocation[titanEast.Key]].MapChanges) {
-				MapLocationRequirements[MapLocation.TitansTunnelWest].Add(loc | MapChange.TitanFed);
-				}*/
-			//}
 			foreach (var key in titanWalkLocations)
 			{
 				MapLocationRequirements[key].Add(MapChange.TitanFed);

--- a/FF1Lib/OverworldMap.cs
+++ b/FF1Lib/OverworldMap.cs
@@ -367,7 +367,7 @@ namespace FF1Lib
 					keepers.Add(OverworldTeleportIndex.Cardia5);
 				}
 
-				if ((bool)flags.IsFloaterRemoved)
+				if ((bool)flags.IsFloaterRemoved && !(bool)flags.IsAirshipFree)
 				{
 				    if (!(bool)flags.MapBahamutCardiaDock) {
 					keepers.Add(OverworldTeleportIndex.Cardia1);
@@ -377,6 +377,10 @@ namespace FF1Lib
 				    keepers.Add(OverworldTeleportIndex.Cardia4);
 				    keepers.Add(OverworldTeleportIndex.Cardia5);
 				    keepers.Add(OverworldTeleportIndex.Cardia6);
+				    keepers.Add(OverworldTeleportIndex.TitansTunnelWest);
+
+				    defaultRequirements[MapLocation.SardasCave] = new LocationRequirement(new List<MapChange> { MapChange.TitanFed });
+				    defaultRequirements[MapLocation.TitansTunnelWest] = new LocationRequirement(new List<MapChange> { MapChange.TitanFed });
 				}
 
 				placedMaps = placedMaps .Where(x => keepers.Contains(x.Key)) .ToDictionary(x => x.Key, x => x.Value);
@@ -649,6 +653,20 @@ namespace FF1Lib
 			// Titan's Tunnel adjustments. The Titan Fed requirement implies access to one side of the tunnel,
 			// so it is sufficient to say feeding the titan will grant access to all walkable and canoeable nodes
 			// from either entrance.
+
+			//if ((bool)flags.IsFloaterRemoved && !(bool)flags.IsAirshipFree) {
+			    // Floater is removed.  The west end of
+			    // Titan's tunnel is pinned, so the Titan
+			    // has to be fed to access these
+			    // locations.
+			//MapLocationRequirements[MapLocation.SardasCave] = new List<MapChange> { MapChange.TitanFed };
+			//MapLocationRequirements[MapLocation.TitansTunnelWest] = new List<MapChange> { MapChange.TitanFed };
+
+			    /*MapLocationRequirements[MapLocation.TitansTunnelWest].Clear();
+			    foreach (var loc in defaultRequirements[ItemLocations.OverworldToMapLocation[titanEast.Key]].MapChanges) {
+				MapLocationRequirements[MapLocation.TitansTunnelWest].Add(loc | MapChange.TitanFed);
+				}*/
+			//}
 			foreach (var key in titanWalkLocations)
 			{
 				MapLocationRequirements[key].Add(MapChange.TitanFed);


### PR DESCRIPTION
With NoFloater enabled, pin Titan's west to its vanilla location so you are guaranteed to be able to access the Sarda region via the tunnel.

Location of Titan's east, and what is placed at the Sarda entrance, are still random.
