### PR TITLE
Add Compatibility with non-vanilla Spell Lists

### DIFF
--- a/FF1Lib/BugFixes.cs
+++ b/FF1Lib/BugFixes.cs
@@ -96,8 +96,8 @@ namespace FF1Lib
 		public void FixSpellBugs()
 		{
 			Put(0x33A4E, Blob.FromHex("F017EA")); // LOCK routine
-			Put(0x3029C, Blob.FromHex("0E")); // LOK2 spell effect
-			Put(0x302F9, Blob.FromHex("18")); // HEL2 effectivity
+			if (Get(0x3029B, 2) == Blob.FromHex("0110")) Put(0x3029C, Blob.FromHex("0E")); // LOK2 spell effect
+			if (Get(0x302FD, 2) == Blob.FromHex("C027")) Put(0x302F9, Blob.FromHex("18")); // HEL2 effectivity
 
 			// TMPR and SABR
 			// Remove jump to PrepareEnemyMagAttack
@@ -111,7 +111,7 @@ namespace FF1Lib
 			// Call new saving code from BtlMag_SavePlayerDefenderStats
 			Put(0x337C5, Blob.FromHex("209FB6EAEAEAEA"));
 			// SABR's hit% bonus
-			Put(0x30390, Blob.FromHex("0A"));
+			if (Get(0x30391, 3) == Blob.FromHex("100004")) Put(0x30390, Blob.FromHex("0A"));
 
 			TameExitAndWarpBoss();
 

--- a/FF1Lib/ExtConsumables.cs
+++ b/FF1Lib/ExtConsumables.cs
@@ -46,47 +46,50 @@ namespace FF1Lib
 
 		public void AddExtConsumables()
 		{
-			ChangeItemJumpTable();
-
-			WriteOutOfBattleRoutines();
-
-			WriteDrawItemBoxEndOfItemIndex();
-
-			ChangeItemNames();
-			ChangeMenuTexts();
-
-			WriteDrawDrinkBoxBreakoutRoutine();
-			WriteDrawDrinkBoxRoutine();
-			WriteLutDrinkBoxOrder();
-			WriteLutDrinkBoxEffect();
-			WriteLutDrinkBoxTarget();
-			WriteLutDrinkBox();
-			WriteCursorPositions();
-
-			WriteDrinkBoxMenuRoutine();
-			ModifyBattle_PlMag_TargetOnePlayer();
-			WriteCureAilmentsBreakout();
-
-			ModifyUndoBattleCommand();
-			ModifyAfterFadeIn();
-			WriteBattleDoTurn();
-			ModifyBattleLogicLoop();
-
-			if (flags.ExtConsumableSet == ExtConsumableSet.SetA)
+			if (flags.ExtConsumableSet != ExtConsumableSet.None)
 			{
-				CreateLifeSpell();
-				CreateSmokeSpell();
-			}
-			else if (flags.ExtConsumableSet == ExtConsumableSet.SetB)
-			{
-				CreateBlackPotionSpell();
-			}
-			else if (flags.ExtConsumableSet == ExtConsumableSet.SetC)
-			{
-				CreateHighPotionSpell();
-			}
+				ChangeItemJumpTable();
 
-			ClearShops();
+				WriteOutOfBattleRoutines();
+
+				WriteDrawItemBoxEndOfItemIndex();
+
+				ChangeItemNames();
+				ChangeMenuTexts();
+
+				WriteDrawDrinkBoxBreakoutRoutine();
+				WriteDrawDrinkBoxRoutine();
+				WriteLutDrinkBoxOrder();
+				WriteLutDrinkBoxEffect();
+				WriteLutDrinkBoxTarget();
+				WriteLutDrinkBox();
+				WriteCursorPositions();
+
+				WriteDrinkBoxMenuRoutine();
+				ModifyBattle_PlMag_TargetOnePlayer();
+				WriteCureAilmentsBreakout();
+
+				ModifyUndoBattleCommand();
+				ModifyAfterFadeIn();
+				WriteBattleDoTurn();
+				ModifyBattleLogicLoop();
+
+				if (flags.ExtConsumableSet == ExtConsumableSet.SetA)
+				{
+					CreateLifeSpell();
+					CreateSmokeSpell();
+				}
+				else if (flags.ExtConsumableSet == ExtConsumableSet.SetB)
+				{
+					CreateBlackPotionSpell();
+				}
+				else if (flags.ExtConsumableSet == ExtConsumableSet.SetC)
+				{
+					CreateHighPotionSpell();
+				}
+
+				ClearShops();
+			}
 		}		
 
 		private void ChangeItemJumpTable()
