### PR TITLE
Improve versioned deployment to get more stable URLs

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -25,37 +25,51 @@ if "$deployPreview"; then
     post_data='{"body": "Automatic deployment: '$url'"}'
     curl -X POST -H "Accept: application/vnd.github.v3+json" -H "Content-Type:application/json" "$pr_comment_url" -u $GH_USER:"$GH_API" -d "$post_data"
 else
-	if [ "$branch" = "master" ]; then 
-		version=$(grep " Version.*" /root/ff1randomizer/FF1Lib/FFRVersion.cs | grep -Eo "[0-9\.]+" | tr '.' '-')
-		siteExists=$(curl --location --request GET 'https://api.netlify.com/api/v1/dns_zones/finalfantasyrandomizer_com/dns_records' \
-    		--header "Authorization: Bearer ${NETLIFY_AUTH_TOKEN}" \
-    		--header 'Content-Type: application/json' | jq -r ".[].hostname" | grep -q "${version}" && echo true || echo false
-    		)
-    		
-    		
-    		if [ "${siteExists}" = true ]; then
-    			echo "The version ${version} was found in the dns entries, make sure you increment the version in FF1Lib/FFRVersion.cs"
-    			exit 1
-    		fi
-    		
-    		createdSite=$(curl --location --request POST 'https://api.netlify.com/api/v1/sites' \
-    		--header "Authorization: Bearer ${NETLIFY_AUTH_TOKEN}" \
-    		--header 'Content-Type: application/json' \
-    		--data-raw "{\"custom_domain\": \"${version}.finalfantasyrandomizer.com\", \"force_ssl\": \"true\"}")
-    		
-    		
-    		errors=$(echo "$createdSite" | jq ".errors")
-    		if [ "$errors" -ne "null" ]; then
-    		        echo "errors encountered while creating site:"
-    		        echo "$errors"
-    		        exit 2
-    		fi
-    		
-    		id=$(echo "$createdSite" | jq -r ".site_id")
-    		echo "$id"
-    		
-    		netlify deploy --dir=/root/ff1randomizer/FF1Blazorizer/output/wwwroot --prod --site="$id"
-	fi
-    netlify deploy --dir=/root/ff1randomizer/FF1Blazorizer/output/wwwroot --prod --site="$netlifyID"
+    if [ "$branch" = "master" ]; then
+	version=$(grep " Version.*" /root/ff1randomizer/FF1Lib/FFRVersion.cs | grep -Eo "[0-9\.]+" | tr '.' '-')
+    elif [ "$branch" = "dev" ]; then
+	version=beta-$(echo $CIRCLE_SHA1 | cut -c1-8)
+    else
+    	echo "Don't know what to do to deploy branch '$branch' expected 'master' or 'dev'"
+    	exit 1
+    fi
 
+    siteExists=$(curl --location --request GET 'https://api.netlify.com/api/v1/dns_zones/finalfantasyrandomizer_com/dns_records' \
+    		      --header "Authorization: Bearer ${NETLIFY_AUTH_TOKEN}" \
+    		      --header 'Content-Type: application/json' | jq -r ".[].hostname" | grep -q "${version}" && echo true || echo false
+    	      )
+
+    if [ "${siteExists}" = true ]; then
+    	echo "The version ${version} was found in the dns entries, make sure you increment the version in FF1Lib/FFRVersion.cs"
+    	exit 1
+    fi
+
+    createdSite=$(curl --location --request POST 'https://api.netlify.com/api/v1/sites' \
+    		       --header "Authorization: Bearer ${NETLIFY_AUTH_TOKEN}" \
+    		       --header 'Content-Type: application/json' \
+    		       --data-raw "{\"custom_domain\": \"${version}.finalfantasyrandomizer.com\", \"force_ssl\": \"true\"}")
+
+
+    errors=$(echo "$createdSite" | jq ".errors")
+    if [ "$errors" -ne "null" ]; then
+    	echo "errors encountered while creating site:"
+    	echo "$errors"
+    	exit 2
+    fi
+
+    id=$(echo "$createdSite" | jq -r ".site_id")
+    echo "$id"
+
+    # Deploy the instanced site
+    netlify deploy --dir=/root/ff1randomizer/FF1Blazorizer/output/wwwroot --prod --site="$id"
+
+    # Copy over index.redirect.html, this will make the front page of
+    # either the main site or the beta site to redirect to the
+    # instanced site that we just deployed.
+    mkdir -p /root/finalfantasyrandomizer.com
+    cp /root/ff1randomizer/FF1Blazorizer/output/wwwroot/index.redirect.html /root/finalfantasyrandomizer.com/index.html
+    sed -i "s/VERSION/${version}/" /root/finalfantasyrandomizer.com/index.html
+
+    # Deploy index.html
+    netlify deploy --dir=/root/finalfantastyrandomizer.com --prod --site="$netlifyID"
 fi

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -28,7 +28,7 @@ else
     if [ "$branch" = "master" ]; then
 	version=$(grep " Version.*" /root/ff1randomizer/FF1Lib/FFRVersion.cs | grep -Eo "[0-9\.]+" | tr '.' '-')
     elif [ "$branch" = "dev" ]; then
