### PR TITLE
Bugfixes & Cleanup for Item Magic Pools & Starting Caster Items

### DIFF
--- a/FF1Lib/ItemMagic.cs
+++ b/FF1Lib/ItemMagic.cs
@@ -52,7 +52,7 @@ namespace FF1Lib
 			}
 			else if (flags.ItemMagicPool == ItemMagicPool.Curated)
 			{
-				Spells = GetTournamentSpells(rng);
+				Spells = GetTournamentSpells(rng, (bool)flags.MagisizeWeapons);
 			}
 			else
 			{
@@ -228,12 +228,12 @@ namespace FF1Lib
 			return foundSpells.Concat(foundSpells).ToList();
 		}
 
-		private List<MagicSpell> GetTournamentSpells(MT19337 rng)
+		private List<MagicSpell> GetTournamentSpells(MT19337 rng, bool AllWeaponsMagic)
 		{
 			var Spells = GetSpells();
 
 			SpellHelper spellHelper = new SpellHelper(this);
-			List<(Spell Id, MagicSpell Info)> foundSpells = GetTournamentSpells(spellHelper, rng);
+			List<(Spell Id, MagicSpell Info)> foundSpells = GetTournamentSpells(spellHelper, rng, AllWeaponsMagic);
 
 			var Spells2 = new List<MagicSpell>();
 			foreach (var spl in foundSpells)
@@ -246,7 +246,7 @@ namespace FF1Lib
 			return Spells2;
 		}
 
-		private List<(Spell Id, MagicSpell Info)> GetTournamentSpells(SpellHelper spellHelper, MT19337 rng)
+		private List<(Spell Id, MagicSpell Info)> GetTournamentSpells(SpellHelper spellHelper, MT19337 rng, bool AllWeaponsMagic)
 		{
 			List<(Spell Id, MagicSpell Info)> foundSpells = new List<(Spell Id, MagicSpell Info)>();
 
@@ -283,7 +283,13 @@ namespace FF1Lib
 			foundSpells.AddRange(spellHelper.FindSpells(SpellRoutine.InflictStatus, SpellTargeting.Any, SpellElement.Any, SpellStatus.Stun));
 
 			foundSpells.Shuffle(rng);
+
+			// For normal situations, prevents any spell from appearing on more than two items
 			var selection = foundSpells.Take(22).Distinct();
+			// Use the full set with the All Weapons Cast Spells flag so that there's enough
+			if (AllWeaponsMagic) {
+				selection = foundSpells;
+			}
 
 			return selection.Concat(selection).ToList();
 		}

--- a/FF1Lib/StartingEquipment.cs
+++ b/FF1Lib/StartingEquipment.cs
@@ -137,16 +137,6 @@ namespace FF1Lib
 
 		private void GetRandomAoe(List<Item> items)
 		{
-			if (!(flags.Weaponizer ?? false) && !(flags.MagisizeWeapons ?? false))
-			{
-				var pool = new Item[] { Item.BaneSword, Item.BlackShirt, Item.ZeusGauntlets, Item.ThorHammer, Item.MageRod }.ToList();
-
-				if (flags.StartingEquipmentNoDuplicates) pool.RemoveAll(i => items.Contains(i));
-
-				if (pool.Count > 0) items.Add(pool.PickRandom(rng));
-			}
-			else
-			{
 				var damageAoes = spellHelper.FindSpells(SpellRoutine.Damage, SpellTargeting.AllEnemies).Select(s => s.Id);
 				var instaAoes = spellHelper.FindSpells(SpellRoutine.InflictStatus, SpellTargeting.AllEnemies, SpellElement.Any, SpellStatus.Death).Select(s => s.Id);
 				var powerWordAoes = spellHelper.FindSpells(SpellRoutine.PowerWord, SpellTargeting.AllEnemies, SpellElement.Any, SpellStatus.Death).Select(s => s.Id);
@@ -160,26 +150,15 @@ namespace FF1Lib
 
 				var names = weapons.Where(w => spells.Contains(w.Spell)).Select(w => w.Name).Concat(armors.Where(w => spells.Contains(w.Spell)).Select(a => a.Name)).ToList();
 
+				if (flags.StartingEquipmentNoDuplicates) pool.RemoveAll(i => items.Contains(i));
 				if (pool.Count > 0) items.Add(pool.PickRandom(rng));
-			}
 		}
 
 		private void GetRandomCasterItem(List<Item> items)
 		{
-			if (!(flags.Weaponizer ?? false) && !(flags.MagisizeWeapons ?? false))
-			{
-				var pool = new Item[] { Item.BaneSword, Item.BlackShirt, Item.ZeusGauntlets, Item.ThorHammer, Item.MageRod, Item.Defense, Item.WhiteShirt, Item.HealRod, Item.PowerGauntlets }.ToList();
-
-				if (flags.StartingEquipmentNoDuplicates) pool.RemoveAll(i => items.Contains(i));
-
-				if (pool.Count > 0) items.Add(pool.PickRandom(rng));
-			}
-			else
-			{
-				var pool = GetCasterItemPool();
-
-				if (pool.Count > 0) items.Add(pool.PickRandom(rng));
-			}
+			var pool = GetCasterItemPool();
+			if (flags.StartingEquipmentNoDuplicates) pool.RemoveAll(i => items.Contains(i));
+			if (pool.Count > 0) items.Add(pool.PickRandom(rng));
 		}
 
 		private List<Item> GetCasterItemPool()
@@ -212,15 +191,13 @@ namespace FF1Lib
 		private void GetOneItem(List<Item> items)
 		{
 			var pool = GetLegendaryPool();
-
 			if (flags.StartingEquipmentNoDuplicates) pool.RemoveAll(i => items.Contains(i));
-
 			items.Add(pool.PickRandom(rng));
 		}
 
 		private List<Item> GetLegendaryPool()
 		{
-			if (!(flags.Weaponizer ?? false) && !(flags.MagisizeWeapons ?? false))
+			if (!(flags.Weaponizer ?? false) && !(flags.MagisizeWeapons ?? false) && flags.ItemMagicMode == ItemMagicMode.Vanilla)
 			{
 				return ItemLists.UberTier
 				.Concat(ItemLists.LegendaryWeaponTier)


### PR DESCRIPTION
Fixed: Curated Item Magic Pool + All Weapons Cast Spells not filling fully
Fixed: Random Starting Caster Items not caring about Randomized Item Magic Pools
Cleanup: Starting Caster or Caster AoE Items now always dynamic rather than hard-coded
Fixed: No Legendary Duplicates mostly not working with non-vanilla sets