### PR TITLE
Remove Chaos floor from chest relocation

### DIFF
--- a/FF1Lib/Maps.cs
+++ b/FF1Lib/Maps.cs
@@ -1891,8 +1891,7 @@ namespace FF1Lib
 			    MapId.TempleOfFiendsRevisitedEarth,
 			    MapId.TempleOfFiendsRevisitedFire,
 			    MapId.TempleOfFiendsRevisitedWater,
-			    MapId.TempleOfFiendsRevisitedAir,
-			    MapId.TempleOfFiendsRevisitedChaos }, // ToFR
+			    MapId.TempleOfFiendsRevisitedAir }, // ToFR
 
 			// new MapId[] { MapId.TitansTunnel }, // Titan
 		    };


### PR DESCRIPTION
Nothing can fit there normally, and it breaks short ToFR