### PR TITLE
Added extra turns to bosses.

### DIFF
--- a/FF1Blazorizer/Tabs/ExperimentalTab.razor
+++ b/FF1Blazorizer/Tabs/ExperimentalTab.razor
@@ -12,6 +12,9 @@
 			<CheckBox UpdateToolTip="@UpdateToolTipID" IsEnabled="@Flags.Treasures" Id="OpenChestsInOrder" @bind-Value="Flags.OpenChestsInOrder">Open Chests in Order</CheckBox>
 			<div class="checkbox-cell"></div>
 			<TriStateCheckBox UpdateToolTip="@UpdateToolTipID" Id="AirBoatCheckBox" @bind-Value="Flags.AirBoat">AirBoat</TriStateCheckBox>
+            <div class="checkbox-cell"></div>
+            <IntSlider Id="BossExtraTurnsSlider" Indent Min="1" Max="4" Step="1" UpdateToolTip="@UpdateToolTipID" IsEnabled="@(Flags.TransformFinalFormation == FinalFormation.None)" @bind-Value="@Flags.BossExtraTurns">Boss Turns: </IntSlider>
+            <CheckBox Id="SplitExtraTurnAttacks" UpdateToolTip="@UpdateToolTipID" IsEnabled="@(Flags.TransformFinalFormation == FinalFormation.None)" @bind-Value="Flags.SplitExtraTurnAttacks">Scale Attacks Down With Extra Turns</CheckBox>
 		</div>
 		<div class="col2">
 			<div class="checkbox-cell"></div>

--- a/FF1Blazorizer/wwwroot/tooltips/tooltips.json
+++ b/FF1Blazorizer/wwwroot/tooltips/tooltips.json
@@ -2173,6 +2173,18 @@
 		"description": "HARM spells (including via item magic) will deal damage to any target if CAST or USED by a White Mage/White Wizard. On non-undead targets, the spells will not crit (will not deal double damage except on a 3/256), averaging 30/60/90/120 damage for HARM1-4."
 	},
 	{
+		"Id": "BossExtraTurnsSlider",
+		"title": "Boss Extra Turns",
+		"screenshot": null,
+		"description": "Bosses (Garland, Astos, Warmech, Fiends, and Chaos) will take additional turns per round. This is a flag recommended for advanced players. This flag is not compatable with alternate final formations."
+	},
+	{
+		"Id": "SplitExtraTurnAttacks",
+		"title": "Scale Attacks Down To Extra Turns",
+		"screenshot": null,
+		"description": "When bosses have extra turns, their number of attacks are divided by the number of turns they have (rounded up). In addition the chance to cast spells or skills is reduced if it is greater than 48 (Spells) or 32 (Skills)."
+	},
+	{
 		"Id": "armorCrafterCheckBox",
 		"title": "Use Armor Crafter",
 		"screenshot": "armorCrafter.png",

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -1170,6 +1170,11 @@ public partial class FF1Rom : NesRom
 			ScaleBossStats(rng, flags);
 		}
 
+		if(flags.BossExtraTurns > 1 && flags.BossExtraTurns <= 9 && flags.TransformFinalFormation == FinalFormation.None)
+		{
+			ExtraBossTurns(flags.BossExtraTurns, flags.SplitExtraTurnAttacks);
+		}
+
 		PartyGeneration(rng, flags, preferences);
 
 		if (((bool)flags.RecruitmentMode))

--- a/FF1Lib/Flags.cs
+++ b/FF1Lib/Flags.cs
@@ -699,6 +699,11 @@ namespace FF1Lib
 
 		public bool WhiteMageHarmEveryone { get; set; } = false;
 
+		[IntegerFlag(1, 9)]
+		public int BossExtraTurns { get; set; } = 1;
+
+		public bool SplitExtraTurnAttacks { get; set; } = false;
+
 		public bool? EarlierRuby { get; set; } = false;
 		public bool? MapCanalBridge => ((NPCItems) | (NPCFetchItems) | MapOpenProgression | MapOpenProgressionExtended) & (!DesertOfDeath);
 		public bool DisableOWMapModifications => SanityCheckerV2 & (GameMode == GameModes.Standard && OwMapExchange != OwMapExchanges.None);

--- a/FF1Lib/FlagsViewModel.cs
+++ b/FF1Lib/FlagsViewModel.cs
@@ -4930,6 +4930,26 @@ namespace FF1Lib
 			}
 		}
 
