### PR TITLE
Replace floater in unincentivizedQuestItems list when IsFloaterRemoved

### DIFF
--- a/FF1Lib/ItemPlacement.cs
+++ b/FF1Lib/ItemPlacement.cs
@@ -112,6 +112,11 @@ namespace FF1Lib
 			{
 				shards.Add(Item.Shard);
 			}
+			if ((bool)_flags.IsFloaterRemoved)
+			{
+			    unincentivizedQuestItems.Remove(Item.Floater);
+			    unincentivizedQuestItems.Add(ReplacementItem);
+			}
 
 			ItemPlacementContext ctx = new ItemPlacementContext
 			{
@@ -130,10 +135,6 @@ namespace FF1Lib
 			if ((bool)_flags.FreeBridge)
 			{
 				placedItems = placedItems.Select(x => x.Item != Item.Bridge ? x : NewItemPlacement(x, ReplacementItem)).ToList();
-			}
-			if ((bool)_flags.IsFloaterRemoved)
-			{
-				placedItems = placedItems.Select(x => x.Item != Item.Floater ? x : NewItemPlacement(x, ReplacementItem)).ToList();
 			}
 			if ((bool)_flags.IsShipFree)
 			{


### PR DESCRIPTION
This fixes a major placement bug in the previous logic:

The floater would get placed as a loose item, progression items would
get placed on the basis of assumed access to the airship, but after
sane placement was complete, the the floater was replaced with a dud
item (cabin), making progression impossible.

This removes the floater entirely, prior to placement, as intended.