### PR TITLE
Added an option for spellcaster's spell charges to restored on max mp up.

### DIFF
--- a/FF1Blazorizer/Tabs/ClassesTab.razor
+++ b/FF1Blazorizer/Tabs/ClassesTab.razor
@@ -42,6 +42,7 @@
 </div>
 <div class="col2">
 	<h4>Magic Charges</h4>
+	<EnumDropDown UpdateToolTip="@UpdateToolTipID" Id="MpGainOnMaxGainModeDropDown" TItem="MpGainOnMaxGain" @bind-Value="Flags.MpGainOnMaxGainMode">Mp Charges Restore On New Max Mp:</EnumDropDown>
 	<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="ChangeMaxMP" @bind-Value="@Flags.ChangeMaxMP">Max MP</TriStateCheckBox>
 	<IntSlider Indent Min="1" Max="9" Step="1" DisableTooltip UpdateToolTip="@UpdateToolTipID" IsEnabled="@Flags.ChangeMaxMP" Id="RedMageMaxMP" @bind-Value="@Flags.RedMageMaxMP">Red Mage Max MP:</IntSlider>
 	<IntSlider Indent Min="1" Max="9" Step="1" DisableTooltip UpdateToolTip="@UpdateToolTipID" IsEnabled="@Flags.ChangeMaxMP" Id="WhiteMageMaxMP" @bind-Value="@Flags.WhiteMageMaxMP">White Mage Max MP:</IntSlider>

--- a/FF1Blazorizer/wwwroot/tooltips/tooltips.json
+++ b/FF1Blazorizer/wwwroot/tooltips/tooltips.json
@@ -1591,7 +1591,12 @@
 		"screenshot": "RPSpoilers.png",
 		"description": "The names of the various classes with be changed to show what classes they will become after promotions.\nFormat: Current Class - Promotion Class"
 	},
-
+	{
+		"Id": "MpGainOnMaxGainModeDropDown",
+		"title": "Gain Spell Charges With Max MP Gain",
+		"screenshot": null,
+		"description": "When a character gains Max MP, they also gain a current MP in that spell slot. \n\nThis can be enabled for all classes, only for classes once they promote, or only for classes that receive the 'Max+MP+' class blessing (which will only show up when this option is set to blessed classes)."
+	},
 	{
 		"Id": "ChangeMaxMP",
 		"title": "Change Spellcaster Max MP",
@@ -1604,9 +1609,6 @@
 		"screenshot": "AllSpellLevelsForKnightNinja.png",
 		"description": "Sets the Knight and Ninja magic charge growth to give a charge in all levels whenever those classes gain a charge in any level, giving Knight and Ninja tier 4-8 charges. This alleviates an issue with \"Keep Permissions\" where the Knight and Ninja could never cast spells they could learn, but is useless otherwise."
 	},
-
-
-
 	{
 		"Id": "startingEquipmentHealStaff",
 		"title": "Starting Equipment - Heal Staff",

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -1100,6 +1100,7 @@ namespace FF1Lib
 			SetupClassAltXp();
 
 			ClassData.SetMPMax(flags);
+			ClassData.SetMpGainOnMaxGain(flags, this);
 			ClassData.RaiseThiefHitRate(flags);
 			ClassData.BuffThiefAGI(flags);
 			ClassData.Randomize(flags, rng, oldItemNames, ItemsText, this);

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -648,6 +648,8 @@ namespace FF1Lib
 		[IntegerFlag(0, 9)]
 		public int NinjaMaxMP { get; set; } = 4;
 
+		public MpGainOnMaxGain MpGainOnMaxGainMode { get; set; } = MpGainOnMaxGain.None;
+
 		public LockHitMode LockMode { get; set; } = LockHitMode.Vanilla;
 
 		public MDEFGrowthMode MDefMode { get; set; } = MDEFGrowthMode.None;

--- a/FF1Lib/FlagsViewModel.cs
+++ b/FF1Lib/FlagsViewModel.cs
@@ -3940,6 +3940,16 @@ namespace FF1Lib
 			}
 		}
 
