### PR TITLE
'gating' cleanup plus volcano deliniation

### DIFF
--- a/FF1Blazorizer/Tabs/IncentivesTab.razor
+++ b/FF1Blazorizer/Tabs/IncentivesTab.razor
@@ -58,7 +58,7 @@
 					<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="incentivizeEarthCheckBox" IsEnabled="@Flags.Treasures" @bind-Value="Flags.IncentivizeEarth">Earth Cave</TriStateCheckBox>
 				</div>
 				<div class="col-sm-6">
-					<EnumDropDown DisableTooltip UpdateToolTip="@UpdateToolTipID" Id="shardCountDropDown" TItem="IncentivePlacementTypeGated" @bind-Value="Flags.EarthIncentivePlacementType"></EnumDropDown>
+					<EnumDropDown DisableTooltip UpdateToolTip="@UpdateToolTipID" Id="shardCountDropDown" TItem="IncentivePlacementTypeEarth" @bind-Value="Flags.EarthIncentivePlacementType"></EnumDropDown>
 				</div>
 			</div>
 
@@ -67,7 +67,7 @@
 					<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="incentivizeVolcanoCheckBox" IsEnabled="@Flags.Treasures" @bind-Value="Flags.IncentivizeVolcano">Volcano</TriStateCheckBox>
 				</div>
 				<div class="col-sm-6">
-					<EnumDropDown DisableTooltip UpdateToolTip="@UpdateToolTipID" Id="shardCountDropDown" TItem="IncentivePlacementType" @bind-Value="Flags.VolcanoIncentivePlacementType"></EnumDropDown>
+					<EnumDropDown DisableTooltip UpdateToolTip="@UpdateToolTipID" Id="shardCountDropDown" TItem="IncentivePlacementTypeVolcano" @bind-Value="Flags.VolcanoIncentivePlacementType"></EnumDropDown>
 				</div>
 			</div>
 
@@ -76,7 +76,7 @@
 					<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="incentivizeSeaShrineCheckBox" IsEnabled="@Flags.Treasures" @bind-Value="Flags.IncentivizeSeaShrine">Sea Shrine</TriStateCheckBox>
 				</div>
 				<div class="col-sm-6">
-					<EnumDropDown DisableTooltip UpdateToolTip="@UpdateToolTipID" Id="shardCountDropDown" TItem="IncentivePlacementTypeGated" @bind-Value="Flags.SeaShrineIncentivePlacementType"></EnumDropDown>
+					<EnumDropDown DisableTooltip UpdateToolTip="@UpdateToolTipID" Id="shardCountDropDown" TItem="IncentivePlacementTypeSea" @bind-Value="Flags.SeaShrineIncentivePlacementType"></EnumDropDown>
 				</div>
 			</div>
 
@@ -85,7 +85,7 @@
 					<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="incentivizeSkyPalaceCheckBox" IsEnabled="@Flags.Treasures" @bind-Value="Flags.IncentivizeSkyPalace">Sky Palace</TriStateCheckBox>
 				</div>
 				<div class="col-sm-6">
-					<EnumDropDown DisableTooltip UpdateToolTip="@UpdateToolTipID" Id="shardCountDropDown" TItem="IncentivePlacementTypeGated" @bind-Value="Flags.SkyPalaceIncentivePlacementType"></EnumDropDown>
+					<EnumDropDown DisableTooltip UpdateToolTip="@UpdateToolTipID" Id="shardCountDropDown" TItem="IncentivePlacementTypeSky" @bind-Value="Flags.SkyPalaceIncentivePlacementType"></EnumDropDown>
 				</div>
 			</div>
 			<div class="checkbox-cell"></div>

--- a/FF1Blazorizer/wwwroot/tooltips/tooltips.json
+++ b/FF1Blazorizer/wwwroot/tooltips/tooltips.json
@@ -480,7 +480,7 @@
 		"Id": "IncentivesTooltip",
 		"title": "Incentivized Items & Locations Explanation",
 		"screenshot": null,
