### PR TITLE
Initialize ItemShopSlot to vanilla location in the ShopData constructor.

### DIFF
--- a/FF1Lib/Data/ShopData.cs
+++ b/FF1Lib/Data/ShopData.cs
@@ -137,6 +137,7 @@
 			rom = _rom;
 			flags = _flags;
 			Index = new MemTable<ushort>(rom, ShopPointerOffset, ShopPointerCount);
+			ItemShopSlot = ItemLocations.CaravanItemShop1;
 			LoadData();
 		}
 


### PR DESCRIPTION
Fixes an issue causing placement logic to fail when ShopShuffle is disabled.