### PR TITLE
NPC sprite import via resource pack

### DIFF
--- a/FF1Lib/ResourcePack.cs
+++ b/FF1Lib/ResourcePack.cs
@@ -86,7 +86,18 @@ namespace FF1Lib
 					}
 				}
 
+				var npcs = resourcePackArchive.GetEntry("npcs.png");
+				if (npcs != null)
+				{
+					using (var s = npcs.Open())
+					{
+						SetCustomNPCGraphics(s);
+					}
+				}
+
 			}
+
+			
 
 		}
 		async Task LoadResourcePackPostROM(string resourcepack, DialogueData dialogues, EnemyScripts enemyScripts, Preferences preferences)
@@ -124,6 +135,8 @@ namespace FF1Lib
 						await SetCustomPlayerSprites(s,false, preferences.MapmanSlot);
 					}
 				}
+
+			
 
 				var fiends = resourcePackArchive.GetEntry("fiends.png");
 				if (fiends != null)


### PR DESCRIPTION
This adds NPC sprite import via resource pack. Here's a reference image for the sprite sheet.
![npcs](https://github.com/user-attachments/assets/cfda96dc-087a-4d30-9c9b-4620c43d5255)

Shopkeepers along the top, followed by 28 npc sprites (leaving out orb and plate sprites, which are coded as npcs and stored with them in the ROM). Vanilla palettes applied; uses grayscale to match pixels to palette values, as with enemy sprite imports. NPC sprites use magenta to indicate transparent, as with mapman sprites.

Tested with npc recruitment flags -- since the sprite replacements happen before any of the randomizing, the recruitable class sprites show up fine.