-		"description": "Incentivized Items are guaranteed to be spread out amongst the Incentivized Locations, giving you an idea of where to look for important items.\nIf there are more Items than Locations selected, the excess items will be \"loose\", meaning they will be in random locations. This can be further controlled via the options in the \"Loose Placement\" section.\nIf there are more Locations than Items selected, excess locations will be duds, and only contain a random treasure.\nAny Key Items given for free or banned (in the Treasures tab) can't be incentivized, and thus won't be included in the total item count at the top."
+		"description": "Incentivized Items are guaranteed to be distributed amongst the Incentivized Locations, giving you an idea of where to look for important items.\nIf there are more Items than Locations selected, the excess items will be \"loose\", meaning they will be in random locations. This can be further controlled via the options in the \"Loose Placement\" section.\nIf there are more Locations than Items selected, excess locations will be duds, and only contain a random treasure.\nAny Key Items given for free or banned (in the Treasures tab) can't be incentivized, and thus won't be included in the total item count at the top."
 	},
 	{
 		"Id": "IncentiveItemsTooltip",
@@ -504,74 +504,74 @@
 		"Id": "incentivizeIceCaveCheckBox",
 		"title": "Ice Cave Incentive Chest",
 		"screenshot": "incentivizeIceCaveCheckBox.png",
-		"description": "Incentivizes the FLOATER chest in Ice Cave from the vanilla game.\nOne random item from your incentive item pool will be guaranteed in this chest, provided the number of incentive items matches or is less than the number of incentive locations."
+		"description": "Vanilla: Incentivizes the FLOATER chest in Ice Cave (pictured)."
 	},
 	{
 		"Id": "incentivizeOrdealsCheckBox",
 		"title": "Castle Ordeals Incentive Chest",
 		"screenshot": "incentivizeOrdealsCheckBox.png",
-		"description": "Incentivizes the TAIL chest in the Castle of Ordeals from the vanilla game.\nOne random item from your incentive item pool will be guaranteed in this chest, provided the number of incentive items matches or is less than the number of incentive locations."
+		"description": "Vanilla: Incentivizes the TAIL chest at the end of the Castle of Ordeals (pictured)."
 	},
 	{
 		"Id": "incentivizeMarshCheckBox",
 		"title": "Marsh Cave Incentive Chest",
 		"screenshot": "incentivizeMarshCheckBox.png",
-		"description": "Incentivizes the CROWN chest in Marsh Cave from the vanilla game.\nOne random item from your incentive item pool will be guaranteed in this chest, provided the number of incentive items matches or is less than the number of incentive locations."
+		"description": "Vanilla: Incentivizes the CROWN chest in Marsh Cave's bottom floor (pictured)."
 	},
 	{
 		"Id": "incentivizeTitansCheckBox",
 		"title": "Titan’s Trove Incentive Chest",
 		"screenshot": "incentivizeTitansCheckBox.png",
-		"description": "Incentivizes the leftmost chest in Titan’s Trove. Note that if the Titan’s Trove map edit is on, this chest will require the RUBY to access.\nOne random item from your incentive item pool will be guaranteed in this chest, provided the number of incentive items matches or is less than the number of incentive locations."
+		"description": "Vanilla: Incentivizes the leftmost chest in Titan’s Trove. Note that if the \"Titan’s Trove\" map edit is on, this chest will require the RUBY to access."
 	},
 	{
 		"Id": "incentivizeEarthCheckBox",
 		"title": "Earth Cave Incentive Chest",
 		"screenshot": "incentivizeEarthCheckBox.png",
-		"description": "Incentivizes the RUBY chest next to the Vampire in Earth Cave in the vanilla game. The Vampire must be killed to obtain access to this chest.\nOne random item from your incentive item pool will be guaranteed in this chest, provided the number of incentive items matches or is less than the number of incentive locations."
+		"description": "Vanilla: Incentivizes the RUBY chest next to the Vampire in Earth Cave (pictured). The Vampire must be killed to obtain access to this chest.\nPre-Rod: A random chest in the first 3 floors of Earth Cave (before the rod plate) will be incentivized.\nPost-Rod: A random chest on floor 4 of Earth Cave (after the rod plate) will be incentivized."
 	},
 	{
 		"Id": "incentivizeVolcanoCheckBox",
 		"title": "Volcano Incentive Chest",
 		"screenshot": "incentivizeVolcanoCheckBox.png",
-		"description": "Incentivizes the leftmost chest on KARY’s floor (the \"Red D Chest\" in the vanilla game). This chest requires the passage of two trap tile encounters to access, so make sure you are prepared before approaching.\nOne random item from your incentive item pool will be guaranteed in this chest, provided the number of incentive items matches or is less than the number of incentive locations."
+		"description": "Vanilla: Incentivizes the leftmost chest on KARY’s floor (the \"Red D Chest\", pictured). This chest requires passing through two trap tile encounters to access.\nShallow: A random chest on the 2nd floor of Volcano (where the \"armory\" and hairpins are) will be incentivized.\nDeep: A random chest on floor 4-5 (Kary's floor and the floor before it) will be incentivized."
 	},
 	{
 		"Id": "incentivizeSeaShrineCheckBox",
 		"title": "Sea Shrine Incentive Chest",
 		"screenshot": "incentivizeSeaShrineCheckBox.png",
-		"description": "Incentivizes the SLAB chest on the Mermaids floor on Sea Shrine from the vanilla game.\nOne random item from your incentive item pool will be guaranteed in this chest, provided the number of incentive items matches or is less than the number of incentive locations."
+		"description": "Vanilla: Incentivizes the SLAB chest on the Mermaids floor on Sea Shrine (pictured).\nLocked: The Crescent-shaped \"TFC\" room, on the floor before you get to the Mermaids on the right side of Sea Shrine, will be incentivized and require the KEY to access. If the \"Mermaid Prison\" flag (Map tab) is on, then either the TFC chest or any mermaid chest will be incentivized (and require the KEY).\nUnlocked: the opposited of Locked - a random Sea Shrine chest that does not require the KEY to access will be incentivized."
 	},
 	{
 		"Id": "incentivizeSkyPalaceCheckBox",
 		"title": "Sky Palace Incentive Chest",
 		"screenshot": "incentivizeSkyPalaceCheckBox.png",
-		"description": "Incentivizes the ADAMANT chest (the bottom-left chest on the \"Sky Spider\" floor) in Sky Palace from the vanilla game.\nOne random item from your incentive item pool will be guaranteed in this chest, provided the number of incentive items matches or is less than the number of incentive locations."
+		"description": "Vanilla: Incentivizes the ADAMANT chest (the bottom-left chest on the \"Sky Spider\" floor) in Sky Palace (pictured).\nMirage: A random chest in Mirage Tower will be incentivized, requiring only the CHIME and not the CUBE to access.\nSky: A random chest in the Sky Palace will be incentivized, on any floor after using the CUBE."
 	},
 	{
 		"Id": "incentivizeConeriaCheckBox",
 		"title": "Coneria Castle Incentive Chest",
 		"screenshot": "incentivizeConeriaCheckBox.png",
-		"description": "Incentivizes the TNT chest in the Coneria locked treasury from the vanilla game. This chest requires the KEY to access.\nOne random item from your incentive item pool will be guaranteed in this chest, provided the number of incentive items matches or is less than the number of incentive locations."
+		"description": "Vanilla: Incentivizes the TNT chest in the Coneria locked treasury (pictured). This chest requires the KEY to access."
 	},
 	{
 		"Id": "incentivizeMarshKeyLockedCheckBox",
 		"title": "Marsh KEY Locked Incentive Chest",
 		"screenshot": "incentivizeMarshKeyLockedCheckBox.png",
-		"description": "Incentivizes the bottom right chest of the bottom floor of Marsh Cave. This chest requires the KEY to access.\nOne random item from your incentive item pool will be guaranteed in this chest, provided the number of incentive items matches or is less than the number of incentive locations."
+		"description": "Vanilla: Incentivizes the bottom right chest of the bottom floor of Marsh Cave (pictured). This chest requires the KEY to access."
 	},
 	{
 		"Id": "incentivizeCardiaCheckBox",
 		"title": "Cardia Incentive Chest",
 		"screenshot": "cardiaIncentive.png",
-		"description": "Incentivizes top-right chest in the left-most room of the forest island of the Cardia Islands. The AIRSHIP is required to access, unless combined with the 'Bahamut Cardia dock' and 'Dragon's Hoard' flags.\nNote that if incentive placement is set to \"random\" this item can appear in any of the chests among the populated Cardia islands.\nOne random item from your incentive item pool will be guaranteed in this chest, provided the number of incentive items matches or is less than the number of incentive locations."
+		"description": "Vanilla: Incentivizes top-right chest in the left-most room of the forest island of the Cardia Islands. The AIRSHIP is required to access, unless combined with the 'Bahamut Cardia dock' and 'Dragon's Hoard' flags.\nRandom: This item can appear in any of the chests among all of the Cardia Islands."
 	},
 
 	{
 		"Id": "incentivePlacementType",
 		"title": "Incentive Placement Types",
 		"screenshot": "incentivizeRandomChestInLocationCheckBox.gif",
-		"description": "Vanilla - Sets the incentive chest to be the default chest and room (the one shown in the tooltip) for a given location.\nRandom - Chooses a random chest at the selected location to act as an incentive chest.\nBefore Gating - Chooses a chest on a floor that comes before gating; e.g. Earth Cave floors 1-3 before the ROD block, Mirage Tower before the CUBE plate, all of Sea Shrine minus the crescent-shaped \"TFC\" room.\nBehind Gating - Chooses a chest on a floor that comes after gating; e.g. Earth Cave Floor 4 after ROD block, Sky Palace after the CUBE plate, Sea Shrine in the crescent-shaped \"TFC\" room (which requires the KEY to enter)."
+		"description": "Vanilla: Sets the incentive chest to be the default chest (pictured in each tooltip) for a given location.\nRandom: Chooses a random chest from all chests at the selected location to act as an incentive chest.\nSome locations will also have additional options, explained in their tooltips."
 	},
 
 	{

--- a/FF1Blazorizer/wwwroot/tooltips/tooltips.json
+++ b/FF1Blazorizer/wwwroot/tooltips/tooltips.json
@@ -540,7 +540,7 @@
 		"Id": "incentivizeSeaShrineCheckBox",
 		"title": "Sea Shrine Incentive Chest",
 		"screenshot": "incentivizeSeaShrineCheckBox.png",
-		"description": "Vanilla: Incentivizes the SLAB chest on the Mermaids floor on Sea Shrine (pictured).\nLocked: The Crescent-shaped \"TFC\" room, on the floor before you get to the Mermaids on the right side of Sea Shrine, will be incentivized and require the KEY to access. If the \"Mermaid Prison\" flag (Map tab) is on, then either the TFC chest or any mermaid chest will be incentivized (and require the KEY).\nUnlocked: the opposited of Locked - a random Sea Shrine chest that does not require the KEY to access will be incentivized."
+		"description": "Vanilla: Incentivizes the SLAB chest on the Mermaids floor at the end of the right Sea Shrine path (pictured).\nLocked: The Crescent-shaped \"TFC\" room, on the floor before you get to the Mermaids on the right side of Sea Shrine, will be incentivized and require the KEY to access. If the \"Mermaid Prison\" flag (Map tab) is on, then either the TFC chest or any mermaid chest will be incentivized (and require the KEY).\nUnlocked: the opposited of Locked - a random Sea Shrine chest that does not require the KEY to access will be incentivized."
 	},
 	{
 		"Id": "incentivizeSkyPalaceCheckBox",
@@ -564,7 +564,7 @@
 		"Id": "incentivizeCardiaCheckBox",
 		"title": "Cardia Incentive Chest",
 		"screenshot": "cardiaIncentive.png",
-		"description": "Vanilla: Incentivizes top-right chest in the left-most room of the forest island of the Cardia Islands. The AIRSHIP is required to access, unless combined with the 'Bahamut Cardia dock' and 'Dragon's Hoard' flags.\nRandom: This item can appear in any of the chests among all of the Cardia Islands."
+		"description": "Vanilla: Incentivizes top-right chest in the left-most room of the forest island of the Cardia Islands. The AIRSHIP is required to access, unless combined with the 'Bahamut Cardia Dock' and 'Dragon's Hoard' flags.\nRandom: This item can appear in any of the chests among all of the Cardia Islands."
 	},
 
 	{

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -317,10 +317,10 @@ namespace FF1Lib
 		public IncentivePlacementType OrdealsIncentivePlacementType { get; set; } = IncentivePlacementType.Vanilla;
 		public IncentivePlacementType MarshIncentivePlacementType { get; set; } = IncentivePlacementType.Vanilla;
 		public IncentivePlacementType TitansIncentivePlacementType { get; set; } = IncentivePlacementType.Vanilla;
-		public IncentivePlacementTypeGated EarthIncentivePlacementType { get; set; } = IncentivePlacementTypeGated.Vanilla;
-		public IncentivePlacementType VolcanoIncentivePlacementType { get; set; } = IncentivePlacementType.Vanilla;
-		public IncentivePlacementTypeGated SeaShrineIncentivePlacementType { get; set; } = IncentivePlacementTypeGated.Vanilla;
-		public IncentivePlacementTypeGated SkyPalaceIncentivePlacementType { get; set; } = IncentivePlacementTypeGated.Vanilla;
+		public IncentivePlacementTypeEarth EarthIncentivePlacementType { get; set; } = IncentivePlacementTypeEarth.Vanilla;
+		public IncentivePlacementTypeVolcano VolcanoIncentivePlacementType { get; set; } = IncentivePlacementTypeVolcano.Vanilla;
+		public IncentivePlacementTypeSea SeaShrineIncentivePlacementType { get; set; } = IncentivePlacementTypeSea.Vanilla;
+		public IncentivePlacementTypeSky SkyPalaceIncentivePlacementType { get; set; } = IncentivePlacementTypeSky.Vanilla;
 		public IncentivePlacementType CorneriaIncentivePlacementType { get; set; } = IncentivePlacementType.Vanilla;
 		public IncentivePlacementType MarshLockedIncentivePlacementType { get; set; } = IncentivePlacementType.Vanilla;
 		public IncentivePlacementType CardiaIncentivePlacementType { get; set; } = IncentivePlacementType.Vanilla;

--- a/FF1Lib/FlagsViewModel.cs
+++ b/FF1Lib/FlagsViewModel.cs
@@ -1690,7 +1690,7 @@ namespace FF1Lib
 			}
 		}
 
