### PR TITLE
Tweak Equipment Tiers

### DIFF
--- a/FF1Lib/ItemGenerator.cs
+++ b/FF1Lib/ItemGenerator.cs
@@ -37,11 +37,11 @@ namespace FF1Lib
 		// Type:          Vanilla Count:
 		// Unique (Masa)       1
 		// Legendary Weapon    4
-		// Legendary Armor     9
-		// Rare Weapon        17
-		// Rare Armor         19
-		// Common Weapon      35 - 1 - 4 - 17 = 13
-		// Common Armor       51 - 12 - 16    = 23
+		// Legendary Armor    10
+		// Rare Weapon        18
+		// Rare Armor         18
+		// Common Weapon      35 - 1 - 4 - 18 = 12
+		// Common Armor       51 - 10 - 18    = 23
 		// Weapon          35 / 234        15
 		// Armor           51 / 234        22
 		// Consumable      36 / 234        15

--- a/FF1Lib/ItemGenerator.cs
+++ b/FF1Lib/ItemGenerator.cs
@@ -48,7 +48,7 @@ namespace FF1Lib
 		// Gold           112 / 234        48
 
 		private static readonly List<int>[] RelativeRatios = {
-			new List<int> {  1,  3, 6, 7, 9, -4, -5, -12, -5 },  // High Wealth
+			new List<int> {  1,  3, 7, 7, 9, -4, -5, -13, -5 },  // High Wealth
 			new List<int> {  0,  0, 0, 0, 0,  0,  0,   0,  0 },
 			//new List<int> {  0,  -1, -2, -3, -3, 4, 5, 0,  0 },
 			//new List<int> {  0,  -1, -3, -5, -4, 6, 7, 0,  0 },
@@ -126,7 +126,7 @@ namespace FF1Lib
 
 	public class ShopItemGenerator : IItemGenerator
 	{
-		private static readonly List<int> Ratios = new() { 1, 4, 8, 17, 19, 13, 23, 36, 112 };
+		private static readonly List<int> Ratios = new() { 1, 4, 10, 18, 18, 12, 23, 36, 112 };
 
 		private List<List<Item>> _pool;
 

--- a/FF1Lib/ItemGenerator.cs
+++ b/FF1Lib/ItemGenerator.cs
@@ -37,9 +37,9 @@ namespace FF1Lib
 		// Type:          Vanilla Count:
 		// Unique (Masa)       1
 		// Legendary Weapon    4
-		// Legendary Armor    12
+		// Legendary Armor     9
 		// Rare Weapon        17
-		// Rare Armor         16
+		// Rare Armor         19
 		// Common Weapon      35 - 1 - 4 - 17 = 13
 		// Common Armor       51 - 12 - 16    = 23
 		// Weapon          35 / 234        15

--- a/FF1Lib/ItemGenerator.cs
+++ b/FF1Lib/ItemGenerator.cs
@@ -48,11 +48,11 @@ namespace FF1Lib
 		// Gold           112 / 234        48
 
 		private static readonly List<int>[] RelativeRatios = {
-			new List<int> {  1,  3, 9, 7, 8, -4, -5, -13, -6 },
+			new List<int> {  1,  3, 6, 7, 9, -4, -5, -12, -5 },  // High Wealth
 			new List<int> {  0,  0, 0, 0, 0,  0,  0,   0,  0 },
 			//new List<int> {  0,  -1, -2, -3, -3, 4, 5, 0,  0 },
 			//new List<int> {  0,  -1, -3, -5, -4, 6, 7, 0,  0 },
-			new List<int> {  -1, -2, -4, -5, -4, 14, 14, 0, -12 },
+			new List<int> {  -1, -2, -4, -5, -5, 14, 15, 0, -12 }, //Melmond Wealth
 		};
 
 		private List<List<Item>> _pool;
@@ -126,7 +126,7 @@ namespace FF1Lib
 
 	public class ShopItemGenerator : IItemGenerator
 	{
-		private static readonly List<int> Ratios = new() { 1, 4, 12, 17, 16, 13, 23, 36, 112 };
+		private static readonly List<int> Ratios = new() { 1, 4, 8, 17, 19, 13, 23, 36, 112 };
 
 		private List<List<Item>> _pool;
 

--- a/FF1Lib/ItemLists.cs
+++ b/FF1Lib/ItemLists.cs
@@ -42,7 +42,7 @@ namespace FF1Lib
 			Item.SunSword, Item.CoralSword, Item.WereSword, Item.RuneSword,
 			Item.LightAxe, Item.HealRod, Item.MageRod, Item.Defense,
 			Item.WizardRod, Item.CatClaw, Item.ThorHammer, Item.BaneSword,
-			Item.PowerRod, // Usually spellcasting and good in most flagsets; ideally added situationally if this gets overhauled
+			Item.PowerRod, // Usually spellcasting and good in most flagsets; ideally added situationally if this section gets overhauled
 		};
 
 		public static readonly IReadOnlyList<Item> RareArmorTier =

--- a/FF1Lib/ItemLists.cs
+++ b/FF1Lib/ItemLists.cs
@@ -33,6 +33,7 @@ namespace FF1Lib
 			Item.OpalArmor, Item.DragonArmor, Item.Opal,
 			Item.OpalShield, Item.AegisShield,
 			Item.Ribbon, Item.Ribbon, Item.Ribbon,
+			Item.PowerGauntlets,
 		};
 
 		public static readonly IReadOnlyList<Item> RareWeaponTier =
@@ -41,6 +42,7 @@ namespace FF1Lib
 			Item.SunSword, Item.CoralSword, Item.WereSword, Item.RuneSword,
 			Item.LightAxe, Item.HealRod, Item.MageRod, Item.Defense,
 			Item.WizardRod, Item.CatClaw, Item.ThorHammer, Item.BaneSword,
+			Item.PowerRod,
 		};
 
 		public static readonly IReadOnlyList<Item> RareArmorTier =
