### PR TITLE
LockRespondRate: Add a slider which controls the respond rate.

### DIFF
--- a/FF1Blazorizer/Tabs/QoLTab.razor
+++ b/FF1Blazorizer/Tabs/QoLTab.razor
@@ -13,6 +13,7 @@
     <CheckBox UpdateToolTip="@UpdateToolTipID" Id="disableDamageTileSFXCheckBox" @bind-Value="Flags.DisableDamageTileSFX">Disable Damage Tile SFX</CheckBox>
     <CheckBox UpdateToolTip="@UpdateToolTipID" Id="uninterruptedMusicCheckBox" @bind-Value="Flags.UninterruptedMusic">Uninterrupted Music</CheckBox>
     <CheckBox UpdateToolTip="@UpdateToolTipID" Id="lockRespondRateCheckBox" @bind-Value="Flags.LockRespondRate">Lock Respond Rate</CheckBox>
+    <IntSlider Indent Min="1" Max="8" Step="1" DisableTooltip UpdateToolTip="@UpdateToolTipID" IsEnabled="Flags.LockRespondRate" Id="respondRate" @bind-Value="@Flags.RespondRate">Respond Rate:</IntSlider>
     <CheckBox UpdateToolTip="@UpdateToolTipID" Id="accessibleSpellNamesCheckBox" IsEnabled="@(!Flags.GenerateNewSpellbook)" @bind-Value="Flags.AccessibleSpellNames">Accessible Spell Names</CheckBox>
     <CheckBox UpdateToolTip="@UpdateToolTipID" Id="cleanBlursedEquipmentNamesCheckBox" @bind-Value="Flags.CleanBlursedEquipmentNames">Cleaner Blursed Names</CheckBox>
 	<CheckBox UpdateToolTip="@UpdateToolTipID" Id="shopInfoIconsCheckBox" @bind-Value="Flags.ShopInfoIcons">Shop Information Icons</CheckBox>

--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -1328,7 +1328,7 @@ public partial class FF1Rom : NesRom
 
 		if (preferences.LockRespondRate)
 		{
-			LockRespondRate();
+			LockRespondRate(preferences.RespondRate);
 		}
 
 		if (preferences.UninterruptedMusic)

--- a/FF1Lib/FlagsViewModel.cs
+++ b/FF1Lib/FlagsViewModel.cs
@@ -2929,6 +2929,16 @@ namespace FF1Lib
 			}
 		}
 
+		public int RespondRate
+		{
+			get => Preferences.RespondRate;
+			set
+			{
+				Preferences.RespondRate = value;
+				RaisePropertyChanged();
+			}
+		}
+
 		public bool UninterruptedMusic
 		{
 			get => Preferences.UninterruptedMusic;

--- a/FF1Lib/Fun.cs
+++ b/FF1Lib/Fun.cs
@@ -174,7 +174,7 @@ namespace FF1Lib
 			Put(0x32051, Blob.FromHex("AD446D"));
 		}
 
-		public void LockRespondRate()
+		public void LockRespondRate(int respondRate)
 		{
 			// original title screen behavior
 			/*
@@ -205,6 +205,10 @@ namespace FF1Lib
 			 */
 
 			Put(0x3A1FD, Blob.FromHex("C901D004A900D002A9001865FA290785FA"));
+
+			// Override the read of the respond rate address so that it always reports a hardcoded value
+			PutInBank(0x0B, 0x99C8, Blob.FromHex("A0001A"));
+			PutInBank(0x0B, 0x99C9, Blob.FromHex($"{respondRate - 1:X2}")); // respondrate is 0-based
 		}
 
 		public void UninterruptedMusic()

--- a/FF1Lib/Hacks.cs
+++ b/FF1Lib/Hacks.cs
@@ -104,6 +104,9 @@ namespace FF1Lib
 			PutInBank(0x1B, 0x89F0, Blob.FromHex("4CE38B"));
 
 			var responserate = preferences.OptOutSpeedHackMessages ? (byte)0x04 : (byte)0x07;
+			if (preferences.LockRespondRate) {
+				responserate = (byte)(preferences.RespondRate - 1);
+			}
 
 			// Default Response Rate 8 (0-based)
 			Data[0x384CB] = responserate; // Initialize respondrate to 7

--- a/FF1Lib/Preferences.cs
+++ b/FF1Lib/Preferences.cs
@@ -14,6 +14,8 @@
 		public MapmanSlot MapmanSlot { get; set; } = MapmanSlot.Leader;
 		public bool DisableSpellCastFlash { get; set; } = true;
 		public bool LockRespondRate { get; set; } = true;
+		[IntegerFlag(1, 8)]
+		public int RespondRate { get; set; } = 8;
 		public bool UninterruptedMusic { get; set; } = false;
 		public bool ChangeLute { get; set; } = false;
 		public TitanSnack TitanSnack { get; set; } = TitanSnack.Ruby;

--- a/FF1Lib/asm/0B_99C8_FixRespondRate.asm
+++ b/FF1Lib/asm/0B_99C8_FixRespondRate.asm
@@ -1,0 +1,7 @@
+; bank 0B
+.orig $99C8
+
+LDY 00
+NOP
+
+; A0001A


### PR DESCRIPTION
Instead we replace the value at the point where it is read. Instead of reading from the respond rate byte we read a hardcoded value which is written by the randomizer.