-		public IncentivePlacementTypeGated EarthIncentivePlacementType
+		public IncentivePlacementTypeEarth EarthIncentivePlacementType
 		{
 			get => Flags.EarthIncentivePlacementType;
 			set
@@ -1700,7 +1700,7 @@ namespace FF1Lib
 			}
 		}
 
-		public IncentivePlacementType VolcanoIncentivePlacementType
+		public IncentivePlacementTypeVolcano VolcanoIncentivePlacementType
 		{
 			get => Flags.VolcanoIncentivePlacementType;
 			set
@@ -1710,7 +1710,7 @@ namespace FF1Lib
 			}
 		}
 
-		public IncentivePlacementTypeGated SeaShrineIncentivePlacementType
+		public IncentivePlacementTypeSea SeaShrineIncentivePlacementType
 		{
 			get => Flags.SeaShrineIncentivePlacementType;
 			set
@@ -1720,7 +1720,7 @@ namespace FF1Lib
 			}
 		}
 
-		public IncentivePlacementTypeGated SkyPalaceIncentivePlacementType
+		public IncentivePlacementTypeSky SkyPalaceIncentivePlacementType
 		{
 			get => Flags.SkyPalaceIncentivePlacementType;
 			set

--- a/FF1Lib/IncentiveData.cs
+++ b/FF1Lib/IncentiveData.cs
@@ -14,7 +14,7 @@ namespace FF1Lib
 		RandomAtLocation
 	}
 
