### PR TITLE
'Life in Battle' Sub-option for Only Life1

### DIFF
--- a/FF1Blazorizer/Tabs/ShopsTab.razor
+++ b/FF1Blazorizer/Tabs/ShopsTab.razor
@@ -49,7 +49,7 @@
 			<EnumDropDown UpdateToolTip="@UpdateToolTipID" Id="LockMode" TItem="LockHitMode" @bind-Value="Flags.LockMode">LOCK & LOK2 Mode:</EnumDropDown>
 			<EnumDropDown UpdateToolTip="@UpdateToolTipID" Id="magicAutohitThresholdDropDown" TItem="AutohitThreshold" @bind-Value="Flags.MagicAutohitThreshold">Power Word Threshold:</EnumDropDown>
 			<CheckBox UpdateToolTip="@UpdateToolTipID" Id="enableSoftInBattle" @bind-Value="Flags.EnableSoftInBattle">Enable Soft in Battle</CheckBox>
-			<CheckBox UpdateToolTip="@UpdateToolTipID" Id="enableLifeInBattle" @bind-Value="Flags.EnableLifeInBattle">Enable Life in Battle</CheckBox>
+            <EnumDropDown UpdateToolTip="@UpdateToolTipID" Id="lifeInBattleDropDown" TItem="LifeInBattleSetting" @bind-Value="Flags.EnableLifeInBattle">Life in Battle:</EnumDropDown>
 
 			<div class="checkbox-cell"></div>
 			<h4>Spell Crafter</h4>

--- a/FF1Blazorizer/wwwroot/presets/Beginner.json
+++ b/FF1Blazorizer/wwwroot/presets/Beginner.json
@@ -53,7 +53,7 @@
     "SpellNameMadness": 0,
     "ExtConsumableSet": 0,
     "EnableSoftInBattle": true,
-    "EnableLifeInBattle": true,
+    "EnableLifeInBattle": 0,
     "NormalShopsHaveExtConsumables": false,
     "LegendaryShopHasExtConsumables": false,
     "ExtConsumableTreasureStackSize": 0,

--- a/FF1Blazorizer/wwwroot/presets/Chaos_Rush.json
+++ b/FF1Blazorizer/wwwroot/presets/Chaos_Rush.json
@@ -53,7 +53,7 @@
     "SpellNameMadness": 0,
     "ExtConsumableSet": 0,
     "EnableSoftInBattle": true,
-    "EnableLifeInBattle": true,
+    "EnableLifeInBattle": 0,
     "NormalShopsHaveExtConsumables": false,
     "LegendaryShopHasExtConsumables": false,
     "ExtConsumableTreasureStackSize": 0,

--- a/FF1Blazorizer/wwwroot/presets/Deep_Dungeon.json
+++ b/FF1Blazorizer/wwwroot/presets/Deep_Dungeon.json
@@ -53,7 +53,7 @@
     "SpellNameMadness": 0,
     "ExtConsumableSet": 0,
     "EnableSoftInBattle": true,
-    "EnableLifeInBattle": true,
+    "EnableLifeInBattle": 0,
     "NormalShopsHaveExtConsumables": false,
     "LegendaryShopHasExtConsumables": false,
     "ExtConsumableTreasureStackSize": 0,

--- a/FF1Blazorizer/wwwroot/presets/Entrance_Floor_Shuffle.json
+++ b/FF1Blazorizer/wwwroot/presets/Entrance_Floor_Shuffle.json
@@ -53,7 +53,7 @@
     "SpellNameMadness": 0,
     "ExtConsumableSet": 0,
     "EnableSoftInBattle": true,
-    "EnableLifeInBattle": true,
+    "EnableLifeInBattle": 0,
     "NormalShopsHaveExtConsumables": false,
     "LegendaryShopHasExtConsumables": false,
     "ExtConsumableTreasureStackSize": 0,

--- a/FF1Blazorizer/wwwroot/presets/Floaterless.json
+++ b/FF1Blazorizer/wwwroot/presets/Floaterless.json
@@ -53,7 +53,7 @@
     "SpellNameMadness": 0,
     "ExtConsumableSet": 0,
     "EnableSoftInBattle": true,
-    "EnableLifeInBattle": true,
+    "EnableLifeInBattle": 0,
     "NormalShopsHaveExtConsumables": false,
     "LegendaryShopHasExtConsumables": false,
     "ExtConsumableTreasureStackSize": 0,

