### PR TITLE
Legendary Shops: Replace PURE/SOFT w/ XFER/HEL2; fix Spellcrafter pool bug; add tooltips

### DIFF
--- a/FF1Blazorizer/Tabs/ShopsTab.razor
+++ b/FF1Blazorizer/Tabs/ShopsTab.razor
@@ -24,10 +24,10 @@
       <TriStateCheckBox DisableTooltip Id="legendaryArmorShopCheckBox" @bind-Value="Flags.LegendaryArmorShop">Legendary Armor Shop</TriStateCheckBox>
       <CheckBox Indent DisableTooltip Id="exlegendaryArmorShopCheckBox" IsEnabled="Flags.LegendaryArmorShop" @bind-Value="Flags.ExclusiveLegendaryArmorShop">Exclusive</CheckBox>
 
-	    <TriStateCheckBox DisableTooltip Id="legendaryBlackShopCheckBox" @bind-Value="Flags.LegendaryBlackShop">Legendary Black Shop</TriStateCheckBox>
+	    <TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="legendaryBlackShopCheckBox" @bind-Value="Flags.LegendaryBlackShop">Legendary Black Shop</TriStateCheckBox>
 	    <CheckBox Indent DisableTooltip Id="exlegendaryBlackShopCheckBox" IsEnabled="Flags.LegendaryBlackShop" @bind-Value="Flags.ExclusiveLegendaryBlackShop">Exclusive</CheckBox>
 
-	    <TriStateCheckBox DisableTooltip Id="legendaryWhiteShopCheckBox" @bind-Value="Flags.LegendaryWhiteShop">Legendary White Shop</TriStateCheckBox>
+	    <TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="legendaryWhiteShopCheckBox" @bind-Value="Flags.LegendaryWhiteShop">Legendary White Shop</TriStateCheckBox>
 	    <CheckBox Indent DisableTooltip Id="exlegendaryWhiteShopCheckBox" IsEnabled="Flags.LegendaryWhiteShop" @bind-Value="Flags.ExclusiveLegendaryWhiteShop">Exclusive</CheckBox>
 
 	    <TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="legendaryItemShopCheckBox" @bind-Value="Flags.LegendaryItemShop">Legendary Item Shop</TriStateCheckBox>
@@ -46,7 +46,7 @@
 			<h4>Balance</h4>
 			<CheckBox UpdateToolTip="@UpdateToolTipID" Id="cureHealBuffCheckBox" @bind-Value="Flags.BuffHealingSpells">Improve CUREs, HEALs, LAMP, AMUT spells</CheckBox>
 			<CheckBox UpdateToolTip="@UpdateToolTipID" Id="tier1DamageBuff" @bind-Value="Flags.BuffTier1DamageSpells">Improve FIRE, LIT, ICE, HARM spells</CheckBox>
-			<EnumDropDown UpdateToolTip="@UpdateToolTipID" Id="LockMode" TItem="LockHitMode" @bind-Value="Flags.LockMode">LOCK and LOK2 Mode:</EnumDropDown>
+			<EnumDropDown UpdateToolTip="@UpdateToolTipID" Id="LockMode" TItem="LockHitMode" @bind-Value="Flags.LockMode">LOCK & LOK2 Mode:</EnumDropDown>
 			<EnumDropDown UpdateToolTip="@UpdateToolTipID" Id="magicAutohitThresholdDropDown" TItem="AutohitThreshold" @bind-Value="Flags.MagicAutohitThreshold">Power Word Threshold:</EnumDropDown>
 			<CheckBox UpdateToolTip="@UpdateToolTipID" Id="enableSoftInBattle" @bind-Value="Flags.EnableSoftInBattle">Enable Soft in Battle</CheckBox>
 			<CheckBox UpdateToolTip="@UpdateToolTipID" Id="enableLifeInBattle" @bind-Value="Flags.EnableLifeInBattle">Enable Life in Battle</CheckBox>