-	public enum IncentivePlacementTypeGated
+	/*public enum IncentivePlacementTypeGated
 	{
 		[Description("Vanilla")]
 		Vanilla,
@@ -24,6 +24,54 @@ namespace FF1Lib
 		RandomNoGating,
 		[Description("Behind Gating")]
 		RandomBehindGating
+	}*/
+	
+	public enum IncentivePlacementTypeEarth
+	{
+		[Description("Vanilla")]
+		Vanilla,
+		[Description("Random")]
+		RandomAtLocation,
+		[Description("Random Pre-Rod")]
+		RandomPreRod,
+		[Description("Random Post-Rod")]
+		RandomPostRod
+	}
+	
+	public enum IncentivePlacementTypeSky
+	{
+		[Description("Vanilla")]
+		Vanilla,
+		[Description("Random")]
+		RandomAtLocation,
+		[Description("Random Mirage")]
+		RandomMirage,
+		[Description("Random Sky")]
+		RandomSky
+	}
+	
+	public enum IncentivePlacementTypeSea
+	{
+		[Description("Vanilla")]
+		Vanilla,
+		[Description("Random")]
+		RandomAtLocation,
+		[Description("Random Unlocked")]
+		RandomUnlocked,
+		[Description("Random Locked")]
+		RandomLocked
+	}
+	
+		public enum IncentivePlacementTypeVolcano
+	{
+		[Description("Vanilla")]
+		Vanilla,
+		[Description("Random")]
+		RandomAtLocation,
+		[Description("Random Deep")]
+		RandomDeep,
+		[Description("Random Shallow")]
+		RandomShallow
 	}
 
 	public class IncentiveData

