### PR TITLE
Bugfix for true RNG clobbers transmoog data

### DIFF
--- a/FF1Lib/BankUsageRegister.md
+++ b/FF1Lib/BankUsageRegister.md
@@ -85,6 +85,7 @@ Bank Offset Range Description
 1E   8000-85B0    Moving routines from bank 0E to 1E (PartyGen and menu stuff)
 1E   85B0-85C1    Parry Permissions table
 1E   8680-86A7    New Icons routine
+1E   86E0-B9F1    Encounter Table True PRNG
 1E   8800-8933    Class Info Window
 1E  ~8970-8AF6    [NO MAX SET] Info Window Content
 1E   B100-B21C    Damage Tiles Kill

--- a/FF1Lib/RngTables.cs
+++ b/FF1Lib/RngTables.cs
@@ -24,7 +24,7 @@ namespace FF1Lib
 		private const int BattleStepRNGOffset = 0xC571; // Bank 1F
 		private ushort BattleStepSeed;
 		private const int BattleStepSeedOffset = 0xDB09; // two unused bytes in Bank 1F
-		private const int LoadPRNGSeedOnPartyGenOffset = 0x8C00; // Bank 1E
+		private const int LoadPRNGSeedOnPartyGenOffset = 0x86E0; // Bank 1E
 
 		private List<byte> BattleRNG;
 		private List<byte> EncounterRNG;
@@ -72,7 +72,7 @@ namespace FF1Lib
 			{
 				// just after partygen is confirmed, this executes the subroutine to
 				// write the battlestep seed into sram
-				rom.PutInBank(0x1E, 0x806B, Blob.FromHex("EAEA20008C"));
+				rom.PutInBank(0x1E, 0x806B, Blob.FromHex("EAEA20E086"));
 				rom.PutInBank(0x1E, LoadPRNGSeedOnPartyGenOffset, Blob.FromHex("A9008D0120AD09DB8DF06FAD0ADB8DF16F60"));
 
 				// write the prng over the subroutine that followed the encounter table

--- a/FF1Lib/asm/1F_C571_EncounterPrng.asm
+++ b/FF1Lib/asm/1F_C571_EncounterPrng.asm
@@ -18,11 +18,11 @@ NewGame_LoadStartingStats = $C76D
     JSR PartyGen_ShutOffPPUAndLoadBattleStepSeed
 
     ;;; assembled bytes 
-    ;;; EAEA20008C
+    ;;; EAEA20E086
 
 
 
-.ORG $8C00
+.ORG $86E0
 PartyGen_ShutOffPPUAndLoadBattleStepSeed:
     ;;; we call this subroutine from bank $1E $806B
     ;;; do the PPU reset that was there


### PR DESCRIPTION
Moved the offending bytes to a new spot and recorded in the register.