### PR TITLE
Transmooglifier Unarmed Display Fix

### DIFF
--- a/FF1Lib/Transmooglifier.cs
+++ b/FF1Lib/Transmooglifier.cs
@@ -1248,7 +1248,7 @@ namespace FF1Lib
 			// Add Weapon information here. There will never be more than 6 weapons.
 			description += "\nEquipment  \n";
 
-			if (finalSets.Count > 0)
+			if (finalSets.Count > 0 || rom.ClassData[(Classes)classIndex].UnarmedAttack)
 			{
 				var weaponTypes = "";
 


### PR DESCRIPTION
Fix a bug where Unarmed attack wouldn't show in the status screen if it was the only weapon a class would roll access to (looking at you, Chocobo)