--- a/FF1Blazorizer/wwwroot/tooltips/tooltips.json
+++ b/FF1Blazorizer/wwwroot/tooltips/tooltips.json
@@ -1121,6 +1121,18 @@
 		"description": "Creates up to five legendary shops in dungeons, one of each type. Shops will tend to have high-tier gear (which will often include things you cannot normally find in shops) or highly desirable spells.\nThe potential locations are: Earth Cave B2, Marsh Cave B2, Dwarves' Cave, Mirage Tower F1, Ice Cave B1, & Left Sea Shrine 2.\n\"Exclusive\" means that it will also remove any items/spells found in the Legendary Shop from all other shops and treasure chests in the world."
 	},
 	{
+		"Id": "legendaryBlackShopCheckBox",
+		"title": "Legendary Black Magic Shop",
+		"screenshot": null,
+		"description": "Randomly selects 5 strong spells. Compatible with Spell Crafter.\nThe pool for vanilla spells is: FIR2, LIT2, ICE2, FIR3, LIT3, ICE3, NUKE, BRAK, BANE, QAKE, ZAP!, XXXX, LOCK, LOK2, TMPR, SABR, FAST, WARP. If \"LOCK & LOK2 Mode\" is only set to Vanilla or 107 Accuracy, LOCK & LOK2 are removed from the pool."
+	},
+	{
+		"Id": "legendaryWhiteShopCheckBox",
+		"title": "Legendary White Magic Shop",
+		"screenshot": null,
+		"description": "Randomly selects 4 strong spells. Compatible with Spell Crafter.\nThe pool for vanilla spells is: CUR3, CUR4, HEL2, HEL3, LIFE, LIF2, HRM3, HRM4, FADE, RUSE, INVS, INV2, EXIT, WALL, XFER. When Exclusive Legendary White Magic Shops and Exclusive Legendary Item Shops are both present, PURE and SOFT are added to the pool."
+	},
+	{
 		"Id": "legendaryItemShopCheckBox",
 		"title": "Legendary Item Shop",
 		"screenshot": null,

--- a/FF1Lib/LegendaryShops.cs
+++ b/FF1Lib/LegendaryShops.cs
@@ -348,7 +348,13 @@ namespace FF1Lib
 			}
 			else
 			{
-				var spells = new List<Spell> { Spell.LOCK, Spell.TMPR, Spell.FIR2, Spell.LIT2, Spell.LOK2, Spell.FAST, Spell.ICE2, Spell.FIR3, Spell.BANE, Spell.WARP, Spell.LIT3, Spell.QAKE, Spell.ICE3, Spell.BRAK, Spell.SABR, Spell.NUKE, Spell.ZAP, Spell.XXXX };
+				var spells = new List<Spell> { Spell.TMPR, Spell.FIR2, Spell.LIT2, Spell.FAST, Spell.ICE2, Spell.FIR3, Spell.BANE, Spell.WARP, Spell.LIT3, Spell.QAKE, Spell.ICE3, Spell.BRAK, Spell.SABR, Spell.NUKE, Spell.ZAP, Spell.XXXX };
+				// LOCK & LOK2 are included as long as their accuracy is set to high or auto-hit
+				if ((flags.LockMode != LockHitMode.Vanilla) && (flags.LockMode != LockHitMode.Accuracy107)) {
+					spells.Add(Spell.LOCK);
+					spells.Add(Spell.LOK2);
+				}
+
 				var items = spells.Where(s => Spells.ContainsKey(s.ToString().ToLowerInvariant())).Select(s => Convert.ToByte(Spells[s.ToString().ToLowerInvariant()].Index + MagicNamesIndexInItemText)).Cast<Item>().ToList();
 
 				List<Item> result = new List<Item>();

--- a/FF1Lib/LegendaryShops.cs
+++ b/FF1Lib/LegendaryShops.cs
@@ -412,7 +412,7 @@ namespace FF1Lib
 
 			// Only add Soft & Pure if they are otherwise rare/special
 			IEnumerable<byte> specialSpells2 = new List<byte>();
-			if (flags.ExclusiveLegendaryWhiteShop && flags.ExclusiveLegendaryItemShop) {
+			if (flags.ExclusiveLegendaryWhiteShop && flags.ExclusiveLegendaryItemShop && (flags.LegendaryWhiteShop ?? false) && (flags.LegendaryItemShop ?? false)) {
 				specialSpells2 = Spells.Where(s => s.Key.StartsWith("soft"))
 				.Concat(Spells.Where(s => s.Key.StartsWith("sft")))
 				.Concat(Spells.Where(s => s.Key.StartsWith("pure")))
@@ -433,6 +433,7 @@ namespace FF1Lib
 
 			items.Shuffle(rng);
 			result.AddRange(items.Take(slots).Select(i => (Item)Convert.ToByte(i + 0xB0)));
+			//if (result.Contains(items.Take(slots).Select(i => (Item)Convert.ToByte(i + 0xB0)))) { }
 
 			return result;
 		}

--- a/FF1Lib/LegendaryShops.cs
+++ b/FF1Lib/LegendaryShops.cs
@@ -368,6 +368,8 @@ namespace FF1Lib
 
 		private List<Item> GetCraftedSpellInventory(int slots, bool black)
 		{
+			// BUG - Can pull the same spell multiple times, e.g. CUR6 & CUR6
+
 			var stDamSpells = SpellInfos.Where(s => s.routine == 0x01 && s.targeting != 0x01).Where(s => s.tier >= 3).OrderBy(s => -s.tier).Take(3);
 			var aoeDamSpells = SpellInfos.Where(s => s.routine == 0x01 && s.targeting == 0x01).OrderBy(s => -s.tier).Take(6);
 
@@ -399,21 +401,29 @@ namespace FF1Lib
 				.Concat(WordSpells2)
 				.Select(s => Convert.ToByte(SpellInfos.IndexOf(s)));
 
-
 			var specialSpells = Spells.Where(s => s.Key.StartsWith("lif"))
 			.Concat(Spells.Where(s => s.Key.StartsWith("warp")))
 			.Concat(Spells.Where(s => s.Key.StartsWith("wrp")))
 			.Concat(Spells.Where(s => s.Key.StartsWith("exit")))
 			.Concat(Spells.Where(s => s.Key.StartsWith("ext")))
-			.Concat(Spells.Where(s => s.Key.StartsWith("soft")))
-			.Concat(Spells.Where(s => s.Key.StartsWith("sft")))
-			.Concat(Spells.Where(s => s.Key.StartsWith("pure")))
-			.Concat(Spells.Where(s => s.Key.StartsWith("pur")))
+			.Concat(Spells.Where(s => s.Key.StartsWith("xfer")))
+			.Concat(Spells.Where(s => s.Key.StartsWith("xfr")))
 			.Select(s => Convert.ToByte(s.Value.Index));
+
+			// Only add Soft & Pure if they are otherwise rare/special
+			IEnumerable<byte> specialSpells2 = new List<byte>();
+			if (flags.ExclusiveLegendaryWhiteShop && flags.ExclusiveLegendaryItemShop) {
+				specialSpells2 = Spells.Where(s => s.Key.StartsWith("soft"))
+				.Concat(Spells.Where(s => s.Key.StartsWith("sft")))
+				.Concat(Spells.Where(s => s.Key.StartsWith("pure")))
+				.Concat(Spells.Where(s => s.Key.StartsWith("pur")))
+				.Select(s => Convert.ToByte(s.Value.Index));
+			}
 
 
 			var items = spells
 				.Concat(specialSpells)
+				.Concat(specialSpells2)
 				.Where(s => BlackSpell(s) ^ !black)
 				.ToList();
 

--- a/FF1Lib/LegendaryShops.cs
+++ b/FF1Lib/LegendaryShops.cs
@@ -322,7 +322,13 @@ namespace FF1Lib
 			}
 			else
 			{
-				var spells = new List<Spell> { Spell.RUSE, Spell.INVS, Spell.PURE, Spell.CUR3, Spell.LIFE, Spell.HRM3, Spell.SOFT, Spell.EXIT, Spell.INV2, Spell.CUR4, Spell.HRM4, Spell.HEL3, Spell.LIF2, Spell.FADE, Spell.WALL };
+				var spells = new List<Spell> { Spell.RUSE, Spell.INVS, Spell.CUR3, Spell.LIFE, Spell.HRM3, Spell.EXIT, Spell.INV2, Spell.CUR4, Spell.HRM4, Spell.HEL3, Spell.LIF2, Spell.FADE, Spell.WALL, Spell.HEL2, Spell.XFER };
+				// If status restorative effects are set up to be especially rare, lean into that and makes the spells rarer too
+				if (flags.ExclusiveLegendaryWhiteShop && flags.ExclusiveLegendaryItemShop && (flags.LegendaryWhiteShop ?? false) && (flags.LegendaryItemShop ?? false)) {
+					spells.Add(Spell.SOFT);
+					spells.Add(Spell.PURE);
+				}
+
 				var items = spells.Where(s => Spells.ContainsKey(s.ToString().ToLowerInvariant())).Select(s => Convert.ToByte(Spells[s.ToString().ToLowerInvariant()].Index + MagicNamesIndexInItemText)).Cast<Item>().ToList();
 
 				List<Item> result = new List<Item>();

--- a/FF1Lib/LegendaryShops.cs
+++ b/FF1Lib/LegendaryShops.cs
@@ -377,7 +377,7 @@ namespace FF1Lib
 			var aoeHarmSpells = SpellInfos.Where(s => s.routine == 0x02 && s.targeting == 0x01).OrderBy(s => -s.tier).Take(1);
 
 			var stHealSpells = SpellInfos.Where(s => (s.routine == 0x07 || s.routine == 0x0F) && s.targeting != 0x08).OrderBy(s => -s.tier).Take(2);
-			var aoeHealSpells = SpellInfos.Where(s => (s.routine == 0x07 || s.routine == 0x0F) && s.targeting != 0x08).OrderBy(s => -s.tier).Take(2);
+			var aoeHealSpells = SpellInfos.Where(s => (s.routine == 0x07 || s.routine == 0x0F) && s.targeting == 0x08).OrderBy(s => -s.tier).Take(2);
 
 			var WallSpells = SpellInfos.Where(s => s.routine == 0x0A && s.effect == 0xFF).Take(1);
 			var FastSpells = SpellInfos.Where(s => s.routine == 0x0C).OrderBy(s => -s.tier).Take(2);
@@ -406,8 +406,6 @@ namespace FF1Lib
 			.Concat(Spells.Where(s => s.Key.StartsWith("wrp")))
 			.Concat(Spells.Where(s => s.Key.StartsWith("exit")))
 			.Concat(Spells.Where(s => s.Key.StartsWith("ext")))
-			.Concat(Spells.Where(s => s.Key.StartsWith("xfer")))
-			.Concat(Spells.Where(s => s.Key.StartsWith("xfr")))
 			.Select(s => Convert.ToByte(s.Value.Index));
 
 			// Only add Soft & Pure if they are otherwise rare/special

--- a/FF1Lib/LegendaryShops.cs
+++ b/FF1Lib/LegendaryShops.cs
@@ -368,8 +368,6 @@ namespace FF1Lib
 
 		private List<Item> GetCraftedSpellInventory(int slots, bool black)
 		{
-			// BUG - Can pull the same spell multiple times, e.g. CUR6 & CUR6
-
 			var stDamSpells = SpellInfos.Where(s => s.routine == 0x01 && s.targeting != 0x01).Where(s => s.tier >= 3).OrderBy(s => -s.tier).Take(3);
 			var aoeDamSpells = SpellInfos.Where(s => s.routine == 0x01 && s.targeting == 0x01).OrderBy(s => -s.tier).Take(6);
 
@@ -406,6 +404,8 @@ namespace FF1Lib
 			.Concat(Spells.Where(s => s.Key.StartsWith("wrp")))
 			.Concat(Spells.Where(s => s.Key.StartsWith("exit")))
 			.Concat(Spells.Where(s => s.Key.StartsWith("ext")))
+			.Concat(Spells.Where(s => s.Key.StartsWith("xfer")))
+			.Concat(Spells.Where(s => s.Key.StartsWith("xfr")))
 			.Select(s => Convert.ToByte(s.Value.Index));
 
 			// Only add Soft & Pure if they are otherwise rare/special
@@ -431,7 +431,6 @@ namespace FF1Lib
 
 			items.Shuffle(rng);
 			result.AddRange(items.Take(slots).Select(i => (Item)Convert.ToByte(i + 0xB0)));
-			//if (result.Contains(items.Take(slots).Select(i => (Item)Convert.ToByte(i + 0xB0)))) { }
 
 			return result;
 		}


### PR DESCRIPTION
Fix Spellcrafter + Legendary Shop bug that could dupe spells and wasn't pulling HEALs
Remove PURE & SOFT from the normal Legendary Shop pool (they are re-added when White & Item shops are both exclusive)
Add XFER and HEL2 to the pool
Add tooltips for White/Black Legendary Magic Shops explaining vanilla spells available
Made LOCK/LOK2 pool-inclusion dependent on the LOCK Buff flag