### PR TITLE
Armor Crafter/Weaponizer Spell Bugfixes

### DIFF
--- a/FF1Lib/Armor.cs
+++ b/FF1Lib/Armor.cs
@@ -219,7 +219,7 @@ namespace FF1Lib
 
 								Concat(spellHelper.FindSpells(SpellRoutine.ArmorUp, SpellTargeting.AllCharacters)).
 
-								Concat(spellHelper.FindSpells(SpellRoutine.DefElement, SpellTargeting.Any, SpellElement.All)).
+								Concat(spellHelper.FindSpells(SpellRoutine.DefElement, SpellTargeting.Any).Where(s => s.Info.status == SpellStatus.Any)).
 
 								Select(s => s.Id));
 		    // Any elemental AOE damage, excludes NUKE/FADE
@@ -366,7 +366,7 @@ namespace FF1Lib
 			    } else if (itemId == Item.WhiteShirt) {
 				spells = whiteShirtSpells;
 			    } else if (itemId == Item.BlackShirt) {
-				spells = whiteShirtSpells;
+				spells = blackShirtSpells;
 			    } else if (itemId == Item.Ribbon) {
 			    } else if (tier >= 1 &&
 				       (armorType == HELM || armorType == GAUNTLET ||

--- a/FF1Lib/Weapon.cs
+++ b/FF1Lib/Weapon.cs
@@ -354,7 +354,7 @@ namespace FF1Lib
 
 		    var defenseSwordSpells = new List<FF1Lib.Spell>(spellHelper.FindSpells(SpellRoutine.Ruse, SpellTargeting.Any).
 								Concat(spellHelper.FindSpells(SpellRoutine.ArmorUp, SpellTargeting.AllCharacters)).
-								Concat(spellHelper.FindSpells(SpellRoutine.DefElement, SpellTargeting.Any, SpellElement.All)).
+								Concat(spellHelper.FindSpells(SpellRoutine.DefElement, SpellTargeting.Any).Where(s => s.Info.status == SpellStatus.Any)).
 								Select(s => s.Id));
 		    var thorHammerSpells =  new List<FF1Lib.Spell>(spellHelper.FindSpells(SpellRoutine.Damage, SpellTargeting.AllEnemies).
 								   Where(s => s.Info.elem != (byte)SpellElement.None).


### PR DESCRIPTION
Fix: WALL wasn't generating in Weaponizer or Armor Crafter correctly
Fix: Armor Crafter Black Shirt was pulling from the White Shirt defensive spell pool instead of the intended damage-spell pool