--- a/FF1Lib/IncentiveData.cs
+++ b/FF1Lib/IncentiveData.cs
@@ -357,9 +357,17 @@ namespace FF1Lib
 
 			if (flags.IncentivizeVolcano ?? false)
 			{
-				if (flags.VolcanoIncentivePlacementType == IncentivePlacementType.RandomAtLocation)
+				if (flags.VolcanoIncentivePlacementType == IncentivePlacementTypeVolcano.RandomAtLocation)
 				{
 					incentiveLocationPool.Add(ItemLocations.Volcano.ToList().SpliceRandom(rng));
+				}
+				else if (flags.VolcanoIncentivePlacementType == IncentivePlacementTypeVolcano.RandomShallow)
+				{
+					incentiveLocationPool.Add(ItemLocations.VolcanoShallow.ToList().SpliceRandom(rng));
+				}
+				else if (flags.VolcanoIncentivePlacementType == IncentivePlacementTypeVolcano.RandomDeep)
+				{
+					incentiveLocationPool.Add(ItemLocations.VolcanoDeep.ToList().SpliceRandom(rng));
 				}
 				else
 				{
@@ -368,15 +376,15 @@ namespace FF1Lib
 			}
 			if (flags.IncentivizeEarth ?? false)
 			{
-				if (flags.EarthIncentivePlacementType == IncentivePlacementTypeGated.RandomAtLocation)
+				if (flags.EarthIncentivePlacementType == IncentivePlacementTypeEarth.RandomAtLocation)
 				{
 					incentiveLocationPool.Add(ItemLocations.EarthCave.ToList().SpliceRandom(rng));
 				}
-				else if (flags.EarthIncentivePlacementType == IncentivePlacementTypeGated.RandomBehindGating)
+				else if (flags.EarthIncentivePlacementType == IncentivePlacementTypeEarth.RandomPostRod)
 				{
 					incentiveLocationPool.Add(ItemLocations.EarthCaveFloor4.ToList().SpliceRandom(rng));
 				}
-				else if (flags.EarthIncentivePlacementType == IncentivePlacementTypeGated.RandomNoGating)
+				else if (flags.EarthIncentivePlacementType == IncentivePlacementTypeEarth.RandomPreRod)
 				{
 					incentiveLocationPool.Add(ItemLocations.EarthCavePreRod.ToList().SpliceRandom(rng));
 				}
@@ -409,15 +417,15 @@ namespace FF1Lib
 			}
 			if (flags.IncentivizeSkyPalace ?? false)
 			{
-				if (flags.SkyPalaceIncentivePlacementType == IncentivePlacementTypeGated.RandomAtLocation)
+				if (flags.SkyPalaceIncentivePlacementType == IncentivePlacementTypeSky.RandomAtLocation)
 				{
 					incentiveLocationPool.Add(ItemLocations.SkyPalace.Concat(ItemLocations.MirageTower).ToList().SpliceRandom(rng));
 				}
-				else if (flags.SkyPalaceIncentivePlacementType == IncentivePlacementTypeGated.RandomBehindGating)
+				else if (flags.SkyPalaceIncentivePlacementType == IncentivePlacementTypeSky.RandomSky)
 				{
 					incentiveLocationPool.Add(ItemLocations.SkyPalace.ToList().SpliceRandom(rng));
 				}
-				else if (flags.SkyPalaceIncentivePlacementType == IncentivePlacementTypeGated.RandomNoGating)
+				else if (flags.SkyPalaceIncentivePlacementType == IncentivePlacementTypeSky.RandomMirage)
 				{
 					incentiveLocationPool.Add(ItemLocations.MirageTower.ToList().SpliceRandom(rng));
 				}
@@ -428,11 +436,11 @@ namespace FF1Lib
 			}
 			if (flags.IncentivizeSeaShrine ?? false)
 			{
-				if (flags.SeaShrineIncentivePlacementType == IncentivePlacementTypeGated.RandomAtLocation)
+				if (flags.SeaShrineIncentivePlacementType == IncentivePlacementTypeSea.RandomAtLocation)
 				{
 					incentiveLocationPool.Add(ItemLocations.SeaShrine.ToList().SpliceRandom(rng));
 				}
-				else if (flags.SeaShrineIncentivePlacementType == IncentivePlacementTypeGated.RandomBehindGating)
+				else if (flags.SeaShrineIncentivePlacementType == IncentivePlacementTypeSea.RandomLocked)
 				{
 					if ((bool)flags.MermaidPrison)
 					{
@@ -443,9 +451,16 @@ namespace FF1Lib
 						incentiveLocationPool.Add(ItemLocations.SeaShrineLocked);
 					}
 				}
-				else if (flags.SeaShrineIncentivePlacementType == IncentivePlacementTypeGated.RandomNoGating)
+				else if (flags.SeaShrineIncentivePlacementType == IncentivePlacementTypeSea.RandomUnlocked)
 				{
-					incentiveLocationPool.Add(ItemLocations.SeaShrineUnlocked.ToList().SpliceRandom(rng));
+					if ((bool)flags.MermaidPrison)
+					{
+						incentiveLocationPool.Add(ItemLocations.SeaShrineUnlockedMinusMermaids.ToList().SpliceRandom(rng));
+					}
+					else
+					{
+						incentiveLocationPool.Add(ItemLocations.SeaShrineUnlocked.ToList().SpliceRandom(rng));
+					}
 				}
 				else
 				{

--- a/FF1Lib/IncentiveData.cs
+++ b/FF1Lib/IncentiveData.cs
@@ -14,18 +14,6 @@ namespace FF1Lib
 		RandomAtLocation
 	}
 
-	/*public enum IncentivePlacementTypeGated
-	{
-		[Description("Vanilla")]
-		Vanilla,
-		[Description("Random")]
-		RandomAtLocation,
-		[Description("Before Gating")]
-		RandomNoGating,
-		[Description("Behind Gating")]
-		RandomBehindGating
-	}*/
-	
 	public enum IncentivePlacementTypeEarth
 	{
 		[Description("Vanilla")]
@@ -36,8 +24,7 @@ namespace FF1Lib
 		RandomPreRod,
 		[Description("Random Post-Rod")]
 		RandomPostRod
-	}
-	
+	}	
 	public enum IncentivePlacementTypeSky
 	{
 		[Description("Vanilla")]
@@ -48,8 +35,7 @@ namespace FF1Lib
 		RandomMirage,
 		[Description("Random Sky")]
 		RandomSky
-	}
-	
+	}	
 	public enum IncentivePlacementTypeSea
 	{
 		[Description("Vanilla")]
@@ -60,9 +46,8 @@ namespace FF1Lib
 		RandomUnlocked,
 		[Description("Random Locked")]
 		RandomLocked
-	}
-	
-		public enum IncentivePlacementTypeVolcano
+	}	
+	public enum IncentivePlacementTypeVolcano
 	{
 		[Description("Vanilla")]
 		Vanilla,

--- a/FF1Lib/Interfaces.cs
+++ b/FF1Lib/Interfaces.cs
@@ -31,10 +31,10 @@
 		IncentivePlacementType OrdealsIncentivePlacementType { get; }
 		IncentivePlacementType MarshIncentivePlacementType { get; }
 		IncentivePlacementType TitansIncentivePlacementType { get; }
-		IncentivePlacementTypeGated EarthIncentivePlacementType { get; }
-		IncentivePlacementType VolcanoIncentivePlacementType { get; }
-		IncentivePlacementTypeGated SeaShrineIncentivePlacementType { get; }
-		IncentivePlacementTypeGated SkyPalaceIncentivePlacementType { get; }
+		IncentivePlacementTypeEarth EarthIncentivePlacementType { get; }
+		IncentivePlacementTypeVolcano VolcanoIncentivePlacementType { get; }
+		IncentivePlacementTypeSea SeaShrineIncentivePlacementType { get; }
+		IncentivePlacementTypeSky SkyPalaceIncentivePlacementType { get; }
 		IncentivePlacementType CorneriaIncentivePlacementType { get; }
 		IncentivePlacementType MarshLockedIncentivePlacementType { get; }
 		IncentivePlacementType CardiaIncentivePlacementType { get; }

--- a/FF1Lib/ItemLocations.Lists.cs
+++ b/FF1Lib/ItemLocations.Lists.cs
@@ -59,6 +59,16 @@ namespace FF1Lib
 			Volcano20, Volcano21, Volcano22, Volcano23, Volcano24,
 			Volcano25, Volcano26, Volcano27, Volcano28, Volcano29,
 			Volcano30, Volcano31, Volcano32, VolcanoMajor };