@@ -49,7 +51,7 @@ namespace FF1Lib
 			Item.SteelArmor, Item.FlameArmor, Item.IceArmor, Item.Gold,
 			Item.WhiteShirt, Item.BlackShirt, Item.FlameShield, Item.IceShield,
 			Item.ProCape, Item.ProCape, Item.HealHelm,
-			Item.ZeusGauntlets, Item.PowerGauntlets, Item.ProRing, Item.ProRing,
+			Item.ZeusGauntlets, Item.ProRing, Item.ProRing,
 		};
 
 		public static readonly IReadOnlyList<Item> CommonWeaponTier =
@@ -59,7 +61,7 @@ namespace FF1Lib
 			Item.Rapier, Item.IronHammer, Item.ShortSword, Item.HandAxe,
 			Item.Scimitar, Item.IronNunchucks, Item.LargeKnife, Item.IronStaff,
 			Item.Sabre, Item.LongSword, Item.GreatAxe, Item.Falchon, Item.SilverKnife,
-			Item.SilverSword, Item.SilverHammer, Item.SilverAxe, Item.PowerRod,
+			Item.SilverSword, Item.SilverHammer, Item.SilverAxe, 
 		};
 
 		public static readonly IReadOnlyList<Item> CommonArmorTier =

--- a/FF1Lib/ItemLists.cs
+++ b/FF1Lib/ItemLists.cs
@@ -30,9 +30,9 @@ namespace FF1Lib
 
 		public static readonly IReadOnlyList<Item> LegendaryArmorTier =
 		new List<Item> {
-			Item.OpalArmor, Item.DragonArmor, Item.Opal, Item.OpalShield,
-			Item.OpalShield, Item.AegisShield, Item.OpalHelm, Item.Ribbon,
-			Item.Ribbon, Item.Ribbon, Item.OpalGauntlets, Item.OpalGauntlets,
+			Item.OpalArmor, Item.DragonArmor, Item.Opal,
+			Item.OpalShield, Item.AegisShield,
+			Item.Ribbon, Item.Ribbon, Item.Ribbon,
 		};
 
 		public static readonly IReadOnlyList<Item> RareWeaponTier =
@@ -45,6 +45,7 @@ namespace FF1Lib
 
 		public static readonly IReadOnlyList<Item> RareArmorTier =
 		new List<Item> {
+			Item.OpalHelm, Item.OpalGauntlets,
 			Item.SteelArmor, Item.FlameArmor, Item.IceArmor, Item.Gold,
 			Item.WhiteShirt, Item.BlackShirt, Item.FlameShield, Item.IceShield,
 			Item.ProCape, Item.ProCape, Item.HealHelm,

--- a/FF1Lib/ItemLists.cs
+++ b/FF1Lib/ItemLists.cs
@@ -42,7 +42,7 @@ namespace FF1Lib
 			Item.SunSword, Item.CoralSword, Item.WereSword, Item.RuneSword,
 			Item.LightAxe, Item.HealRod, Item.MageRod, Item.Defense,
 			Item.WizardRod, Item.CatClaw, Item.ThorHammer, Item.BaneSword,
-			Item.PowerRod,
+			Item.PowerRod, // Usually spellcasting and good in most flagsets; ideally added situationally if this gets overhauled
 		};
 
 		public static readonly IReadOnlyList<Item> RareArmorTier =


### PR DESCRIPTION
Makes Opal Helm & Gauntlets Rare instead of Legendary.
Makes Power Gauntlet Legendary instead of Rare.
Makes Power Staff Rare instead of Common.
Adjusts generated wealth/shop ratios to match changes.