--- a/FF1Blazorizer/wwwroot/presets/Free_Enterprise.json
+++ b/FF1Blazorizer/wwwroot/presets/Free_Enterprise.json
@@ -53,7 +53,7 @@
     "SpellNameMadness": 0,
     "ExtConsumableSet": 0,
     "EnableSoftInBattle": true,
-    "EnableLifeInBattle": true,
+    "EnableLifeInBattle": 0,
     "NormalShopsHaveExtConsumables": false,
     "LegendaryShopHasExtConsumables": false,
     "ExtConsumableTreasureStackSize": 0,

--- a/FF1Blazorizer/wwwroot/presets/Hidden_Chaos.json
+++ b/FF1Blazorizer/wwwroot/presets/Hidden_Chaos.json
@@ -53,7 +53,7 @@
     "SpellNameMadness": 0,
     "ExtConsumableSet": 0,
     "EnableSoftInBattle": true,
-    "EnableLifeInBattle": true,
+    "EnableLifeInBattle": 0,
     "NormalShopsHaveExtConsumables": false,
     "LegendaryShopHasExtConsumables": false,
     "ExtConsumableTreasureStackSize": 0,

--- a/FF1Blazorizer/wwwroot/presets/Improved_Vanilla.json
+++ b/FF1Blazorizer/wwwroot/presets/Improved_Vanilla.json
@@ -53,7 +53,7 @@
     "SpellNameMadness": 0,
     "ExtConsumableSet": 0,
     "EnableSoftInBattle": false,
-    "EnableLifeInBattle": false,
+    "EnableLifeInBattle": 2,
     "NormalShopsHaveExtConsumables": false,
     "LegendaryShopHasExtConsumables": false,
     "ExtConsumableTreasureStackSize": 0,

--- a/FF1Blazorizer/wwwroot/presets/Lichs_Revenge.json
+++ b/FF1Blazorizer/wwwroot/presets/Lichs_Revenge.json
@@ -53,7 +53,7 @@
     "SpellNameMadness": 0,
     "ExtConsumableSet": 0,
     "EnableSoftInBattle": true,
-    "EnableLifeInBattle": true,
+    "EnableLifeInBattle": 0,
     "NormalShopsHaveExtConsumables": false,
     "LegendaryShopHasExtConsumables": false,
     "ExtConsumableTreasureStackSize": 0,

--- a/FF1Blazorizer/wwwroot/presets/NOverworld.json
+++ b/FF1Blazorizer/wwwroot/presets/NOverworld.json
@@ -53,7 +53,7 @@
     "SpellNameMadness": 0,
     "ExtConsumableSet": 0,
     "EnableSoftInBattle": true,
-    "EnableLifeInBattle": true,
+    "EnableLifeInBattle": 0,
     "NormalShopsHaveExtConsumables": false,
     "LegendaryShopHasExtConsumables": false,
     "ExtConsumableTreasureStackSize": 0,

--- a/FF1Blazorizer/wwwroot/presets/Oops_All_Loose.json
+++ b/FF1Blazorizer/wwwroot/presets/Oops_All_Loose.json
@@ -53,7 +53,7 @@
     "SpellNameMadness": 0,
     "ExtConsumableSet": 0,
     "EnableSoftInBattle": true,
-    "EnableLifeInBattle": true,
+    "EnableLifeInBattle": 0,
     "NormalShopsHaveExtConsumables": false,
     "LegendaryShopHasExtConsumables": false,
     "ExtConsumableTreasureStackSize": 0,

--- a/FF1Blazorizer/wwwroot/presets/Over_Randomizer.json
+++ b/FF1Blazorizer/wwwroot/presets/Over_Randomizer.json
@@ -53,7 +53,7 @@
     "SpellNameMadness": 0,
     "ExtConsumableSet": 0,
     "EnableSoftInBattle": true,
-    "EnableLifeInBattle": true,
+    "EnableLifeInBattle": 0,
     "NormalShopsHaveExtConsumables": false,
     "LegendaryShopHasExtConsumables": false,
     "ExtConsumableTreasureStackSize": 0,