+		public static readonly IReadOnlyCollection<IRewardSource> VolcanoShallow =
+			new List<IRewardSource> { Volcano1, Volcano2, Volcano3, Volcano4,
+			Volcano5, Volcano6, Volcano7, Volcano8, Volcano9,
+			Volcano10, Volcano11, Volcano12, Volcano13, Volcano14,
+			Volcano15, Volcano16, Volcano17, Volcano18 };
+		public static readonly IReadOnlyCollection<IRewardSource> VolcanoDeep =
+			new List<IRewardSource> { Volcano19,
+			Volcano20, Volcano21, Volcano22, Volcano23, Volcano24,
+			Volcano25, Volcano26, Volcano27, Volcano28, Volcano29,
+			Volcano30, Volcano31, Volcano32, VolcanoMajor };
 		public static readonly IReadOnlyCollection<IRewardSource> IceCave =
 			new List<IRewardSource> { IceCave1, IceCave2, IceCave3, IceCave4,
 			IceCave5, IceCave6, IceCave7, IceCaveMajor, IceCave9,
@@ -88,7 +98,14 @@ namespace FF1Lib
 			SeaShrine25, SeaShrine26, SeaShrine27, SeaShrine28, SeaShrine29,
 			SeaShrine30, SeaShrine31, SeaShrineMajor };
 		public static readonly IReadOnlyCollection<IRewardSource> SeaShrineMermaids =
-			new List<IRewardSource> { SeaShrine20, SeaShrine21, SeaShrine22, SeaShrine23, SeaShrine24, SeaShrine25, SeaShrine26, SeaShrine27, SeaShrine28, SeaShrine29, SeaShrine30, SeaShrine31 };
+			new List<IRewardSource> { SeaShrine20, SeaShrine21, SeaShrine22, SeaShrine23,
+			SeaShrine24, SeaShrine25, SeaShrine26, SeaShrine27, SeaShrine28, SeaShrine29,
+			SeaShrine30, SeaShrine31, SeaShrineMajor };
+		public static readonly IReadOnlyCollection<IRewardSource> SeaShrineUnlockedMinusMermaids =
+			new List<IRewardSource> { SeaShrine1, SeaShrine2, SeaShrine3, SeaShrine4,
+			SeaShrine5, SeaShrine6, SeaShrine7, SeaShrine8, SeaShrine9,
+			SeaShrine10, SeaShrine11, SeaShrine12, SeaShrine13, SeaShrine14,
+			SeaShrine15, SeaShrine16, SeaShrine18, SeaShrine19, };
 		public static readonly IReadOnlyCollection<IRewardSource> Waterfall =
 			new List<IRewardSource> { Waterfall1, Waterfall2, Waterfall3, Waterfall4,
 			Waterfall5, Waterfall6 };