@@ -434,6 +437,23 @@ namespace FF1Lib
 				var spl2 = Spells.Where(s => s.Key.StartsWith(altname)).OrderBy(s => s.Key).Select(s => s.Value).Last();
 				return (byte)(spl2.Index);
 			}
+		}
+		private byte FindWeakCure()
+		{
+			var spl = SpellInfos.Where(s => s.routine == 0x07 && s.targeting == 0x10 && s.effect < 33).OrderBy(s => -s.tier).First();
+			return (byte)(SpellInfos.IndexOf(spl));
+		}
+
+		private byte FindAntidote()
+		{
+			var spl = SpellInfos.Where(s => s.routine == 0x08 && (s.effect & 0b100) > 0).OrderBy(s => -s.tier).First();
+			return (byte)(SpellInfos.IndexOf(spl));
+		}
+
+		private byte FindLotion()
+		{
+			var spl = SpellInfos.Where(s => s.routine == 0x08 && (s.effect & 0b10) > 0).OrderBy(s => -s.tier).First();
+			return (byte)(SpellInfos.IndexOf(spl));
 		}
 
 		private byte FindBlastSpell()

--- a/FF1Lib/ExtConsumables.cs
+++ b/FF1Lib/ExtConsumables.cs
@@ -46,47 +46,50 @@ namespace FF1Lib
 
 		public void AddExtConsumables()
 		{
-			ChangeItemJumpTable();
-
-			WriteOutOfBattleRoutines();
-
-			WriteDrawItemBoxEndOfItemIndex();
-
-			ChangeItemNames();
-			ChangeMenuTexts();
-
-			WriteDrawDrinkBoxBreakoutRoutine();
-			WriteDrawDrinkBoxRoutine();
-			WriteLutDrinkBoxOrder();
-			WriteLutDrinkBoxEffect();
-			WriteLutDrinkBoxTarget();
-			WriteLutDrinkBox();
-			WriteCursorPositions();
-
-			WriteDrinkBoxMenuRoutine();
-			ModifyBattle_PlMag_TargetOnePlayer();
-			WriteCureAilmentsBreakout();
-
-			ModifyUndoBattleCommand();
-			ModifyAfterFadeIn();
-			WriteBattleDoTurn();
-			ModifyBattleLogicLoop();
-
-			if (flags.ExtConsumableSet == ExtConsumableSet.SetA)
+			if (flags.ExtConsumableSet != ExtConsumableSet.None)
 			{
-				CreateLifeSpell();
-				CreateSmokeSpell();
-			}
-			else if (flags.ExtConsumableSet == ExtConsumableSet.SetB)
-			{
-				CreateBlackPotionSpell();
-			}
-			else if (flags.ExtConsumableSet == ExtConsumableSet.SetC)
-			{
-				CreateHighPotionSpell();
-			}
+				ChangeItemJumpTable();
 
-			ClearShops();
+				WriteOutOfBattleRoutines();
+
+				WriteDrawItemBoxEndOfItemIndex();
+
+				ChangeItemNames();
+				ChangeMenuTexts();
+
+				WriteDrawDrinkBoxBreakoutRoutine();
+				WriteDrawDrinkBoxRoutine();
+				WriteLutDrinkBoxOrder();
+				WriteLutDrinkBoxEffect();
+				WriteLutDrinkBoxTarget();
+				WriteLutDrinkBox();
+				WriteCursorPositions();
+
+				WriteDrinkBoxMenuRoutine();
+				ModifyBattle_PlMag_TargetOnePlayer();
+				WriteCureAilmentsBreakout();
+
+				ModifyUndoBattleCommand();
+				ModifyAfterFadeIn();
+				WriteBattleDoTurn();
+				ModifyBattleLogicLoop();
+
+				if (flags.ExtConsumableSet == ExtConsumableSet.SetA)
+				{
+					CreateLifeSpell();
+					CreateSmokeSpell();
+				}
+				else if (flags.ExtConsumableSet == ExtConsumableSet.SetB)
+				{
+					CreateBlackPotionSpell();
+				}
+				else if (flags.ExtConsumableSet == ExtConsumableSet.SetC)
+				{
+					CreateHighPotionSpell();
+				}
+
+				ClearShops();
+			}
 		}		
 
 		private void ChangeItemJumpTable()

