### PR TITLE
Fix flipped procgen waterfall bug

### DIFF
--- a/FF1Lib/BankUsageRegister.md
+++ b/FF1Lib/BankUsageRegister.md
@@ -48,7 +48,7 @@ ROM: 04000-07FFF
 01
 
 ROM: 08000-0BFFF
-02   8F60-8F6F    Mapman for nones and Fun% Party Leader
+02   8FF0-8FFF    Mapman for nones and Fun% Party Leader
 
 ROM: 0C000-09FFF
 03   8220-8230    Palm tree tile used for pub sign (also 8320-8330)

--- a/FF1Lib/StandardMaps/FlippedMaps.cs
+++ b/FF1Lib/StandardMaps/FlippedMaps.cs
@@ -76,6 +76,11 @@ namespace FF1Lib
 				ValidMaps_Vertical.Remove(MapIndex.EarthCaveB5);
 			}
 
+			if (flags.ProcgenWaterfall != ProcgenWaterfall.Off)
+			{
+				ValidMaps_Vertical.Remove(MapIndex.Waterfall);
+			}
+
 			ValidMaps_Vertical.Shuffle(rng);
 			mapsToFlipVertically = ValidMaps_Vertical.GetRange(0, rng.Between((int)(ValidMaps_Vertical.Count * 0.33), (int)(ValidMaps_Vertical.Count * 0.75)));
 			//if (flags.EFGWaterfall) mapsToFlipVertically.Remove(MapIndex.Waterfall);
@@ -463,6 +468,11 @@ namespace FF1Lib
 				ValidMaps_Horizontal.Remove(MapIndex.EarthCaveB3);
 				ValidMaps_Horizontal.Remove(MapIndex.EarthCaveB4);
 				ValidMaps_Horizontal.Remove(MapIndex.EarthCaveB5);
+			}
+
+			if (flags.ProcgenWaterfall != ProcgenWaterfall.Off)
+			{
+				ValidMaps_Horizontal.Remove(MapIndex.Waterfall);
 			}
 
 			ValidMaps_Horizontal.Shuffle(rng);


### PR DESCRIPTION
Removes waterfall from lists of valid flippable locations when procgen waterfall is on.

Also quick edit to bank register to reflect movement of one instruction