--- a/FF1Lib/Maps.cs
+++ b/FF1Lib/Maps.cs
@@ -1912,12 +1912,12 @@ namespace FF1Lib
 
 		    bool addearth = true;
 		    if ((bool)flags.IncentivizeEarth) {
-			if (flags.EarthIncentivePlacementType == IncentivePlacementTypeGated.Vanilla) {
+			if (flags.EarthIncentivePlacementType == IncentivePlacementTypeEarth.Vanilla) {
 			    preserveChests.Add((MapId.EarthCaveB3, 0x51));
 			}
 
-			if (flags.EarthIncentivePlacementType == IncentivePlacementTypeGated.RandomNoGating ||
-			    flags.EarthIncentivePlacementType == IncentivePlacementTypeGated.RandomBehindGating)
+			if (flags.EarthIncentivePlacementType == IncentivePlacementTypeEarth.RandomPreRod ||
+			    flags.EarthIncentivePlacementType == IncentivePlacementTypeEarth.RandomPostRod)
 			{
 			    // Split shuffle before/after gating
 			    dungeons.Add(new MapId[] { MapId.EarthCaveB1, MapId.EarthCaveB2, MapId.EarthCaveB3 });
@@ -1931,7 +1931,7 @@ namespace FF1Lib
 
 		    dungeons.Add(new MapId[] { MapId.GurguVolcanoB1, MapId.GurguVolcanoB2, MapId.GurguVolcanoB3, MapId.GurguVolcanoB4, MapId.GurguVolcanoB5 });
 
-		    if ((bool)flags.IncentivizeVolcano && flags.VolcanoIncentivePlacementType == IncentivePlacementType.Vanilla) {
+		    if ((bool)flags.IncentivizeVolcano && flags.VolcanoIncentivePlacementType == IncentivePlacementTypeVolcano.Vanilla) {
 			preserveChests.Add((MapId.GurguVolcanoB5, 0x7E));
 		    }
 
@@ -1944,13 +1944,13 @@ namespace FF1Lib
 		    }
 
 		    if ((bool)flags.IncentivizeSeaShrine) {
-			if (flags.SeaShrineIncentivePlacementType == IncentivePlacementTypeGated.Vanilla)
+			if (flags.SeaShrineIncentivePlacementType == IncentivePlacementTypeSea.Vanilla)
 			{
 			    preserveChests.Add((MapId.SeaShrineB1, 0x7B));
 			}
 
-			if (flags.SeaShrineIncentivePlacementType == IncentivePlacementTypeGated.RandomNoGating ||
-			    flags.SeaShrineIncentivePlacementType == IncentivePlacementTypeGated.RandomBehindGating)
+			if (flags.SeaShrineIncentivePlacementType == IncentivePlacementTypeSea.RandomUnlocked||
+			    flags.SeaShrineIncentivePlacementType == IncentivePlacementTypeSea.RandomLocked)
 			{
 			    preserveChests.Add((MapId.SeaShrineB2, 0x6C));
 			}
@@ -1981,7 +1981,7 @@ namespace FF1Lib
 			}
 		    }
 
-		    if ((bool)flags.IncentivizeSkyPalace && flags.SkyPalaceIncentivePlacementType == IncentivePlacementTypeGated.Vanilla) {
+		    if ((bool)flags.IncentivizeSkyPalace && flags.SkyPalaceIncentivePlacementType == IncentivePlacementTypeSky.Vanilla) {
 			preserveChests.Add((MapId.SkyPalace2F, 0x5F));
 		    }
 

--- a/FF1Lib/Maps.cs
+++ b/FF1Lib/Maps.cs
@@ -1899,7 +1899,6 @@ namespace FF1Lib
 		    List<MapId[]> spreadPlacementDungeons = new() {
 			new MapId[] { MapId.Waterfall, MapId.DwarfCave, MapId.MatoyasCave, MapId.SardasCave },
 			new MapId[] { MapId.Cardia, MapId.BahamutsRoomB1, MapId.BahamutsRoomB2 }, // Cardia
-			//new MapId[] { MapId.SeaShrineB1, MapId.SeaShrineB2, MapId.SeaShrineB3, MapId.SeaShrineB4, MapId.SeaShrineB5 }, // Sea Shrine
 			new MapId[] { MapId.SkyPalace1F, MapId.SkyPalace2F, MapId.SkyPalace3F, MapId.SkyPalace4F, MapId.SkyPalace5F }, // Sky Castle
 			new MapId[] { MapId.TempleOfFiends }, // ToF
 		    };
@@ -1949,11 +1948,11 @@ namespace FF1Lib
 
 
 			if ((bool)flags.IncentivizeIceCave && flags.IceCaveIncentivePlacementType == IncentivePlacementType.Vanilla) {
-			preserveChests.Add((MapId.IceCaveB2, 0x5F));
+				preserveChests.Add((MapId.IceCaveB2, 0x5F));
 		    }
 
 		    if ((bool)flags.IncentivizeOrdeals && flags.OrdealsIncentivePlacementType == IncentivePlacementType.Vanilla) {
-			preserveChests.Add((MapId.CastleOfOrdeals3F, 0x78));
+				preserveChests.Add((MapId.CastleOfOrdeals3F, 0x78));
 		    }
 
 			bool addsea = true;

--- a/FF1Lib/Maps.cs
+++ b/FF1Lib/Maps.cs
@@ -1972,7 +1972,6 @@ namespace FF1Lib
 						dungeons.Add(new MapId[] { MapId.SeaShrineB1 }); //Mermaid Floor
 						preserveChests.Add((MapId.SeaShrineB2, 0x6C));
 						addsea = false;
-						Console.WriteLine("OKAY");
 					}
 					else {
 						preserveChests.Add((MapId.SeaShrineB2, 0x6C)); // TFC

--- a/FF1Lib/Maps.cs
+++ b/FF1Lib/Maps.cs
@@ -1899,7 +1899,7 @@ namespace FF1Lib
 		    List<MapId[]> spreadPlacementDungeons = new() {
 			new MapId[] { MapId.Waterfall, MapId.DwarfCave, MapId.MatoyasCave, MapId.SardasCave },
 			new MapId[] { MapId.Cardia, MapId.BahamutsRoomB1, MapId.BahamutsRoomB2 }, // Cardia
-			new MapId[] { MapId.SeaShrineB1, MapId.SeaShrineB2, MapId.SeaShrineB3, MapId.SeaShrineB4, MapId.SeaShrineB5 }, // Sea Shrine
+			//new MapId[] { MapId.SeaShrineB1, MapId.SeaShrineB2, MapId.SeaShrineB3, MapId.SeaShrineB4, MapId.SeaShrineB5 }, // Sea Shrine
 			new MapId[] { MapId.SkyPalace1F, MapId.SkyPalace2F, MapId.SkyPalace3F, MapId.SkyPalace4F, MapId.SkyPalace5F }, // Sky Castle
 			new MapId[] { MapId.TempleOfFiends }, // ToF
 		    };
@@ -1929,13 +1929,26 @@ namespace FF1Lib
 			dungeons.Add(new MapId[] { MapId.EarthCaveB1, MapId.EarthCaveB2, MapId.EarthCaveB3, MapId.EarthCaveB4, MapId.EarthCaveB5 });
 		    }
 
-		    dungeons.Add(new MapId[] { MapId.GurguVolcanoB1, MapId.GurguVolcanoB2, MapId.GurguVolcanoB3, MapId.GurguVolcanoB4, MapId.GurguVolcanoB5 });
+		    
 
-		    if ((bool)flags.IncentivizeVolcano && flags.VolcanoIncentivePlacementType == IncentivePlacementTypeVolcano.Vanilla) {
-			preserveChests.Add((MapId.GurguVolcanoB5, 0x7E));
-		    }
+			bool addvolcano = true;
+			if ((bool)flags.IncentivizeVolcano && flags.VolcanoIncentivePlacementType == IncentivePlacementTypeVolcano.Vanilla) {
+				preserveChests.Add((MapId.GurguVolcanoB5, 0x7E));
+			}
+			else if (flags.VolcanoIncentivePlacementType == IncentivePlacementTypeVolcano.RandomShallow ||
+					 flags.VolcanoIncentivePlacementType == IncentivePlacementTypeVolcano.RandomDeep)
+			{
+				// Split shuffle before/after gating
+				dungeons.Add(new MapId[] { MapId.GurguVolcanoB1, MapId.GurguVolcanoB2 });
+				dungeons.Add(new MapId[] { MapId.GurguVolcanoB3, MapId.GurguVolcanoB4, MapId.GurguVolcanoB5 });
+				addvolcano = false;
+			}
+			if (addvolcano) {
+				dungeons.Add(new MapId[] { MapId.GurguVolcanoB1, MapId.GurguVolcanoB2, MapId.GurguVolcanoB3, MapId.GurguVolcanoB4, MapId.GurguVolcanoB5 });
+			}
 
-		    if ((bool)flags.IncentivizeIceCave && flags.IceCaveIncentivePlacementType == IncentivePlacementType.Vanilla) {
+
+			if ((bool)flags.IncentivizeIceCave && flags.IceCaveIncentivePlacementType == IncentivePlacementType.Vanilla) {
 			preserveChests.Add((MapId.IceCaveB2, 0x5F));
 		    }
 
@@ -1943,17 +1956,31 @@ namespace FF1Lib
 			preserveChests.Add((MapId.CastleOfOrdeals3F, 0x78));
 		    }
 
+			bool addsea = true;
 		    if ((bool)flags.IncentivizeSeaShrine) {
-			if (flags.SeaShrineIncentivePlacementType == IncentivePlacementTypeSea.Vanilla)
-			{
-			    preserveChests.Add((MapId.SeaShrineB1, 0x7B));
-			}
+				if (flags.SeaShrineIncentivePlacementType == IncentivePlacementTypeSea.Vanilla)
+				{
+					preserveChests.Add((MapId.SeaShrineB1, 0x7B));
+				}
 
-			if (flags.SeaShrineIncentivePlacementType == IncentivePlacementTypeSea.RandomUnlocked||
-			    flags.SeaShrineIncentivePlacementType == IncentivePlacementTypeSea.RandomLocked)
-			{
-			    preserveChests.Add((MapId.SeaShrineB2, 0x6C));
-			}
+				if (flags.SeaShrineIncentivePlacementType == IncentivePlacementTypeSea.RandomUnlocked||
+					flags.SeaShrineIncentivePlacementType == IncentivePlacementTypeSea.RandomLocked)
+				{
+					if ((bool)flags.MermaidPrison) {
+						// Split shuffle before/after gating
+						dungeons.Add(new MapId[] { MapId.SeaShrineB2, MapId.SeaShrineB3, MapId.SeaShrineB4, MapId.SeaShrineB5 });
+						dungeons.Add(new MapId[] { MapId.SeaShrineB1 }); //Mermaid Floor
+						preserveChests.Add((MapId.SeaShrineB2, 0x6C));
+						addsea = false;
+						Console.WriteLine("OKAY");
+					}
+					else {
+						preserveChests.Add((MapId.SeaShrineB2, 0x6C)); // TFC
+					}
+				}
+				if (addsea) {
+					dungeons.Add(new MapId[] { MapId.SeaShrineB1, MapId.SeaShrineB2, MapId.SeaShrineB3, MapId.SeaShrineB4, MapId.SeaShrineB5 });
+				}
 		    }
 
 		    if ((bool)flags.IncentivizeConeria) {


### PR DESCRIPTION
Clarifies where random incentives are more clearly by naming them specifically instead of using a generic "Gating" terminology.
Adds a Random Deep/Shallow option for Volcano.
Fixes Mermaid Prison + Sea Shrine Locked Incentive.
Cleans up redundant tooltips.