### PR TITLE
Archipelago PlayerName in FileTab

### DIFF
--- a/FF1Blazorizer/Tabs/FileTab.razor
+++ b/FF1Blazorizer/Tabs/FileTab.razor
@@ -1,4 +1,4 @@
-﻿@using System.ComponentModel;
+@using System.ComponentModel;
 @using System.IO;
 @using System.Web;
 @using RomUtilities;
@@ -44,6 +44,16 @@
 		<input style="width: calc(100% - 80px);" type="text" class="nes-input" value="@Flagstring" @onchange="@OnFlagsInputChanged" />
 		<a class="styled-button" @onclick="@OnCopyToClipboard">Export</a>
 	</p>
+
+	@if (Flags.Archipelago)
+	{
+		<p>
+			Archipelago Player Name:
+			<br>
+				<input type="text" style="width: calc(100% - 80px);" class="nes-input" maxlength="16" @onchange="@OnPlayerNameChanged" value="@(Preferences.PlayerName)" />
+		</p>
+	}
+
 	<p>@((MarkupString)StatusMessage)</p>
 	<div class="row">&nbsp;</div>
 	<a class="styled-button generate-button" @onclick="@OnRandomize">Generate ROM</a>
@@ -219,6 +229,15 @@
 		{
 			SetStatusMessage("Invalid Flags String.");
 		}
+	}
+
+	void OnPlayerNameChanged(ChangeEventArgs e)
+	{
+		string playername = (e.Value as string);
+
+		Preferences.PlayerName = playername.Length > 16 ? playername.Substring(0, 16) : playername;
+
+		UpdateAction?.Invoke("UpdateFlagstring","");
 	}
 
 	async Task OnRandomize(MouseEventArgs e)

--- a/FF1Blazorizer/Tabs/GoalTab.razor
+++ b/FF1Blazorizer/Tabs/GoalTab.razor
@@ -1,4 +1,4 @@
-﻿@using FF1Lib;
+@using FF1Lib;
 @using static FF1Lib.FF1Rom;
 
 
@@ -29,7 +29,7 @@
 		<p>
 			Player Name:
 			<br>
-				<input type="text" style="width: calc(100% - 80px);" class="nes-input" id="seedInput" maxlength="16" @onchange="@OnPlayerNameChanged" value="@(Preferences.PlayerName)" />
+				<input UpdateAction="@UpdateAction" type="text" style="width: calc(100% - 80px);" class="nes-input" id="seedInput" maxlength="16" @onchange="@OnPlayerNameChanged" value="@(Preferences.PlayerName)" />
 		</p>
 </div>
 
@@ -65,5 +65,9 @@
 		string playername = (e.Value as string);
 
 		Preferences.PlayerName = playername.Length > 16 ? playername.Substring(0, 16) : playername;
+
+		UpdateAction?.Invoke("UpdateFlagstring","");
 	}
+
+
 }

--- a/FF1Blazorizer/Tabs/GoalTab.razor
+++ b/FF1Blazorizer/Tabs/GoalTab.razor
@@ -29,7 +29,7 @@
 		<p>
 			Player Name:
 			<br>
-				<input UpdateAction="@UpdateAction" type="text" style="width: calc(100% - 80px);" class="nes-input" id="seedInput" maxlength="16" @onchange="@OnPlayerNameChanged" value="@(Preferences.PlayerName)" />
+				<input type="text" style="width: calc(100% - 80px);" class="nes-input" id="seedInput" maxlength="16" @onchange="@OnPlayerNameChanged" value="@(Preferences.PlayerName)" />
 		</p>
 </div>
 


### PR DESCRIPTION
This adds the Archipelago Player Name preference to the File tab. It stays in the Goals tab as well. The primary reason for including it here is that blind flags make the Goals tab inaccessible to edit the player name.

When Archipelago is enabled, a text field opens in the File tab updated with the current Player Name value. Editing in either tab updates the other.

