### PR TITLE
Block caster items from the shop in Weaponizer

### DIFF
--- a/FF1Lib/FF1Rom.cs
+++ b/FF1Lib/FF1Rom.cs
@@ -672,7 +672,14 @@ public partial class FF1Rom : NesRom
 
 					if (!((bool)flags.RandomWaresIncludesSpecialGear))
 					{
-						excludeItemsFromRandomShops.AddRange(ItemLists.SpecialGear);
+						if ((bool)flags.Weaponizer)
+						{
+							excludeItemsFromRandomShops.AddRange(Weapon.LoadAllWeapons(this, flags).Where(w => w.Spell >= Spell.CURE).Select(w => w.Id));
+							excludeItemsFromRandomShops.AddRange(Armor.LoadAllArmors(this, flags).Where(w => w.Spell >= Spell.CURE).Select(w => w.Id));
+							excludeItemsFromRandomShops.AddRange(ItemLists.RareWeaponTier.Except(ItemLists.AllMagicItem));
+						}
+						else
+							excludeItemsFromRandomShops.AddRange(ItemLists.SpecialGear);
 
 						if (flags.GuaranteedDefenseItem != GuaranteedDefenseItem.None && !(flags.ItemMagicMode == ItemMagicMode.None))
 							excludeItemsFromRandomShops.Add(Item.PowerRod);


### PR DESCRIPTION
- prevents magic items from being in shops in weaponizer, unless Allow Caster & Elite Gear is checked