### PR TITLE
Tetron/better instanced deploy

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -66,10 +66,9 @@ else
     # Copy over index.redirect.html, this will make the front page of
     # either the main site or the beta site to redirect to the
     # instanced site that we just deployed.
-    mkdir -p /root/finalfantasyrandomizer.com
-    cp /root/ff1randomizer/FF1Blazorizer/output/wwwroot/index.redirect.html /root/finalfantasyrandomizer.com/index.html
-    sed -i "s/VERSION/${version}/" /root/finalfantasyrandomizer.com/index.html
+    cp /root/ff1randomizer/FF1Blazorizer/output/wwwroot/index.redirect.html /root/ff1randomizer/FF1Blazorizer/output/wwwroot/index.html
+    sed -i "s/VERSION/${version}/" /root/ff1randomizer/FF1Blazorizer/output/wwwroot/index.html
 
-    # Deploy index.html
-    netlify deploy --dir=/root/finalfantasyrandomizer.com --prod --site="$netlifyID"
+    # Deploy with the redirect version of index.html
+    netlify deploy --dir=/root/ff1randomizer/FF1Blazorizer/output/wwwroot --prod --site="$netlifyID"
 fi

--- a/FF1Blazorizer/wwwroot/index.redirect.html
+++ b/FF1Blazorizer/wwwroot/index.redirect.html
@@ -46,7 +46,8 @@
             <p>&nbsp;</p>
             <p>Don't forget, if you leave your game,</p>
             <p>Hold RESET while you turn POWER off!!</p>
-            <p><a href="http://VERSION.finalfantasyrandomizer.com/">Or click here</a></p>
+            <p>&nbsp;</p>
+            <p><a href="https://VERSION.finalfantasyrandomizer.com/">Go to the latest version of the site</a></p>
         </div>
     </app>
 </body>


### PR DESCRIPTION
Switch it to just replace `index.html` with the "redirect" version and redeploy the site.  This ensures that stylesheets, fonts, favico and so forth on the redirect page match the site style.
