### PR TITLE
Reduce the size of the code needed to check for Thief Lockpicking

### DIFF
--- a/FF1Lib/Lockpicking.cs
+++ b/FF1Lib/Lockpicking.cs
@@ -6,7 +6,7 @@
 		{
 			//put in the base hack: see 1B_9300_LockpickDoors.asm for more info
 			PutInBank(0x1F, 0xCE53, Blob.FromHex("AA9848A91B2003FE200093C00168A88AB0ED"));
-			PutInBank(0x1B, 0x9300, Blob.FromHex("8A4A2903C902D059A2008645AE2560D050AE2661E009900BAE0061E001F042E007F03EAE6661E009900BAE4061E001F030E007F02CAEA661E009900BAE8061E001F01EE007F01AAEE661E009900BAEC061E001F00CE007F008A001AAA90E4C03FEA000AAA90E4C03FE"));
+			PutInBank(0x1B, 0x9300, Blob.FromHex("8A4A2903C902D038A2008645AE2560D02F48A90048A000BE2661E009B00B18686940B013A8484C1793BE0061E001F010E007F00C4C1E93A00168AAA90E4C03FEA0006868AAA90E4C03FE"));
 		}
 
 		public void SetLockpickingLevel(int requiredLevel)
@@ -15,10 +15,7 @@
 			if (requiredLevel > 0 && requiredLevel <= 50)
 			{
 				//level is stored zero based
-				PutInBank(0x1B, 0x9315, new byte[] { (byte)(requiredLevel - 1) });
-				PutInBank(0x1B, 0x9327, new byte[] { (byte)(requiredLevel - 1) });
-				PutInBank(0x1B, 0x9339, new byte[] { (byte)(requiredLevel - 1) });
-				PutInBank(0x1B, 0x934B, new byte[] { (byte)(requiredLevel - 1) });
+				PutInBank(0x1B, 0x931B, new byte[] { (byte)(requiredLevel - 1) });
 			}
 		}
 	}

--- a/FF1Lib/asm/1B_9300_LockpickDoors.asm
+++ b/FF1Lib/asm/1B_9300_LockpickDoors.asm
@@ -1,4 +1,4 @@
-﻿.include "Constants.inc"
+.include "Constants.inc"
 .include "variables.inc"
 
 SwapPRG = $FE03
@@ -6,7 +6,7 @@ SMMove_Norm_RTS = $CE52
 
 ;currently in the MENU_BANK
 ;this replacement could be a lot less bytes if we use a temporary memory to store A
-;A gets overwriten by the bank swap method and we cant grab it from the stack without some heavy stack manipulation
+;A gets overwritten by the bank swap method and we cant grab it from the stack without some heavy stack manipulation
 ;so we store it in X to carry through bank swaps
 .org $CE53
 TAX
@@ -37,58 +37,46 @@ CheckDoorLocked:
   STX tileprop+1            ; erase the secondary attribute byte (prevent it from being a locked shop)
   LDX item_mystickey        ; check to see if the player has the key
   BNE DoorUnlocked             ; if they do, open the door
-    ;all of this checking is rom space ineffecient but I don't know if we have available temp memory to do an index
+    ;all of this checking is rom space inefficient but I don't know if we have available temp memory to do an index
     ;check to see if they have a thief/ninja in the party, and they're at or above level 10, the class and level are randomizable at rom creation
-    LDX ch_level
-    CPX #$09
-    BCC Slot1UnderLeveled
-    LDX ch_class
-    CPX #$01
-    BEQ DoorUnlocked
-    CPX #$07
-    BEQ DoorUnlocked
+    PHA
+    LDA #$00
+    PHA
+    LDY #$00
+    CheckLevel:
+      LDX ch_level,Y
+      CPX #$09
+      BCS CheckClass
+    NextClass:
+      CLC
+      PLA
+      ADC #$40
+      BCS UnderLeveled
+      TAY
+      PHA
+      JMP CheckLevel
+    CheckClass:
+      LDX ch_class,Y
+      CPX #$01
+      BEQ DoorUnlocked
+      CPX #$07
+      BEQ DoorUnlocked
+      JMP NextClass
 
-    Slot1UnderLeveled:
-    LDX ch_level+$40
-    CPX #$09
-    BCC Slot2UnderLeveled
-    LDX ch_class+$40
-    CPX #$01
-    BEQ DoorUnlocked
-    CPX #$07
-    BEQ DoorUnlocked
-
-    Slot2UnderLeveled:
-    LDX ch_level+$80
-    CPX #$09
-    BCC Slot3UnderLeveled
-    LDX ch_class+$80
-    CPX #$01
-    BEQ DoorUnlocked
-    CPX #$07
-    BEQ DoorUnlocked
-
-    Slot3UnderLeveled:
-    LDX ch_level+$C0
-    CPX #$09
-    BCC Slot4UnderLeveled
-    LDX ch_class+$C0
-    CPX #$01
-    BEQ DoorUnlocked
-    CPX #$07
-    BEQ DoorUnlocked
-
-    Slot4UnderLeveled:
+  UnderLeveled:
     LDY #$01
+    PLA
     TAX
     LDA #BANK_MENUS
     JMP SwapPRG
 
   DoorUnlocked:
     LDY #$00
+    PLA
+    PLA
     TAX
     LDA #BANK_MENUS
     JMP SwapPRG
 
-;105 bytes
-;8A 4A 29 03 C9 02 D0 59 A2 00 86 45 AE 25 60 D0 50 AE 26 61 E0 09 90 0B AE 00 61 E0 01 F0 42 E0 07 F0 3E AE 66 61 E0 09 90 0B AE 40 61 E0 01 F0 30 E0 07 F0 2C AE A6 61 E0 09 90 0B AE 80 61 E0 01 F0 1E E0 07 F0 1A AE E6 61 E0 09 90 0B AE C0 61 E0 01 F0 0C E0 07 F0 08 A0 01 AA A9 0E 4C 03 FE A0 00 AA A9 0E 4C 03 FE
+;74 bytes
+;8A4A2903C902D038A2008645AE2560D02F48A90048A000BE2661E009B00B18686940B013A8484C1793BE0061E001F010E007F00C4C1E93A00168AAA90E4C03FEA0006868AAA90E4C03FE


### PR DESCRIPTION
I initially wanted to reduce this to make room for some additional code I plan to add shortly, but it appears not to be needed since it looks like there is plenty of space should it be needed.

In the end I did this more as an exercise in understanding the codebase a little bit, doing a little practical work in 6502 (which I am not very familiar with), and as a way to figure out how to develop and test this sort of chage.

I tested this with no Thief in the party, with a Thief of the requisite level in each slot, and with a Thief of too low a level in at least one slot. I did not test with a Ninja, but I can't imagine that it would behave any differently.