### PR TITLE
Adds "true prng" encounter table to Experimental

### DIFF
--- a/FF1Blazorizer/Tabs/ExperimentalTab.razor
+++ b/FF1Blazorizer/Tabs/ExperimentalTab.razor
@@ -10,6 +10,7 @@
 		<p>Test out features from 2000 years in the future - at your own risk!</p>
 		<div class="col1">
 			<CheckBox UpdateAction="@UpdateAction" IsEnabled="@((Flags.Treasures != false) && !Flags.Archipelago)" Id="OpenChestsInOrder" @bind-Value="Flags.OpenChestsInOrder">Open Chests in Order</CheckBox>
+			<TriStateCheckBox UpdateAction="@UpdateAction" Id="EncounterPRNG" @bind-Value="Flags.EncounterPrng">Encounter Table Uses True RNG</TriStateCheckBox>
 			<TriStateCheckBox UpdateAction="@UpdateAction" Id="ArmorResistsDamageTileDamageCheckBox" @bind-Value="Flags.ArmorResistsDamageTileDamage" IsEnabled="!Flags.ArmorCrafter">Armor Resists Damage Tiles</TriStateCheckBox>
 			<TriStateCheckBox UpdateAction="@UpdateAction" Id="shuffleLavaTiles" @bind-Value="Flags.ShuffleLavaTiles">Shuffle Lava Tiles</TriStateCheckBox>
 			<TriStateCheckBox UpdateAction="@UpdateAction" Id="addDamageTiles" @bind-Value="Flags.AddDamageTiles">Add Damage Tiles</TriStateCheckBox>

--- a/FF1Blazorizer/wwwroot/tooltips/tooltips.json
+++ b/FF1Blazorizer/wwwroot/tooltips/tooltips.json
@@ -2478,6 +2478,11 @@
 		"description": "Non incentive items are opened in order. \n\nWarning, if your inventory gets full it will block your equipment progress."
 	},
 	{
+		"Id": "EncounterPRNG",
+		"title": "Encounter Table Uses True RNG",
+		"description": "Instead of a 256-step encounter table that resets with a hard reset, the game uses a pseudo-random number generator with a period of 65,535 steps, which does not reset on hard reset."
+	},
+	{
 		"Id": "SetRNG",
 		"title": "Set RNG",
 		"description": "Between two runners playing the same seed, identical battles will start at the same location in the RNG table and the RNG pointer will not progress each frame.\n\nAll bosses and spike tiles will have the same RNG.\n\nThe first through nth random encounter will consume the same RNG values for each battle. If you are facing an issue with a particular random encounter try soft reseting."

--- a/FF1Lib/Flags/Flags.cs
+++ b/FF1Lib/Flags/Flags.cs
@@ -210,6 +210,8 @@ namespace FF1Lib
 		public bool? Rng { get; set; } = false;
 		public bool FixMissingBattleRngEntry { get; set; } = false;
 
+		public bool? EncounterPrng { get; set; } = false;
+
 		public bool? UnrunnableShuffle { get; set; } = true;
 		[IntegerFlag(0, 100, 4)]
 		public int UnrunnablesLow { get; set; } = 0;

--- a/FF1Lib/Randomize.cs
+++ b/FF1Lib/Randomize.cs
@@ -418,7 +418,7 @@ public partial class FF1Rom : NesRom
 		TileSetsData.Write();
 		ZoneFormations.Write(this);
 		StartingItems.Write();
-		RngTables.Write(this);
+		RngTables.Write(this,flags);
 		Teleporters.Write();
 		Overworld.Write();
 		ArmorPermissions.Write(this);

--- a/FF1Lib/RngTables.cs
+++ b/FF1Lib/RngTables.cs
@@ -1,13 +1,17 @@
 ﻿using RomUtilities;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO.Compression;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace FF1Lib
 {
+
+	
 	public class RngTables
 	{
 		private const int RngOffset = 0xF100;
@@ -17,14 +21,27 @@ namespace FF1Lib
 		private const int NewBattleRngOffset = 0xFCF1;
 		private const int NewRngBank = 0x1F;
 		private const int RngSize = 256;
+		private const int BattleStepRNGOffset = 0xC571; // Bank 1F
+		private ushort BattleStepSeed;
+		private const int BattleStepSeedOffset = 0xDB09; // two unused bytes in Bank 1F
+		private const int LoadPRNGSeedOnPartyGenOffset = 0x8C00; // Bank 1E
 
 		private List<byte> BattleRNG;
 		private List<byte> EncounterRNG;
+		private List<string> PRNGAlgorithms = new List<string> {
+			"ADF16F4AADF06F6A4DF16F85116A4DF06F8DF06F45118DF16F60EA",
+			"ADF06F0AADF16F2A4DF06F85112A4DF16F8DF16F45118DF06F60EA",
+			"ADF06F4DF16F85114AADF06F6A45118DF16F6A4DF06F8DF06F60EA",
+			"ADF16F4DF06F85110AADF16F2A45118DF06F2A4DF16F8DF16F60EA"
+		};
+		private string PRNGAlgorithm;
 		public RngTables(FF1Rom rom)
 		{
 			BattleRNG = rom.GetFromBank(RngBank, BattleRngOffset, RngSize, false).ToBytes().ToList();
 			EncounterRNG = rom.GetFromBank(RngBank, RngOffset, RngSize, false).ToBytes().ToList();
 		}
+
+
 		public void Update(Flags flags, MT19337 rng)
 		{
 			if ((bool)flags.FixMissingBattleRngEntry)
@@ -39,11 +56,29 @@ namespace FF1Lib
 				BattleRNG.Shuffle(rng);
 				EncounterRNG.Shuffle(rng);
 			}
+
+			if ((bool)flags.EncounterPrng)
+			{
+				BattleStepSeed = (ushort)rng.Between(0x0001, 0xFFFF);
+				PRNGAlgorithm = PRNGAlgorithms.PickRandom(rng);
+			}
 		}
-		public void Write(FF1Rom rom)
+		public void Write(FF1Rom rom, Flags flags)
 		{
 			rom.PutInBank(NewRngBank, NewRngOffset, EncounterRNG.ToArray());
 			rom.PutInBank(NewRngBank, NewBattleRngOffset, BattleRNG.ToArray());
+
+			if ((bool)flags.EncounterPrng)
+			{
+				// just after partygen is confirmed, this executes the subroutine to
+				// write the battlestep seed into sram
+				rom.PutInBank(0x1E, 0x806B, Blob.FromHex("EAEA20008C"));
+				rom.PutInBank(0x1E, LoadPRNGSeedOnPartyGenOffset, Blob.FromHex("A9008D0120AD09DB8DF06FAD0ADB8DF16F60"));
+
+				// write the prng over the subroutine that followed the encounter table
+				rom.PutInBank(0x1F, BattleStepRNGOffset, Blob.FromHex(PRNGAlgorithm));
+				rom.PutInBank(0x1F, BattleStepSeedOffset, BattleStepSeed);
+			}
 		}
 	}
 }