--- a/FF1Blazorizer/wwwroot/presets/Procgen_Overworld.json
+++ b/FF1Blazorizer/wwwroot/presets/Procgen_Overworld.json
@@ -53,7 +53,7 @@
     "SpellNameMadness": 0,
     "ExtConsumableSet": 0,
     "EnableSoftInBattle": true,
-    "EnableLifeInBattle": true,
+    "EnableLifeInBattle": 0,
     "NormalShopsHaveExtConsumables": false,
     "LegendaryShopHasExtConsumables": false,
     "ExtConsumableTreasureStackSize": 0,

--- a/FF1Blazorizer/wwwroot/presets/Shard_Hunt.json
+++ b/FF1Blazorizer/wwwroot/presets/Shard_Hunt.json
@@ -53,7 +53,7 @@
     "SpellNameMadness": 0,
     "ExtConsumableSet": 0,
     "EnableSoftInBattle": true,
-    "EnableLifeInBattle": true,
+    "EnableLifeInBattle": 0,
     "NormalShopsHaveExtConsumables": false,
     "LegendaryShopHasExtConsumables": false,
     "ExtConsumableTreasureStackSize": 0,

--- a/FF1Blazorizer/wwwroot/presets/coop2022.json
+++ b/FF1Blazorizer/wwwroot/presets/coop2022.json
@@ -53,7 +53,7 @@
     "SpellNameMadness": 0,
     "ExtConsumableSet": 0,
     "EnableSoftInBattle": false,
-    "EnableLifeInBattle": false,
+    "EnableLifeInBattle": 2,
     "NormalShopsHaveExtConsumables": false,
     "LegendaryShopHasExtConsumables": false,
     "ExtConsumableTreasureStackSize": 0,

--- a/FF1Blazorizer/wwwroot/presets/default.json
+++ b/FF1Blazorizer/wwwroot/presets/default.json
@@ -53,7 +53,7 @@
     "SpellNameMadness": 0,
     "ExtConsumableSet": 0,
     "EnableSoftInBattle": true,
-    "EnableLifeInBattle": true,
+    "EnableLifeInBattle": 0,
     "NormalShopsHaveExtConsumables": false,
     "LegendaryShopHasExtConsumables": false,
     "ExtConsumableTreasureStackSize": 0,

--- a/FF1Blazorizer/wwwroot/tooltips/tooltips.json
+++ b/FF1Blazorizer/wwwroot/tooltips/tooltips.json
@@ -102,10 +102,10 @@
 		"description": "Makes the SOFT spell and the SOFT potion work in battle."
 	},
 	{
-		"Id": "enableLifeInBattle",
+		"Id": "lifeInBattleDropDown",
 		"title": "Enable Life in Battle",
 		"screenshot": "enableLifeInBattleCheckBox.gif",
-		"description": "Makes the LIFE spell, the LIF2 spell and the PHNIX potion (if enabled) work in battle.\nCombat buffs & debuffs are retained when revived during battle - you will keep the benefits of any FAST, TMPR, FOG, etc. (as well as the detriment of SLOW) that were applied before dying. (Status Ailments such as Poison, Mute, or Stun are removed when the character dies and will not be retained.)"
+		"description": "Makes LIFE spells and the PHNIX potion (if enabled - Gear & Items Tab) work in battle. If \"LIFE1 Only\" is selected, LIF2 will only work outside of battle, while LIFE1 and PHNIX potions will also work during battle.\nCombat buffs & debuffs are retained when revived during battle - you will keep the benefits of any FAST, TMPR, FOG, etc. (as well as the detriment of SLOW) that were applied before dying. (Status Ailments such as Poison, Mute, or Stun are removed when the character dies and will not be retained.)"
 	},
 	{
 		"Id": "kiPlacementMode",

--- a/FF1Lib/ExtConsumables.cs
+++ b/FF1Lib/ExtConsumables.cs
@@ -225,7 +225,7 @@ namespace FF1Lib
 			if (flags.ExtConsumableSet == ExtConsumableSet.SetA)
 			{
 				blob += "1C";
-				blob += flags.EnableLifeInBattle ? "1D" : "00";
+				blob += (flags.EnableLifeInBattle != LifeInBattleSetting.LifeInBattleOff) ? "1D" : "00";
 				blob += "1E1F";
 			}
 			else if (flags.ExtConsumableSet == ExtConsumableSet.SetB)

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -801,9 +801,9 @@ public partial class FF1Rom : NesRom
 			EnableSoftInBattle();
 		}
 
