### PR TITLE
Save preferences and ROM data at a single domain.

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -69,6 +69,9 @@ else
     cp /root/ff1randomizer/FF1Blazorizer/output/wwwroot/index.redirect.html /root/ff1randomizer/FF1Blazorizer/output/wwwroot/index.html
     sed -i "s/VERSION/${version}/" /root/ff1randomizer/FF1Blazorizer/output/wwwroot/index.html
 
+    # Also record version into a simple file that we can fetch to find out the latest version.
+    echo "${version}" > /root/ff1randomizer/FF1Blazorizer/output/wwwroot/version
+
     # Deploy with the redirect version of index.html
     netlify deploy --dir=/root/ff1randomizer/FF1Blazorizer/output/wwwroot --prod --site="$netlifyID"
 fi

--- a/FF1Blazorizer/Tabs/FileTab.razor
+++ b/FF1Blazorizer/Tabs/FileTab.razor
@@ -84,14 +84,13 @@
 				TrySetFlags(flags.First());
 			}
 
-			await JSRuntime.InvokeVoidAsync("getFFRPreferences",
-		                          "file",
-					  DotNetObjectReference.Create(this),
-					  "LoadLastROM");
+			var romfile = await JSRuntime.InvokeAsync<string>("getFFRPreferences", "file");
+			if (romfile != null) {
+			    LoadLastROM(romfile);
+			}
 		}
 
-		[JSInvokable]
-		public void LoadLastROM(string encoded)
+		void LoadLastROM(string encoded)
 		{
 			RememberROM = encoded != null && encoded.Length > 0;
 			if (RememberROM)

--- a/FF1Blazorizer/Tabs/FileTab.razor
+++ b/FF1Blazorizer/Tabs/FileTab.razor
@@ -84,13 +84,15 @@
 				TrySetFlags(flags.First());
 			}
 
-			await LoadLastROM();
-			StateHasChanged();
+			await JSRuntime.InvokeVoidAsync("getFFRPreferences",
+		                          "file",
+					  DotNetObjectReference.Create(this),
+					  "LoadLastROM");
 		}
 
-		async Task LoadLastROM()
+		[JSInvokable]
+		public void LoadLastROM(string encoded)
 		{
-			string encoded = await LocalStorage.GetItemAsync<string>("file");
 			RememberROM = encoded != null && encoded.Length > 0;
 			if (RememberROM)
 			{
@@ -108,7 +110,9 @@
 
 			if (RememberROM)
 			{
-				await LocalStorage.SetItemAsync("file", encoded);
+				await JSRuntime.InvokeVoidAsync("setFFRPreferences",
+		                          "file",
+		                          encoded);
 			}
 		}
 

--- a/FF1Blazorizer/Tabs/FunTab.razor
+++ b/FF1Blazorizer/Tabs/FunTab.razor
@@ -36,13 +36,10 @@
 	[Parameter] public Action<string, MouseEventArgs> UpdateToolTipID { get; set; }
 	[Parameter] public Action<string> SetStatusMessage { get; set; }
 
-	protected override void OnInitialized()
+	protected override async void OnInitialized()
 	{
 		Flags.Preferences = new Preferences();
-		JSRuntime.InvokeVoidAsync("getFFRPreferences",
-		                          "preferences",
-					  DotNetObjectReference.Create(this),
-		                          "LoadPreferences");
+		await LoadPreferences();
 	}
 
 	void SavePreferences()
@@ -52,10 +49,9 @@
 		SetStatusMessage.Invoke("Preferences saved.");
 	}
 