--- a/FF1Lib/ExtConsumables.cs
+++ b/FF1Lib/ExtConsumables.cs
@@ -46,50 +46,47 @@ namespace FF1Lib
 
 		public void AddExtConsumables()
 		{
-			if (flags.ExtConsumableSet != ExtConsumableSet.None)
+			ChangeItemJumpTable();
+
+			WriteOutOfBattleRoutines();
+
+			WriteDrawItemBoxEndOfItemIndex();
+
+			ChangeItemNames();
+			ChangeMenuTexts();
+
+			WriteDrawDrinkBoxBreakoutRoutine();
+			WriteDrawDrinkBoxRoutine();
+			WriteLutDrinkBoxOrder();
+			WriteLutDrinkBoxEffect();
+			WriteLutDrinkBoxTarget();
+			WriteLutDrinkBox();
+			WriteCursorPositions();
+
+			WriteDrinkBoxMenuRoutine();
+			ModifyBattle_PlMag_TargetOnePlayer();
+			WriteCureAilmentsBreakout();
+
+			ModifyUndoBattleCommand();
+			ModifyAfterFadeIn();
+			WriteBattleDoTurn();
+			ModifyBattleLogicLoop();
+
+			if (flags.ExtConsumableSet == ExtConsumableSet.SetA)
 			{
-				ChangeItemJumpTable();
-
-				WriteOutOfBattleRoutines();
-
-				WriteDrawItemBoxEndOfItemIndex();
-
-				ChangeItemNames();
-				ChangeMenuTexts();
-
-				WriteDrawDrinkBoxBreakoutRoutine();
-				WriteDrawDrinkBoxRoutine();
-				WriteLutDrinkBoxOrder();
-				WriteLutDrinkBoxEffect();
-				WriteLutDrinkBoxTarget();
-				WriteLutDrinkBox();
-				WriteCursorPositions();
-
-				WriteDrinkBoxMenuRoutine();
-				ModifyBattle_PlMag_TargetOnePlayer();
-				WriteCureAilmentsBreakout();
-
-				ModifyUndoBattleCommand();
-				ModifyAfterFadeIn();
-				WriteBattleDoTurn();
-				ModifyBattleLogicLoop();
-
-				if (flags.ExtConsumableSet == ExtConsumableSet.SetA)
-				{
-					CreateLifeSpell();
-					CreateSmokeSpell();
-				}
-				else if (flags.ExtConsumableSet == ExtConsumableSet.SetB)
-				{
-					CreateBlackPotionSpell();
-				}
-				else if (flags.ExtConsumableSet == ExtConsumableSet.SetC)
-				{
-					CreateHighPotionSpell();
-				}
-
-				ClearShops();
+				CreateLifeSpell();
+				CreateSmokeSpell();
 			}
+			else if (flags.ExtConsumableSet == ExtConsumableSet.SetB)
+			{
+				CreateBlackPotionSpell();
+			}
+			else if (flags.ExtConsumableSet == ExtConsumableSet.SetC)
+			{
+				CreateHighPotionSpell();
+			}
+
+			ClearShops();
 		}		
 
 		private void ChangeItemJumpTable()


### PR DESCRIPTION
### ExtConsumables.cs ###
- Wraps the contents of AddExtConsumables() in "value is not None"
- This avoids needing to search for CURE, PURE, and SOFT in the spell list, even when no consumables were added
- Added searches for those spell types, but they are not used yet
  - **FindWeakCure()** Looks for HP Up, One Ally, and Power less than 33
  - **FindAntidote()** Looks for Remove Ailment with the Poison bit on
  - **FindLotion()** Looks for Remove Ailment with the Stone bit on

### BugFixes.cs ###
- Altered the LOK2, HEL2, and SABR checks to make sure specific vanilla bytes are present before patching them
  - **LOK2** confirms its contents are Evade Up Targeting All Enemies before changing the routine
  - **HEL2** confirms its in-battle graphic is Orange Stars before changing the effect
  - **SABR** confirms it is Effect 0x10, non-elemental, and self-targeting before changing the accuracy

All proposed changes have been tested against both vanilla and altered spell lists and behave appropriately.
The minimalist approach to the conditions is to limit how much of the input file the randomizer should know about.

LOK2 is probably fine, but any concerns about HEL2 and SABR can be addressed.

My reasoning for HEL2 was that my generator patches spells before randomization, and never assigns Color 0x27 to Shape 0xC0, so they would never collide.

SABR might collide with Apply Fire Resist to Self, but the acc change won't affect the spell meaningfully.
It won't collide with Remove Stun from Self because you cannot physically perform that action in battle.
If it happens to roll completely vanilla SABR in that slot (would require I *don't* have level balance on, as SABR hits +37 at Level 7), well, it earned that +10 to Hit.