-		if (flags.EnableLifeInBattle)
+		if (flags.EnableLifeInBattle != LifeInBattleSetting.LifeInBattleOff)
 		{
-			EnableLifeInBattle();
+			EnableLifeInBattle(flags);
 		}
 
 		if (flags.TranceHasStatusElement)

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -107,8 +107,7 @@ namespace FF1Lib
 		public bool ExtConsumablesEnabled => ExtConsumableSet != ExtConsumableSet.None;
 
 		public bool EnableSoftInBattle { get; set; } = false;
-
-		public bool EnableLifeInBattle { get; set; } = false;
+		public LifeInBattleSetting EnableLifeInBattle { get; set; } = LifeInBattleSetting.LifeInBattleAll;
 
 		public bool? NormalShopsHaveExtConsumables { get; set; } = false;
 

--- a/FF1Lib/FlagsViewModel.cs
+++ b/FF1Lib/FlagsViewModel.cs
@@ -4751,13 +4751,13 @@ namespace FF1Lib
 
 		public bool ExtConsumablesEnabled => Flags.ExtConsumablesEnabled;
 
-		public bool EnableLifeInBattle
+		public LifeInBattleSetting EnableLifeInBattle
 		{
 			get => Flags.EnableLifeInBattle;
 			set
 			{
 				Flags.EnableLifeInBattle = value;
-				RaisePropertyChanged();
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("EnableLifeInBattle"));
 			}
 		}
 

--- a/FF1Lib/Magic.cs
+++ b/FF1Lib/Magic.cs
@@ -40,6 +40,15 @@ namespace FF1Lib
 		Any,
 	}
 
+	public enum LifeInBattleSetting
+	{
+		[Description("LIFE1 & LIFE2")]
+		LifeInBattleAll,
+		[Description("LIFE1 Only")]
+		LifeInBattleLife1Only,
+		[Description("Off (Vanilla)")]
+		LifeInBattleOff
+	}
 	public enum SpellRoutine : byte
 	{
 	        None = 0,
@@ -1259,7 +1268,7 @@ namespace FF1Lib
 
 
 
-		public void EnableLifeInBattle()
+		public void EnableLifeInBattle(Flags flags)
 		{
 			var spellInfos = LoadSpells().ToList();
 			var spells = GetSpells().ToDictionary(s => s.Name.ToLowerInvariant());
@@ -1267,18 +1276,22 @@ namespace FF1Lib
 
 			foreach (var spl in spells.Where(s => s.Key.StartsWith("life") || s.Key.StartsWith("lif")).Select(s => s.Value))
 			{
-				SpellInfo spell = new SpellInfo
+				if ((spl.oobSpellRoutine == OOBSpellRoutine.LIFE && flags.EnableLifeInBattle == LifeInBattleSetting.LifeInBattleLife1Only) || (flags.EnableLifeInBattle == LifeInBattleSetting.LifeInBattleAll))
 				{
-					routine = 0x08, //cure ailment
-					effect = spl.Name == "LIF2" ? (byte)0x81 : (byte)0x01, //death element
-					targeting = 0x10, //single target
-					accuracy = 00,
-					elem = 0,
-					gfx = 224,
-					palette = spl.Name == "LIF2" ? (byte)44 : (byte)43,
-				};
 
-				Put(MagicOffset + spl.Index * MagicSize, spell.compressData());
+					SpellInfo spell = new SpellInfo
+					{
+						routine = 0x08, //cure ailment
+						effect = spl.oobSpellRoutine == OOBSpellRoutine.LIF2 ? (byte)0x81 : (byte)0x01, //death element
+						targeting = 0x10, //single target
+						accuracy = 00,
+						elem = 0,
+						gfx = 224,
+						palette = spl.oobSpellRoutine == OOBSpellRoutine.LIF2 ? (byte)44 : (byte)43,
+					};
+
+					Put(MagicOffset + spl.Index * MagicSize, spell.compressData());
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Life in Battle can now be set to LIFE1 + LIFE2, to LIFE1 (and Phoenix Down) Only, or to Off.
Also fixed a bug where Life in Battle wouldn't work properly for Life2 Spell Crafter effects that weren't named "LIF2" (they're usually LIF7 or LIF8).