-	version=beta-$(echo $CIRCLE_SHA1 | cut -c1-8)
+	version=beta-$(echo "$CIRCLE_SHA1" | cut -c1-8)
     else
     	echo "Don't know what to do to deploy branch '$branch' expected 'master' or 'dev'"
     	exit 1

--- a/FF1Blazorizer/wwwroot/index.redirect.html
+++ b/FF1Blazorizer/wwwroot/index.redirect.html
@@ -1,0 +1,53 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Final Fantasy Randomizer</title>
+
+    <meta name="description" CONTENT="FFR: Randomize Your Final Fantasy Experience">
+    <meta name="keywords" CONTENT="Final Fantasy, Randomizer, Random, Randomize, FFR, Fighter, Black Belt, Thief, Red Mage, Black Mage, White Mage, Chaos, Garland, Gilgamesh">
+    <meta name="author" CONTENT="Entroper, finalfantasyrandomizer@gmail.com">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:creator" content="@ffrandomizer" />
+    <meta name="twitter:title" content="Final Fantasy Randomizer" />
+
+    <meta property="og:site_name" content="Final Fantasy, Randomizer">
+    <meta property="og:title" content="FFR: Randomize Your Final Fantasy Experience">
+    <meta property="og:description" content="The hot new way to play the classic NES game">
+    <meta property="og:image" content="https://www.finalfantasyrandomizer.com/images/splash_image.png">
+    <meta property="og:url" content="https://www.finalfantasyrandomizer.com/">
+    <meta property="og:type" content="video games">
+
+    <meta http-equiv="refresh" content="0;URL='http://VERSION.finalfantasyrandomizer.com/'" />
+
+    <link rel="shortcut icon" href="images/favicon.ico" />
+
+    <base href="/" />
+    <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
+
+    <link href="manifest.json" rel="manifest" />
+
+    <link rel="stylesheet" href="css/site.css" type="text/css">
+    <link rel="stylesheet" href="styles/layout.css" type="text/css">
+    <link rel="stylesheet" href="styles/theme.css" type="text/css">
+
+    <link rel="stylesheet" href="styles/thinner.css" type="text/css" media="only screen and (max-width: 995px)" />
+    <link rel="stylesheet" href="styles/minimize.css" type="text/css" media="only screen and (max-width: 600px)" />
+    <link rel="stylesheet" href="styles/mobile.css" type="text/css" media="screen and (max-device-width: 600px)" />
+
+</head>
+
+<body>
+    <app>
+        <div class="loading">
+            <p>&nbsp;</p>
+            <p>Now loading Final Fantasy Randomizer!</p>
+            <p>&nbsp;</p>
+            <p>Don't forget, if you leave your game,</p>
+            <p>Hold RESET while you turn POWER off!!</p>
+            <p><a href="http://VERSION.finalfantasyrandomizer.com/">Or click here</a></p>
+        </div>
+    </app>
+</body>
+</html>


### PR DESCRIPTION
The goal of this proposed change is to ensure stable URLs by always
sending the user to an instanced site.  This way, when the user copies
a link out of the URL bar to share with others, they get a stable URL.

1) instanced master deploy is the same x-y-z.ffr.com

2) beta site now deploys as beta-(commit).ffr.com

3) ffr.com and beta.ffr.com front page deploy a simple index.html with
a meta refresh redirect to the most recently deployed instanced site.