--- a/FF1Lib/asm/1F_C571_EncounterPrng.asm
+++ b/FF1Lib/asm/1F_C571_EncounterPrng.asm
@@ -1,0 +1,151 @@
+tmp = $10
+rng_state = $6FF0
+state_lo = rng_state + $0
+state_hi = rng_state + $1
+
+;;; put some unused bytes to work 
+lut_BattleStepSeed = $DB09
+NewGame_LoadStartingStats = $C76D
+
+
+
+;;;;;;;;;;;;;;;;;;;
+;; BANK 1E
+;;;;;;;;;;;;;;;;;;;
+.ORG $806B
+    NOP
+    NOP
+    JSR PartyGen_ShutOffPPUAndLoadBattleStepSeed
+
+    ;;; assembled bytes 
+    ;;; EAEA20008C
+
+
+
+.ORG $8C00
+PartyGen_ShutOffPPUAndLoadBattleStepSeed:
+    ;;; we call this subroutine from bank $1E $806B
+    ;;; do the PPU reset that was there
+    LDA #$00
+    STA $2001
+    ;;; load the battle step seed into sram
+    LDA lut_BattleStepSeed
+    STA state_lo
+    LDA lut_BattleStepSeed + 1
+    STA state_hi
+    RTS
+
+    ;;; assembled bytes
+    ;;; A9008D0120AD09DB8DF06FAD0ADB8DF16F60
+
+
+
+
+;;;;;;;;;;;;;;;
+;; BANK 1F
+;;;;;;;;;;;;;;;
+.ORG $C571  ;; location of BattleStepRNG routine
+
+;;;;; 4 16-bit xorshift PRNGs of period 65,535
+;;;;; Rando chooses one of them to replace BattleStepRNG
+;;;;; Vanilla BattleStepRNG is 27 bytes
+;; x ^= x << 7
+;; x ^= x >> 9
+;; x ^= x << 8
+BattleStepRNG1:
+    LDA state_hi        ; 3
+    LSR                 ; 1 -- prev bit 8 in carry
+    LDA state_lo        ; 3
+    ROR                 ; 1 -- A has prev bits [8,7,6,5,4,3,2,1], prev bit 0 in carry 
+    EOR state_hi        ; 3 -- hi part of x ^= x<<7; the lo part (EOR bits 0 and 7) happens below
+    STA tmp + 1         ; 2
+    ROR                 ; 1 -- prev bit 0 from x ^= x<<7 shift rotated in
+    EOR state_lo        ; 3 -- and applied here w/ x ^= x >> 9
+    STA state_lo        ; 3
+    EOR tmp + 1         ; 2 -- x ^= x << 8
+    STA state_hi        ; 3                 ; 1 
+    RTS                 ; 1 -- hi byte in A
+    NOP                 ; 1
+    ;------------------------
+                        ; 27 bytes
+    ;;; assembled bytes
+    ;;; ADF16F4AADF06F6A4DF16F85116A4DF06F8DF06F45118DF16F60EA
+
+
+
+;; same as above w/ opposite shifts.
+;; order of PRNG is different
+;; x ^= x >> 7
+;; x ^= x << 9
+;; x ^= x >> 8
+BattleStepRNG2:
+    LDA state_lo        ; 3
+    ASL                 ; 1
+    LDA state_hi        ; 3
+    ROL                 ; 1
+    EOR state_lo        ; 3
+    STA tmp + 1         ; 2
+    ROL                 ; 1
+    EOR state_hi        ; 3
+    STA state_hi        ; 3
+    EOR tmp + 1         ; 2
+    STA state_lo        ; 3
+    RTS                 ; 1 -- lo byte in A
+    NOP                 ; 1
+    ;------------------------
+                        ; 27 bytes
+
+    ;; assembled bytes
+    ;; ADF06F0AADF16F2A4DF06F85112A4DF16F8DF16F45118DF06F60EA
+
+
+
+
+;;;; rearranging the shift order also
+;;;; reorders the PRNG 
+;; x ^= x << 8
+;; x ^= x << 7
+;; x ^= x >> 9
+BattleStepRNG3:
+    LDA state_lo        ; 3
+    EOR state_hi        ; 3 -- x ^= x << 8
+    STA tmp + 1         ; 2
+    LSR                 ; 1 -- bit 8 now in carry
+    LDA state_lo        ; 3
+    ROR                 ; 1 -- bit 0 now in carry
+    EOR tmp + 1         ; 2 -- hi part of x ^= x << 7
+    STA state_hi        ; 3
+    ROR                 ; 1 -- previous bit 0 now in bit 15
+    EOR state_lo        ; 3 -- lo part of x ^= x << 7, and x ^= x >> 8
+    STA state_lo        ; 3
+    RTS                 ; 1 -- lo byte in A
+    NOP                 ; 1
+    ;------------------------
+                        ; 27 bytes
+
+    ;; assembled bytes 
+    ;; ADF06F4DF16F85114AADF06F6A45118DF16F6A4DF06F8DF06F60EA
+
+
+;; x ^= x >> 8
+;; x ^= x >> 7
+;; x ^= x << 9
+BattleStepRNG4:
+    LDA state_hi        ; 3
+    EOR state_lo        ; 3
+    STA tmp + 1         ; 2
+    ASL                 ; 1
+    LDA state_hi        ; 3
+    ROL                 ; 1
+    EOR tmp + 1         ; 2
+    STA state_lo        ; 3
+    ROL                 ; 1
+    EOR state_hi        ; 3
+    STA state_hi        ; 3
+    RTS                 ; 1 -- hi byte in A 
+    NOP
+    ;------------------------
+                        ; 27 bytes 
+
+    ;; assembled bytes
+    ;; ADF16F4DF06F85110AADF16F2A45118DF06F2A4DF16F8DF16F60EA


### PR DESCRIPTION
This adds a "true prng" encounter table to the Experimental tab. Overwrites the subroutine that reads from the fixed 256-step encounter table with one that draws from a 16-bit xorshift prng. The rando seeds this prng and chooses one of 4 related prngs, so that it almost never the same with new seeds.

The rng state is stored in sram as soon as party select is confirmed, and persists across hard/soft resets.