-	[JSInvokable]
-	public void LoadPreferences(string prefs) {
-	        if (prefs == null || prefs == "") return;
-
+	async Task LoadPreferences() {
+		string prefs = await JSRuntime.InvokeAsync<string>("getFFRPreferences", "preferences");
+		if (prefs == "" || prefs == null) return;
 		Flags.Preferences = JsonSerializer.Deserialize<FF1Lib.Preferences>(prefs);
 		if (Flags.Preferences.SpriteSheet != null) {
 		  SpriteSheetMessage = "Using custom sprites.";

--- a/FF1Blazorizer/Tabs/FunTab.razor
+++ b/FF1Blazorizer/Tabs/FunTab.razor
@@ -1,5 +1,6 @@
 ﻿@using FF1Lib;
-@using System.Text.Json;
+@using Newtonsoft.Json;
+@using System.Reflection;
 @inject Blazored.LocalStorage.ILocalStorageService LocalStorage
 @inject IJSRuntime JSRuntime
 
@@ -42,17 +43,34 @@
 		await LoadPreferences();
 	}
 
-	void SavePreferences()
+	async Task SavePreferences()
 	{
-	        string jsonprefs = JsonSerializer.Serialize(Flags.Preferences);
-		JSRuntime.InvokeVoidAsync("setFFRPreferences", "preferences", jsonprefs);
+	        // For forwards compatability, load the existing preferences, then copy the new preferences on top.
+		// This ensures that new keys introduced in future versions don't get lost.
+
+                string prefs = await JSRuntime.InvokeAsync<string>("getFFRPreferences", "preferences");
+		Dictionary<string, object> existingPrefs;
+		if (prefs == "" || prefs == null) {
+		  existingPrefs = new Dictionary<string, object>();
+		} else {
+                  existingPrefs = JsonConvert.DeserializeObject<Dictionary<string, object>>(prefs);
+		}
+		var properties = typeof(FF1Lib.Preferences).GetProperties(BindingFlags.Instance | BindingFlags.Public);
+		foreach (var pi in properties) {
+                  existingPrefs[pi.Name] = pi.GetValue(Flags.Preferences);
+		}
+	        string jsonprefs = JsonConvert.SerializeObject(existingPrefs);
+		await JSRuntime.InvokeVoidAsync("setFFRPreferences", "preferences", jsonprefs);
 		SetStatusMessage.Invoke("Preferences saved.");
 	}
 
 	async Task LoadPreferences() {
 		string prefs = await JSRuntime.InvokeAsync<string>("getFFRPreferences", "preferences");
 		if (prefs == "" || prefs == null) return;
-		Flags.Preferences = JsonSerializer.Deserialize<FF1Lib.Preferences>(prefs);
+		Flags.Preferences = JsonConvert.DeserializeObject<FF1Lib.Preferences>(prefs, new JsonSerializerSettings
+		    {
+		            Error = (se, ev) => { ev.ErrorContext.Handled = true; }
+	            });
 		if (Flags.Preferences.SpriteSheet != null) {
 		  SpriteSheetMessage = "Using custom sprites.";
 		}

--- a/FF1Blazorizer/Tabs/FunTab.razor
+++ b/FF1Blazorizer/Tabs/FunTab.razor
@@ -1,4 +1,5 @@
 ﻿@using FF1Lib;
+@using System.Text.Json;
 @inject Blazored.LocalStorage.ILocalStorageService LocalStorage
 @inject IJSRuntime JSRuntime
 
@@ -35,32 +36,46 @@
 	[Parameter] public Action<string, MouseEventArgs> UpdateToolTipID { get; set; }
 	[Parameter] public Action<string> SetStatusMessage { get; set; }
 
-	protected override async void OnInitialized()
+	protected override void OnInitialized()
 	{
-		Flags.Preferences = await LocalStorage.GetItemAsync<Preferences>("preferences") ?? new Preferences();
-		if (Flags.Preferences.SpriteSheet != null) {
-		  SpriteSheetMessage = "Using custom sprites.";
-		}
+		Flags.Preferences = new Preferences();
+		JSRuntime.InvokeVoidAsync("getFFRPreferences",
+		                          "preferences",
+					  DotNetObjectReference.Create(this),
+		                          "LoadPreferences");
 	}
 
-	async Task SavePreferences()
+	void SavePreferences()
 	{
-		await LocalStorage.SetItemAsync("preferences", Flags.Preferences);
+	        string jsonprefs = JsonSerializer.Serialize(Flags.Preferences);
+		JSRuntime.InvokeVoidAsync("setFFRPreferences", "preferences", jsonprefs);
 		SetStatusMessage.Invoke("Preferences saved.");
 	}
 
-	private string SpriteSheetMessage = "Load custom player sprites:";
+	[JSInvokable]
+	public void LoadPreferences(string prefs) {
+	        if (prefs == null || prefs == "") return;
 
-		async Task OnSpriteSheetChanged(ChangeEventArgs e)
-		{
-		      Console.WriteLine("OnSpriteSheetChanged");
-	              Flags.SpriteSheet = await JSRuntime.InvokeAsync<string>("handleFileSelect", "spriteSheetInput");
-		      SpriteSheetMessage = "Using custom sprites.";
+		Flags.Preferences = JsonSerializer.Deserialize<FF1Lib.Preferences>(prefs);
+		if (Flags.Preferences.SpriteSheet != null) {
+		  SpriteSheetMessage = "Using custom sprites.";
 		}
+		StateHasChanged();
+	}
 
-		void ClearCustomSprites() {
-		     Flags.SpriteSheet = null;
-		     SpriteSheetMessage = "Load custom player sprites:";
-		}
+	private string SpriteSheetMessage { get; set; } = "Load custom player sprites:";
 
+	async Task OnSpriteSheetChanged(ChangeEventArgs e)
+	{
+		Console.WriteLine("OnSpriteSheetChanged");
+		Flags.SpriteSheet = await JSRuntime.InvokeAsync<string>("handleFileSelect", "spriteSheetInput");
+		SpriteSheetMessage = "Using custom sprites.";
+		StateHasChanged();
+	}
+
+	void ClearCustomSprites() {
+	     Flags.SpriteSheet = null;
+	     SpriteSheetMessage = "Load custom player sprites:";
+	     StateHasChanged();
+	}
 }

--- a/FF1Blazorizer/wwwroot/_headers
+++ b/FF1Blazorizer/wwwroot/_headers
@@ -1,0 +1,3 @@
+/*
+  Access-Control-Allow-Origin: "*"
+  Access-Control-Allow-Methods: "GET"

--- a/FF1Blazorizer/wwwroot/index.html
+++ b/FF1Blazorizer/wwwroot/index.html
@@ -53,6 +53,6 @@
     <!-- This iframe is a hidden stub page that we will interact with to store preferences at
          a single domain, to avoid having separate preferences/saved ROM/presets on every
          instanced site version.  Where we load this from determines that domain. -->
-    <iframe src="https://beta.finalfantasyrandomizer.com/preferences.html" height="0" width="0"></iframe>
+    <iframe src="https://beta.finalfantasyrandomizer.com/preferences.html" height="0" width="0" id="preferences-iframe"></iframe>
 </body>
 </html>

--- a/FF1Blazorizer/wwwroot/index.html
+++ b/FF1Blazorizer/wwwroot/index.html
@@ -53,6 +53,6 @@
     <!-- This iframe is a hidden stub page that we will interact with to store preferences at
          a single domain, to avoid having separate preferences/saved ROM/presets on every
          instanced site version.  Where we load this from determines that domain. -->
-    <iframe src="preferences.html" height="0" width="0"></iframe>
+    <iframe src="https://beta.finalfantasyrandomizer.com/preferences.html" height="0" width="0"></iframe>
 </body>
 </html>

--- a/FF1Blazorizer/wwwroot/index.html
+++ b/FF1Blazorizer/wwwroot/index.html
@@ -49,5 +49,10 @@
     </app>
     <script src="_framework/blazor.webassembly.js" autostart="false"></script>
     <script src="js/site.js"></script>
+
+    <!-- This iframe is a hidden stub page that we will interact with to store preferences at
+         a single domain, to avoid having separate preferences/saved ROM/presets on every
+         instanced site version.  Where we load this from determines that domain. -->
+    <iframe src="preferences.html" height="0" width="0"></iframe>
 </body>
 </html>

--- a/FF1Blazorizer/wwwroot/index.redirect.html
+++ b/FF1Blazorizer/wwwroot/index.redirect.html
@@ -48,6 +48,18 @@
             <p>Hold RESET while you turn POWER off!!</p>
             <p>&nbsp;</p>
             <p><a href="https://VERSION.finalfantasyrandomizer.com/">Go to the latest version of the site</a></p>
+
+	    <script>
+	    // Past versions of the site's front page installed a
+	    // service worker that would return cached versions of the
+	    // app.  This causes all kinds of caching issues, we need
+	    // to make sure to uninstall it.
+            navigator.serviceWorker.getRegistrations().then(function(registrations) {
+              for(let registration of registrations) {
+                registration.unregister()
+              }
+	    })
+	    </script>
         </div>
     </app>
 </body>

--- a/FF1Blazorizer/wwwroot/index.redirect.html
+++ b/FF1Blazorizer/wwwroot/index.redirect.html
@@ -52,8 +52,9 @@
 	    <script>
 	    // Past versions of the site's front page installed a
 	    // service worker that would return cached versions of the
-	    // app.  This causes all kinds of caching issues, we need
-	    // to make sure to uninstall it.
+	    // app.  This causes all kinds of issues with loading
+	    // stale versions of the app now that the main page isn't
+	    // the real site, we need to make sure to uninstall it.
             navigator.serviceWorker.getRegistrations().then(function(registrations) {
               for(let registration of registrations) {
                 registration.unregister()

--- a/FF1Blazorizer/wwwroot/js/prefframe.js
+++ b/FF1Blazorizer/wwwroot/js/prefframe.js
@@ -1,0 +1,19 @@
+window.onmessage = function(e) {
+    /*if (e.origin !== "http://example.com") {
+        return;
+    }*/
+    var payload = JSON.parse(e.data);
+    switch(payload.method) {
+        case 'set':
+            localStorage.setItem(payload.key, JSON.stringify(payload.data));
+            break;
+        case 'get':
+            var parent = window.parent;
+            var data = localStorage.getItem(payload.key);
+            parent.postMessage(JSON.stringify({key: payload.key, data: data}), "*");
+            break;
+        case 'remove':
+            localStorage.removeItem(payload.key);
+            break;
+    }
+};

--- a/FF1Blazorizer/wwwroot/js/prefframe.js
+++ b/FF1Blazorizer/wwwroot/js/prefframe.js
@@ -4,8 +4,12 @@ window.onmessage = function(e) {
     }*/
     var payload = JSON.parse(e.data);
     switch(payload.method) {
-        case 'set':
+    case 'set':
+        if (typeof payload.data === 'string') {
+            localStorage.setItem(payload.key, payload.data);
+        } else {
             localStorage.setItem(payload.key, JSON.stringify(payload.data));
+        }
             break;
         case 'get':
             var parent = window.parent;

--- a/FF1Blazorizer/wwwroot/js/prefframe.js
+++ b/FF1Blazorizer/wwwroot/js/prefframe.js
@@ -1,7 +1,4 @@
 window.onmessage = function(e) {
-    /*if (e.origin !== "http://example.com") {
-        return;
-    }*/
     var payload = JSON.parse(e.data);
     switch(payload.method) {
     case 'set':

--- a/FF1Blazorizer/wwwroot/js/site.js
+++ b/FF1Blazorizer/wwwroot/js/site.js
@@ -1,168 +1,215 @@
 ﻿function handleFileSelect(inputId) {
-	const input = document.getElementById(inputId);
-	const file = input.files[0];
-	const reader = new FileReader();
+        const input = document.getElementById(inputId);
+        const file = input.files[0];
+        const reader = new FileReader();
 
-	return new Promise((resolve, reject) => {
-		reader.onload = e => {
-			const encoded = e.target.result.split(',')[1];
-			resolve(encoded);
-		};
-		reader.onerror = () => {
-			reader.abort();
-			reject(new DOMException("Error reading file"));
-		};
-		reader.readAsDataURL(file);
-	});
+        return new Promise((resolve, reject) => {
+                reader.onload = e => {
+                        const encoded = e.target.result.split(',')[1];
+                        resolve(encoded);
+                };
+                reader.onerror = () => {
+                        reader.abort();
+                        reject(new DOMException("Error reading file"));
+                };
+                reader.readAsDataURL(file);
+        });
 }
 
 function handlePresetSelect(inputId) {
-	const input = document.getElementById(inputId);
-	const file = input.files[0];
-	const reader = new FileReader();
+        const input = document.getElementById(inputId);
+        const file = input.files[0];
+        const reader = new FileReader();
 
-	return new Promise((resolve, reject) => {
-		reader.onload = e => {
-			document.querySelector('#presetNameInput').value = JSON.parse(e.target.result).Name;
-			resolve(e.target.result);
-			input.value = null;
-		};
-		reader.onerror = () => {
-			reader.abort();
-			reject(new DOMException("Error reading file"));
-			input.value = null;
-		};
-		reader.readAsText(file);
-	});
+        return new Promise((resolve, reject) => {
+                reader.onload = e => {
+                        document.querySelector('#presetNameInput').value = JSON.parse(e.target.result).Name;
+                        resolve(e.target.result);
+                        input.value = null;
+                };
+                reader.onerror = () => {
+                        reader.abort();
+                        reject(new DOMException("Error reading file"));
+                        input.value = null;
+                };
+                reader.readAsText(file);
+        });
 }
 
 async function storePreset(name, json) {
-	let presets;
-	try {
-		presets = JSON.parse(localStorage.getItem('presets')) ?? {};
-	} catch {
-		presets = {};
-	}
-	presets[name] = json;
-	localStorage.setItem('presets', JSON.stringify(presets));
+        let presets;
+        try {
+                presets = JSON.parse(localStorage.getItem('presets')) ?? {};
+        } catch {
+                presets = {};
+        }
+        presets[name] = json;
+        localStorage.setItem('presets', JSON.stringify(presets));
 }
 
 async function listLocalPresets() {
-	let presets;
-	try {
-		presets = JSON.parse(localStorage.getItem('presets')) ?? {};
-	} catch {
-		presets = {};
-	}
+        let presets;
+        try {
+                presets = JSON.parse(localStorage.getItem('presets')) ?? {};
+        } catch {
+                presets = {};
+        }
 
-	return Object.keys(presets);
+        return Object.keys(presets);
 }
 
 async function loadLocalPreset(preset) {
-	document.querySelector('#presetNameInput').value = preset;
-	return JSON.parse(localStorage.getItem('presets'))[preset];
+        document.querySelector('#presetNameInput').value = preset;
+        return JSON.parse(localStorage.getItem('presets'))[preset];
 }
 
 async function deleteLocalPreset(preset) {
-	try {
-		const presets = JSON.parse(localStorage.getItem('presets'));
-		delete presets[preset];
-		localStorage.setItem('presets', JSON.stringify(presets));
-	} catch {
-	}
+        try {
+                const presets = JSON.parse(localStorage.getItem('presets'));
+                delete presets[preset];
+                localStorage.setItem('presets', JSON.stringify(presets));
+        } catch {
+        }
 }
 
 async function computePreset(preset) {
-	const result = await fetch('presets/' + preset + '.json');
-	const overrides = await result.json();
+        const result = await fetch('presets/' + preset + '.json');
+        const overrides = await result.json();
 
-	if (preset !== 'default') {
-		const defaultResult = await fetch('presets/default.json');
-		const basic = await defaultResult.json();
-		overrides.Flags = Object.assign(basic.Flags, overrides.Flags);
-	}
-	document.querySelector('#presetNameInput').value = overrides.Name;
-	return JSON.stringify(overrides);
+        if (preset !== 'default') {
+                const defaultResult = await fetch('presets/default.json');
+                const basic = await defaultResult.json();
+                overrides.Flags = Object.assign(basic.Flags, overrides.Flags);
+        }
+        document.querySelector('#presetNameInput').value = overrides.Name;
+        return JSON.stringify(overrides);
 }
 
 async function downloadFile(filename, encoded) {
-	const url = "data:application/octet-stream;base64," + encoded;
-	const result = await fetch(url);
-	const blob = await result.blob();
+        const url = "data:application/octet-stream;base64," + encoded;
+        const result = await fetch(url);
+        const blob = await result.blob();
 
-	const anchor = document.createElement('a');
-	anchor.download = filename;
-	anchor.href = window.URL.createObjectURL(blob);
-	anchor.dispatchEvent(new MouseEvent('click'));
+        const anchor = document.createElement('a');
+        anchor.download = filename;
+        anchor.href = window.URL.createObjectURL(blob);
+        anchor.dispatchEvent(new MouseEvent('click'));
 }
 
 function updateHistory(seedString, flagString) {
-	let href = document.location.href;
-	if (href.indexOf('?') > 0) {
-		href = href.substr(0, href.indexOf('?'));
-	}
+        let href = document.location.href;
+        if (href.indexOf('?') > 0) {
+                href = href.substr(0, href.indexOf('?'));
+        }
 
-	history.replaceState({}, '', href + '?' + 's=' + seedString + '&' + 'f=' + flagString);
+        history.replaceState({}, '', href + '?' + 's=' + seedString + '&' + 'f=' + flagString);
 }
 
 function copyLocation() {
-	const textarea = document.createElement('textarea');
-	textarea.value = location.href;
-	document.body.appendChild(textarea);
-	textarea.select();
-	document.execCommand('copy');
-	document.body.removeChild(textarea);
+        const textarea = document.createElement('textarea');
+        textarea.value = location.href;
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
 }
 
 function getScreenRightEdge() {
-	return window.innerWidth;
+        return window.innerWidth;
 }
 
 let newWorker;
 Blazor.start({}).then(() => {
-	if ('serviceWorker' in navigator) {
-		navigator.serviceWorker.register('/service-worker.js').then(reg => {
-			console.debug('service worker registered');
-			reg.addEventListener('updatefound', () => {
-				console.debug('New update found');
-				newWorker = reg.installing;
-				newWorker.addEventListener('statechange', () => {
-					if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-						console.debug('Showing update notification');
-						DotNet.invokeMethod('FF1Blazorizer', 'ShowUpdateNotification');
-					}
-				});
-			});
-		});
+        if ('serviceWorker' in navigator) {
+                navigator.serviceWorker.register('/service-worker.js').then(reg => {
+                        console.debug('service worker registered');
+                        reg.addEventListener('updatefound', () => {
+                                console.debug('New update found');
+                                newWorker = reg.installing;
+                                newWorker.addEventListener('statechange', () => {
+                                        if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+                                                console.debug('Showing update notification');
+                                                DotNet.invokeMethod('FF1Blazorizer', 'ShowUpdateNotification');
+                                        }
+                                });
+                        });
+                });
 
-		let refreshing;
-		navigator.serviceWorker.addEventListener('controllerchange', function () {
-			if (refreshing) return;
-			window.location.reload();
-			refreshing = true;
-		});
-	}
+                let refreshing;
+                navigator.serviceWorker.addEventListener('controllerchange', function () {
+                        if (refreshing) return;
+                        window.location.reload();
+                        refreshing = true;
+                });
+        }
 })
 
 
 /**
- * Call from Blazor to register the new service worker 
+ * Call from Blazor to register the new service worker
  */
 function updateServiceWorkerNow() {
-	if (newWorker) {
-		newWorker.postMessage({ action: 'skipWaiting' });
-	} else {
-		window.location.reload();
-	}
+        if (newWorker) {
+                newWorker.postMessage({ action: 'skipWaiting' });
+        } else {
+                window.location.reload();
+        }
 }
 
 let pwa;
-window.addEventListener('beforeinstallprompt', (e) => {	
-	e.preventDefault();
-	pwa = e;
+window.addEventListener('beforeinstallprompt', (e) => { 
+        e.preventDefault();
+        pwa = e;
 });
 
 function showPWAInstall() {
-	pwa?.prompt();
-	pwa = null;
+        pwa?.prompt();
+        pwa = null;
 }
+
+window.FFRPreferencesCallbacks = {};
+window.onmessage = function(e) {
+    //if (e.origin != "http://other.example.com") {
+    //    return;
+    //}
+    var response = JSON.parse(e.data);
+    if (window.FFRPreferencesCallbacks[response.key]) {
+        if (response.data[0] == '"') {
+            window.FFRPreferencesCallbacks[response.key](JSON.parse(response.data));
+        } else {
+            window.FFRPreferencesCallbacks[response.key](response.data);
+        }
+    }
+};
+
+function setFFRPreferences(keyname, prefdata) {
+    var iframe = document.getElementsByTagName('iframe')[0];
+    var win;
+    // some browser (don't remember which one) throw exception when you try to access
+    // contentWindow for the first time, it work when you do that second time
+    try {
+        win = iframe.contentWindow;
+    } catch(e) {
+        win = iframe.contentWindow;
+    }
+    // save obj in subdomain localStorage
+    win.postMessage(JSON.stringify({key: keyname, method: "set", data: prefdata}), "*");
+};
+
+function getFFRPreferences(keyname, obj, callback) {
+    var iframe = document.getElementsByTagName('iframe')[0];
+    var win;
+    // some browser (don't remember which one) throw exception when you try to access
+    // contentWindow for the first time, it work when you do that second time
+    try {
+        win = iframe.contentWindow;
+    } catch(e) {
+        win = iframe.contentWindow;
+    }
+    window.FFRPreferencesCallbacks[keyname] = function(data) {
+        obj.invokeMethodAsync(callback, data);
+    }
+    // save obj in subdomain localStorage
+    // fetch previously saved data
+    win.postMessage(JSON.stringify({key: keyname, method: "get"}), "*");
+};

--- a/FF1Blazorizer/wwwroot/js/site.js
+++ b/FF1Blazorizer/wwwroot/js/site.js
@@ -163,7 +163,7 @@ function showPWAInstall() {
         pwa = null;
 }
 
-function setFFRPreferences(keyname, prefdata) {
+async function setFFRPreferences(keyname, prefdata) {
     var iframe = document.getElementsByTagName('iframe')[0];
     var win;
     // some browser (don't remember which one) throw exception when you try to access
@@ -175,13 +175,11 @@ function setFFRPreferences(keyname, prefdata) {
     }
     // save obj in subdomain localStorage
     win.postMessage(JSON.stringify({key: keyname, method: "set", data: prefdata}), "*");
+    return Promise.resolve();
 };
 
 window.FFRPreferencesCallbacks = {};
 window.onmessage = function(e) {
-    //if (e.origin != "http://other.example.com") {
-    //    return;
-    //}
     var response = JSON.parse(e.data);
     if (window.FFRPreferencesCallbacks[response.key]) {
         var resolve = window.FFRPreferencesCallbacks[response.key];
@@ -190,7 +188,7 @@ window.onmessage = function(e) {
 };
 
 async function getFFRPreferences(keyname) {
-    var iframe = document.getElementsByTagName('iframe')[0];
+    var iframe = document.getElementById('preferences-iframe');
     var win;
     // some browser (don't remember which one) throw exception when you try to access
     // contentWindow for the first time, it work when you do that second time

--- a/FF1Blazorizer/wwwroot/preferences.html
+++ b/FF1Blazorizer/wwwroot/preferences.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <script src="js/prefframe.js"></script>
+  </head>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
Workaround for the issue that every instanced site has its own separate local storage, and thus its own separate preferences.

Uses an iframe to load a stub page at a single domain which can then save and load key-value data.  The domain where preferences get stored is determined by where the iframe is loaded from.

done: preferences and the ROM data

todo: convert presets to this scheme.