### PR TITLE
Forced Giving Promoted Fix

### DIFF
--- a/FF1Lib/Party.cs
+++ b/FF1Lib/Party.cs
@@ -65,10 +65,11 @@ namespace FF1Lib
 				{
 					forcedclass = options.PickRandom(rng);
 				}
+				// No available classes from flags - choose an unpromoted class at random
 				else
 				{
 					forcedclass = (FF1Class)(Enum.GetValues(typeof(FF1Class))).
-						GetValue(rng.Between(0, slotNumber == 1 ? 11 : 12));
+						GetValue(rng.Between(0, 5));
 				}
 				options.Clear();
 				options.Add(forcedclass);


### PR DESCRIPTION
If a Forced Class at character select can't find any valid classes, it'll now only randomize amongst unpromoted classes