+		public MpGainOnMaxGain MpGainOnMaxGainMode
+		{
+			get => Flags.MpGainOnMaxGainMode;
+			set
+			{
+				Flags.MpGainOnMaxGainMode = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("MpGainOnMaxGainMode"));
+			}
+		}
+
 		public LockHitMode LockMode
 		{
 			get => Flags.LockMode;

--- a/FF1Lib/asm/1B_9830_LevelUp_MPUp.asm
+++ b/FF1Lib/asm/1B_9830_LevelUp_MPUp.asm
@@ -1,0 +1,80 @@
+﻿;when enabled this is used instead of 1B_8818_LevlUp_levelUp.asm a jump is made from inside the level up function at 88d7 to here.
+
+levindex = $6BAD       ; local, stores the index to level up stats
+lvlupptr = $82         ; local, pointer to level up data
+classid  = $688E 
+lvlup_chmagic       = $84 
+lvlup_chstats       = $86 
+
+unsram          = $6000 
+ch_stats        = unsram + $0100
+ch_level	= ch_stats + $26
+ch_magicdata    = unsram + $0300  ; must be on page bound
+ch_spells       = ch_magicdata
+ch_mp           = ch_magicdata + $20
+ch_curmp        = ch_mp + $00
+ch_maxmp        = ch_mp + $08
+
+SkipMPGain = $891C
+lut_MaxMP = $8902
+
+.ORG $88D7
+JMP LevelUpMagicCurMP
+ 
+.ORG $9830
+lut_EnableMpUpOnMaxGain:
+.byte $01, $01, $01, $01, $01, $01, $01, $01, $01, $01, $01, $01 
+
+LevelUpMagicCurMP:
+  LDX classid                    
+  LDY #$01
+  LDA (lvlupptr), Y              ; get leveldata[1] byte (MP gains)
+  LDY #ch_maxmp - ch_magicdata   ; set Y to index map MP
+MagicLoop:  
+  PHA                            ; Push level data on the stack
+  LDA (lvlup_chmagic), Y         ;  and get current slot MP
+  CMP lut_MaxMP, X               ; Check if we're at max MP
+  BCC NotMaxMP                   
+  PLA                            ; If we are, get level data from stack 
+  LSR                            ;  and check next slot
+  JMP SkipMP                      
+NotMaxMP:
+  PLA                            ; If we're not, get level data back
+  LSR                            ;  and see if we're gaining MP
+  BCC SkipMP                     
+  PHA                            ; Push level data (again)
+
+  ;Increase Max MP
+  LDA (lvlup_chmagic), Y         
+  CLC
+  ADC #$01
+  STA (lvlup_chmagic), Y
+
+  ;Increase Current MP if this class is on the list
+  LDA lut_EnableMpUpOnMaxGain, X
+  BEQ SkipCurrentMpGain
+
+  ;Increase current MP for this level by 1, the data is at pointer -8
+  ;push the counter/pointer
+  TYA
+  PHA 
+  SEC
+  SBC #$08
+  TAY
+
+  LDA (lvlup_chmagic), Y         
+  CLC
+  ADC #$01
+  STA (lvlup_chmagic), Y
+
+  ;restore the counter/pointer
+  PLA 
+  TAY 
+SkipCurrentMpGain:
+  PLA
+SkipMP:
+  INY                               ; INY to look at next spell level
+  CPY #ch_maxmp - ch_magicdata + 8  ; loop for all 8 bits (and all 8 spell levels)
+  BNE MagicLoop
+  JMP SkipMPGain
+


### PR DESCRIPTION
Lets the user restore charges from leveling up. When they get a max mp in a spell level, they will also get a current mp in that same spell level.

They also have the option of having it enabled for all classes, only promoted classes, or as a class blessing.