+		public int BossExtraTurns
+		{
+			get => Flags.BossExtraTurns;
+			set
+			{
+				Flags.BossExtraTurns = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("BossExtraTurns"));
+			}
+		}
+
+		public bool SplitExtraTurnAttacks
+		{
+			get => Flags.SplitExtraTurnAttacks;
+			set
+			{
+				Flags.SplitExtraTurnAttacks = value;
+				RaisePropertyChanged();
+			}
+		}
+
 		public bool CropScreen
 		{
 			get => Preferences.CropScreen;

--- a/FF1Lib/Hacks.cs
+++ b/FF1Lib/Hacks.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
 
 namespace FF1Lib
 {
@@ -1662,6 +1664,77 @@ namespace FF1Lib
 			//Change the too full logic for GiveReward consumables to clear the chest. This is to not run into an issue with consumables blocking chest progression.
 			PutInBank(0x11, 0xB432, Blob.FromHex("B045"));
 		}
+
+		public void ExtraBossTurns(int bossTurns, bool proprotionalHitsExtraTurns)
+		{
+			//move the turn order lut shuffle from bank 0C to the 1C extension bank
+			byte [] turnOrderLut = Get(0x3215C, 13).ToBytes();
+			Put(0x6d900, turnOrderLut);
+
+			var bossTurnOrderLut = Get(0x3215C, 13).ToBytes().ToList();
+			var smallBossTurnOrderLut = Get(0x3215C, 13).ToBytes().ToList();
+
+			//add the extra turns to the fiend lut
+			//replace the non zero indexes with 0x00 the bosse
+			for (int i = 0; i < bossTurns - 1; i++)
+			{
+				int foundIndex = bossTurnOrderLut.IndexOf((byte)(0x08 - i));
+				if (foundIndex > -1)
+				{
+					bossTurnOrderLut.RemoveAt(foundIndex);
+					bossTurnOrderLut.Add(0x00);
+				}
+			}
+
+			Put(0x6d90D, bossTurnOrderLut.ToArray());
+
+
+			//replace the non zero indexes with 0x00 and 0x02 for warmech and astos/garland
+			for (int i = 0; i < bossTurns - 1; i++)
+			{
+				int foundIndex = smallBossTurnOrderLut.IndexOf((byte)(0x08 - (i * 2)));
+				if (foundIndex > -1)
+				{
+					smallBossTurnOrderLut.RemoveAt(foundIndex);
+					smallBossTurnOrderLut.Add(0x00);
+				}
+
+				foundIndex = smallBossTurnOrderLut.IndexOf((byte)(0x08 - (i * 2) - 1));
+				if (foundIndex > -1)
+				{
+					smallBossTurnOrderLut.RemoveAt(foundIndex);
+					smallBossTurnOrderLut.Add(0x02);
+				}				
+			}
+
+			Put(0x6D91A, smallBossTurnOrderLut.ToArray());
+
+			//add the code for turn order selection based on formation
+			//replace old code with stubs to jump to extension
+			Put(0x31452, Blob.FromHex("205CA1"));
+			Put(0x3215C, Blob.FromHex("A99948A92648A91B4C03FEEAEAEAEAEAEAEAEAEAEAEA"));
+			Put(0x6D927, Blob.FromHex("A56AC956F010C97EF012C97CF00EC973900AC980B006205C994C5199A00DB9FF9899476888D0F74C5199A9A148A96648A90C4C03FEA00DAD926CC902D006B919994C6E99B90C9999476888D0EA60"));
+
+
+			//scale boss attacks/scripts if they want to split the attacks
+			if (proprotionalHitsExtraTurns)
+			{
+				ScaleProprotionalToTurns(Enemy.Garland, bossTurns);
+				ScaleProprotionalToTurns(Enemy.Astos, bossTurns);
+				ScaleProprotionalToTurns(Enemy.WarMech, bossTurns);
+				ScaleProprotionalToTurns(Enemy.Lich, bossTurns);
+				ScaleProprotionalToTurns(Enemy.Kary, bossTurns);
+				ScaleProprotionalToTurns(Enemy.Kraken, bossTurns);
+				ScaleProprotionalToTurns(Enemy.Tiamat, bossTurns);
+				ScaleProprotionalToTurns(Enemy.Lich2, bossTurns);
+				ScaleProprotionalToTurns(Enemy.Kary2, bossTurns);
+				ScaleProprotionalToTurns(Enemy.Kraken2, bossTurns);
+				ScaleProprotionalToTurns(Enemy.Tiamat2, bossTurns);
+				ScaleProprotionalToTurns(Enemy.Chaos, bossTurns);
+			}
+		}
+
+
 
 		public void MoveToFBats() {
 		    MoveNpc(MapId.TempleOfFiends, 2, 0x0C, 0x0D, inRoom: false, stationary: false);

--- a/FF1Lib/asm/1C_9900_BossExtraTurns.asm
+++ b/FF1Lib/asm/1C_9900_BossExtraTurns.asm
@@ -1,0 +1,102 @@
+﻿SwapPRG = $FE03
+btl_turnorder = $6848 
+btlformation = $6A
+btl_battletype  = $6C92
+
+;readjust JSR DoBattleRound call
+;31462
+.org 9452
+JSR DoBattleRoundNew
+
+;replace turn order lut and do battle round start with
+;3216C
+.ORG $A15C
+DoBattleRoundNew:
+  ;put the destination address on the stack for after the bank swap
+  LDA #>(InitTurnOrderBuffer-1) ;2
+  PHA ;1
+  LDA #<(InitTurnOrderBuffer-1) ;2
+  PHA ;1
+  ;load the new bank
+  LDA #$1B ;2
+  JMP SwapPRG ;3
+  DoBattleRoundReturn:
+  NOP
+  NOP
+  NOP
+  NOP
+  NOP
+  NOP
+  NOP
+  NOP
+  NOP
+  NOP
+  NOP
+
+;extensions
+;bank 1b 0x6d910
+.ORG $9900
+lut_InitialTurnOrder:
+  .BYTE $00, $01, $02, $03, $04, $05, $06, $07, $08     ; enemy IDs
+  .BYTE $80, $81, $82, $83                              ; character IDs
+
+lut_BossInitialTurnOrder:
+  .BYTE $00, $01, $02, $03, $04, $05, $06, $07, $00     ; enemy IDs
+  .BYTE $80, $81, $82, $83                              ; character IDs
+
+lut_BossMixInitialTurnOrder:
+  .BYTE $00, $01, $02, $03, $04, $05, $06, $07, $02     ; enemy IDs
+  .BYTE $80, $81, $82, $83                              ; character IDs
+
+InitTurnOrderBuffer:
+    ;check to see if this is a boss fight
+    LDA btlformation
+    CMP #$56 ;add warmech
+    BEQ BossFormation
+    CMP #$7E ;skip pirates
+    BEQ RegularFormation
+    CMP #$7C ;skip earth 3 vampire
+    BEQ RegularFormation
+    CMP #$73
+    BCC RegularFormation
+    CMP #$80
+    BCS RegularFormation
+    BossFormation:
+      JSR ExtraTurnsSetup
+      JMP TurnOrderReturn
+    RegularFormation:
+    LDY #$0D                        ; initialize turn order buffer
+    TurnOrderInitLoop:
+        LDA lut_InitialTurnOrder-1, Y ;  by just copying values from a lut
+        STA btl_turnorder-1, Y
+        DEY
+        BNE TurnOrderInitLoop
+        JMP TurnOrderReturn
+
+    TurnOrderReturn:
+    ;put return address for after bank swap back
+    LDA #>(DoBattleRoundReturn-1)
+    PHA
+    LDA #<(DoBattleRoundReturn-1)
+    PHA
+
+    ;go back to bank 0C
+    LDA #$0C
+    JMP SwapPRG
+
+ExtraTurnsSetup:
+  LDY #$0D                        ; initialize turn order buffer
+  TurnOrderInitBossLoop:
+      LDA btl_battletype
+      CMP #$02
+      BNE LargeFormation
+        ;small formation
+        LDA lut_BossMixInitialTurnOrder-1, Y ;astos + garland are set up as a 2-6 mix formation for some reason
+        JMP StoreTurnOrder
+      LargeFormation:
+      LDA lut_BossInitialTurnOrder-1, Y ;  by just copying values from a lut, use the extra turn in the Boss list
+      StoreTurnOrder:
+      STA btl_turnorder-1, Y
+      DEY
+      BNE TurnOrderInitBossLoop
+  RTS


### PR DESCRIPTION
Not sure why I did this. Added the option to give bosses extra turns. They essentially steal turns from the empty turn order pointers. 

Added the option to divide the number of attacks a boss has by the number of turns they have. This should reduce the power level of the flag by a lot.